### PR TITLE
Added necessary java plugin line to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ repositories {
     jcenter()
 }
 
+apply plugin: 'java'
+
 // Apply for baselineUpdateConfig task
 apply plugin: 'com.palantir.baseline-config'
 


### PR DESCRIPTION
The java plugin is necessary, otherwise the user gets this weird error:

```
$ ./gradlew tasks

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project '<project>'.
> Could not find property 'checkstyleMain' on task set.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 2.414 secs
```
