### PR TITLE
Baseline-eclipse merges jdt.core config rather than replacing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 
 ## 0.2.1
 - add 'baselineUpdateConfig' task for plugin users
+
+## <next>
+- baseline-eclipse no longer overwrites jdt-core config, but merges the baseline default config;
+  org.eclipse.jdt.core.prefs moved to a different location in gradle-baseline-java-config

--- a/gradle-baseline-java-config/resources/eclipse/org.eclipse.jdt.core.prefs
+++ b/gradle-baseline-java-config/resources/eclipse/org.eclipse.jdt.core.prefs
@@ -1,4 +1,3 @@
-eclipse.preferences.version=1
 org.eclipse.jdt.core.codeComplete.argumentPrefixes=
 org.eclipse.jdt.core.codeComplete.argumentSuffixes=
 org.eclipse.jdt.core.codeComplete.fieldPrefixes=

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEclipseIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEclipseIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package com.palantir.baseline
 
+import com.google.common.base.Charsets
+import com.google.common.io.Files
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.io.FileUtils
@@ -52,5 +54,16 @@ class BaselineEclipseIntegrationTest extends IntegrationSpec {
         then:
         ExecutionResult result = runTasksSuccessfully('eclipse')
         assert result.wasExecuted(':eclipseTemplate')
+    }
+
+    def 'Eclipse task sets jdt core properties'() {
+        when:
+        buildFile << standardBuildFile
+
+        then:
+        runTasksSuccessfully('eclipse')
+        def jdtCorePrefs = Files.asCharSource(new File(projectDir,
+            ".settings/org.eclipse.jdt.core.prefs"), Charsets.UTF_8).read()
+        jdtCorePrefs.contains("org.eclipse.jdt.core.compiler.annotation.nullable=javax.annotation.CheckForNull")
     }
 }


### PR DESCRIPTION
@bdworth @cjp39 take a look please.