### PR TITLE
allow assertNotNull()

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -193,10 +193,6 @@
             <property name="format" value="assertFalse\(.*[!=]="/>
             <property name="message" value="Use better assertion method(s): assertEquals(), assertNull(), assertSame(), etc."/>
         </module>
-        <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Avoid assertNotNull -->
-            <property name="format" value="assertNotNull\("/>
-            <property name="message" value="assertNotNull() almost always shows up in a lazily-written so-called test for coverage. Do something else to validate the expected output: assertEquals(), assertFalse(String.isEmpty()), etc."/>
-        </module>
         <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Use appropriate assertion methods -->
             <property name="format" value="assertTrue\(!"/>
             <property name="message" value="Use assertFalse()."/>


### PR DESCRIPTION
This can flag bad tests but is occasionally useful. Not to mention
the check is easy to hack around :/
