### PR TITLE
Remove requirement to use ImmutableList.<Foo, Bar>builder() instead of new ImmutableList.Builder<Foo, Bar>()

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -238,18 +238,6 @@
             <property name="format" value="CoreMatchers\.notNull"/>
             <property name="message" value="Use better assertion method(s): Assert.assertEquals(), assertNull(), assertSame(), etc."/>
         </module>
-        <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Avoid Generics clutter where possible -->
-            <property name="format" value="ImmutableList\.Builder.*new ImmutableList\.Builder"/>
-            <property name="message" value="Use ImmutableList.builder() for variable assignment."/>
-        </module>
-        <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Avoid Generics clutter where possible -->
-            <property name="format" value="ImmutableMap\.Builder.*new ImmutableMap\.Builder"/>
-            <property name="message" value="Use ImmutableMap.builder() for variable assignment."/>
-        </module>
-        <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Avoid Generics clutter where possible -->
-            <property name="format" value="ImmutableSet\.Builder.*new ImmutableSet\.Builder"/>
-            <property name="message" value="Use ImmutableSet.builder() for variable assignment."/>
-        </module>
         <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Check parameters for validity -->
             <property name="format" value="Preconditions\.checkNotNull\((?!.*,)([^()]*(\(([^()]*|\(([^()]*|\([^()]*\))*\))*\)[^()]*)*)\)"/>
             <property name="message" value="Use Preconditions.checkNotNull(Object, String)."/>


### PR DESCRIPTION
Doesn't feel like this fits the criteria of being a 'baseline requirement' - in Java 6 there's an advantage to the former, but in Java 7+ there's no practical advantage to using this method, it's just a matter of taste.
