### PR TITLE
don't run findbugs on scala sources

### DIFF
--- a/gradle-baseline-java-config/resources/findbugs/excludeFilter.xml
+++ b/gradle-baseline-java-config/resources/findbugs/excludeFilter.xml
@@ -1,6 +1,10 @@
 <!-- See http://findbugs.sourceforge.net/manual/filter.html for syntax -->
 <FindBugsFilter>
 
+    <Match>
+        <Source name="~.*\.scala" />
+    </Match>
+
     <!-- @NonnullByDefault doesn't play nicely with overriding @Nullable parameters/outputs -->
     <Match>
         <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE" />


### PR DESCRIPTION
Tried baseline 0.6.0 on a scala project. The bytecode that scalac generates breaks antipatterns rules. I think it's easier to disable findbugs on those than change scalac. Sadly findbugs doesn't know how to scala and only understands bytecode.
