### PR TITLE
In BaselineEclipse, apply JDT configuration in project.afterEvaluate …

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
@@ -53,27 +53,29 @@ class BaselineEclipse extends AbstractBaselinePlugin {
 
         // Configure Eclipse JDT Core by merging in Baseline settings.
         project.plugins.withType(EclipsePlugin, { plugin ->
-            project.eclipse {
-                if (jdt != null) {
-                    // Read baseline configuration from config directory
-                    def baselineJdtCoreProps = new Properties()
-                    def baselineJdtCorePropsFile = project.file("${configDir}/eclipse/org.eclipse.jdt.core.prefs")
-                    if (baselineJdtCorePropsFile.canRead()) {
-                        def reader = baselineJdtCorePropsFile.newReader()
-                        baselineJdtCoreProps.load(reader)
-                        reader.close()
+            project.afterEvaluate {
+                project.eclipse {
+                    if (jdt != null) {
+                        // Read baseline configuration from config directory
+                        def baselineJdtCoreProps = new Properties()
+                        def baselineJdtCorePropsFile = project.file("${configDir}/eclipse/org.eclipse.jdt.core.prefs")
+                        if (baselineJdtCorePropsFile.canRead()) {
+                            def reader = baselineJdtCorePropsFile.newReader()
+                            baselineJdtCoreProps.load(reader)
+                            reader.close()
 
-                        def binding = [
-                            javaSourceVersion: project.sourceCompatibility,
-                            javaTargetVersion: project.targetCompatibility]
+                            def binding = [
+                                javaSourceVersion: project.sourceCompatibility,
+                                javaTargetVersion: project.targetCompatibility]
 
-                        // Merge baseline config into default config
-                        jdt.file.withProperties { Properties baseProperties ->
-                            mergeProperties(baselineJdtCoreProps, baseProperties, binding)
+                            // Merge baseline config into default config
+                            jdt.file.withProperties { Properties baseProperties ->
+                                mergeProperties(baselineJdtCoreProps, baseProperties, binding)
+                            }
+                        } else {
+                            project.logger.error("Cannot read Baseline Eclipse configuration, not configuring Eclipse: {}",
+                                baselineJdtCorePropsFile)
                         }
-                    } else {
-                        project.logger.error("Cannot read Baseline Eclipse configuration, not configuring Eclipse: {}",
-                            baselineJdtCorePropsFile)
                     }
                 }
             }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEclipseIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEclipseIntegrationTest.groovy
@@ -66,4 +66,18 @@ class BaselineEclipseIntegrationTest extends IntegrationSpec {
             ".settings/org.eclipse.jdt.core.prefs"), Charsets.UTF_8).read()
         jdtCorePrefs.contains("org.eclipse.jdt.core.compiler.annotation.nullable=javax.annotation.CheckForNull")
     }
+
+    def 'Eclipse task sets correct Java version from sourceCompatibility property'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << "sourceCompatibility = '1.3'"  // use '1.3' since it cannot be the default
+
+        then:
+        runTasksSuccessfully('eclipse')
+        def jdtCorePrefs = Files.asCharSource(new File(projectDir,
+            ".settings/org.eclipse.jdt.core.prefs"), Charsets.UTF_8).read()
+        jdtCorePrefs.contains("org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.3")
+        jdtCorePrefs.contains("org.eclipse.jdt.core.compiler.source=1.3")
+        jdtCorePrefs.contains("org.eclipse.jdt.core.compiler.compliance=1.3")
+    }
 }


### PR DESCRIPTION
…block

This fixes (possibly amongst other things) the Eclipse Java language level settings.
