### PR TITLE
Gradle 2.13 correctly handles compileOnly

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -53,7 +53,6 @@ class BaselineIdea extends AbstractBaselinePlugin {
             // Configure Idea module
             IdeaModel ideaModuleModel = project.extensions.findByType(IdeaModel)
             addJdkVersion(ideaModuleModel)
-            addCompileOnlyConfiguration(ideaModuleModel)
         }
     }
 
@@ -200,13 +199,6 @@ class BaselineIdea extends AbstractBaselinePlugin {
             }
         } else {
             project.logger.info("BaselineIdea: No Java version found in sourceCompatibility property.")
-        }
-    }
-
-    def addCompileOnlyConfiguration(IdeaModel ideaModel) {
-        def compileOnly = project.configurations.findByName("compileOnly")
-        if (compileOnly) {
-            ideaModel.module.scopes.get("PROVIDED").plus += [ compileOnly ]
         }
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -150,4 +150,20 @@ class BaselineIdeaIntegrationTest extends IntegrationSpec {
                   "Adds-compileOnly-dependencies-if-the-configuration-exists.iml"), Charsets.UTF_8).read()
         assert iml.contains('<orderEntry type="module-library" scope="PROVIDED">')
     }
+
+    def 'Doesn\'t make compile dependencies provided unnecessarily'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << """
+            dependencies {
+                compile localGroovy()
+            }
+        """
+
+        then:
+        runTasksSuccessfully('idea')
+        def iml = Files.asCharSource(new File(projectDir,
+                "Doesn-t-make-compile-dependencies-provided-unnecessarily.iml"), Charsets.UTF_8).read()
+        assert iml.contains('<orderEntry type="module-library">')
+    }
 }


### PR DESCRIPTION
This causes massive confusion for gradle and it assigns all compile dependencies as PROVIDED which breaks any launch configuration in intellij.

After looking at https://github.com/gradle/gradle/blob/master/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy it turns out this should already be handled. I guess this workaround is only necessary for 2.12. Confirmed working on contour repo.

If someone has an idea how to make it work for 2.12 and 2.13 at the same time please contribute. Added a test case to ensure we don't have any non solutions.
cc @ash211  @uschi2000 
