### PR TITLE
Drop several log lines from info to debug

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.groovy
@@ -43,7 +43,7 @@ class BaselineCheckstyle extends AbstractBaselinePlugin {
     }
 
     def configureCheckstyle() {
-        project.logger.info("Baseline: Configuring Checkstyle tasks")
+        project.logger.debug("Baseline: Configuring Checkstyle tasks")
 
         def configProps = project.checkstyle.configProperties
         // Required to enable checkstyle suppressions
@@ -78,10 +78,10 @@ class BaselineCheckstyle extends AbstractBaselinePlugin {
     def configureCheckstyleForEclipse() {
         def eclipse = project.plugins.findPlugin "eclipse"
         if (eclipse == null) {
-            project.logger.info "Baseline: Skipping configuring Eclipse for Checkstyle (eclipse not applied)"
+            project.logger.debug "Baseline: Skipping configuring Eclipse for Checkstyle (eclipse not applied)"
             return
         }
-        project.logger.info "Baseline: Configuring Eclipse Checkstyle"
+        project.logger.debug "Baseline: Configuring Eclipse Checkstyle"
         project.eclipse.project {
             natures "net.sf.eclipsecs.core.CheckstyleNature"
             buildCommand "net.sf.eclipsecs.core.CheckstyleBuilder"

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFindBugs.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFindBugs.groovy
@@ -58,7 +58,7 @@ class BaselineFindBugs extends AbstractBaselinePlugin {
     }
 
     def configureFindBugs() {
-        project.logger.info("Baseline: Configuring FindBugs tasks")
+        project.logger.debug("Baseline: Configuring FindBugs tasks")
 
         // Configure findbugs
         project.findbugs {
@@ -75,10 +75,10 @@ class BaselineFindBugs extends AbstractBaselinePlugin {
     // Configure checkstyle settings for Eclipse
     def configureFindBugsForEclipse() {
         if (!project.plugins.findPlugin(EclipsePlugin)) {
-            project.logger.info "Baseline: Skipping configuring Eclipse for FindBugs (eclipse not applied)"
+            project.logger.debug "Baseline: Skipping configuring Eclipse for FindBugs (eclipse not applied)"
             return
         }
-        project.logger.info "Baseline: Configuring Eclipse FindBugs"
+        project.logger.debug "Baseline: Configuring Eclipse FindBugs"
         project.eclipse.project {
             natures "edu.umd.cs.findbugs.plugin.eclipse.findbugsNature"
             buildCommand "edu.umd.cs.findbugs.plugin.eclipse.findbugsBuilder"

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -98,11 +98,11 @@ class BaselineIdea extends AbstractBaselinePlugin {
     private void addCheckstyle(node) {
         def checkstyle = project.plugins.findPlugin(BaselineCheckstyle)
         if (checkstyle == null) {
-            project.logger.info "Baseline: Skipping IDEA checkstyle configuration since baseline-checkstyle not applied"
+            project.logger.debug "Baseline: Skipping IDEA checkstyle configuration since baseline-checkstyle not applied"
             return
         }
 
-        project.logger.info "Baseline: Configuring Checkstyle for Idea"
+        project.logger.debug "Baseline: Configuring Checkstyle for Idea"
         def checkstyleFile = "LOCAL_FILE:\$PRJ_DIR\$.baseline/checkstyle/checkstyle.xml"
         node.append(new XmlParser().parseText("""
             <component name="CheckStyle-IDEA">
@@ -126,7 +126,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
      */
     private void addGit(node) {
         if (!project.file(".git").isDirectory()) {
-            project.logger.info "Baseline: Skipping IDEA Git configuration since .git directory does not exist."
+            project.logger.debug "Baseline: Skipping IDEA Git configuration since .git directory does not exist."
             return
         }
 
@@ -187,7 +187,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
         if (compileJavaTask) {
             def javaVersion = compileJavaTask.sourceCompatibility
             def jdkVersion = 'JDK_' + javaVersion.replaceAll('\\.', '_')
-            project.logger.info("BaselineIdea: Configuring IDEA Module for Java version: " + javaVersion)
+            project.logger.debug("BaselineIdea: Configuring IDEA Module for Java version: " + javaVersion)
 
             if (ideaModel.project != null) {
                 ideaModel.project.languageLevel = javaVersion
@@ -198,7 +198,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 it.asNode().component.find { it.@name == 'NewModuleRootManager' }.@LANGUAGE_LEVEL = jdkVersion
             }
         } else {
-            project.logger.info("BaselineIdea: No Java version found in sourceCompatibility property.")
+            project.logger.debug("BaselineIdea: No Java version found in sourceCompatibility property.")
         }
     }
 }


### PR DESCRIPTION
When running a particular test from gradle with `./gradlew myTest --info`, I am really interested in the output of the test.  In fact, when there are 21 gradle projects, I have to scroll past quite a few debug lines from baseline.

I figured now that the project is quite stable, these don't really need to be announced at `INFO` level, and could safely appear at `DEBUG`.

NB. I have not touched the one error message:

``` groovy
project.logger.error("Cannot read Baseline Eclipse configuration, not configuring Eclipse: {}",
                                baselineJdtCorePropsFile)
```

Here is an illustrative example of the log lines I scroll through every time I want to run a test ;)

```
Baseline: Configuring FindBugs tasks
Skipping adding extra manifest elements from the contacts plugin as it has not been applied
Skipping adding extra manifest elements from the info plugin as it has not been applied
Skipping adding extra scm elements from the info plugin as it has not been applied
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-app' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-app/app.gradle'.
Baseline: Configuring FindBugs tasks
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-bootstrapper' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-bootstrapper/bootstrapper.gradle'.
Baseline: Configuring FindBugs tasks
Evaluating project ':XXXXXXXXX-config' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-config/config.gradle'.
Baseline: Configuring FindBugs tasks
Skipping adding extra manifest elements from the contacts plugin as it has not been applied
Skipping adding extra manifest elements from the info plugin as it has not been applied
Skipping adding extra scm elements from the info plugin as it has not been applied
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-sdk' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-sdk/sdk.gradle'.
Baseline: Configuring FindBugs tasks
Skipping adding extra manifest elements from the contacts plugin as it has not been applied
Skipping adding extra manifest elements from the info plugin as it has not been applied
Skipping adding extra scm elements from the info plugin as it has not been applied
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-coordinator-api' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-coordinator-api/coordinator-api.gradle'.
Baseline: Configuring FindBugs tasks
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-explorer' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-explorer/explorer.gradle'.
Baseline: Configuring FindBugs tasks
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-sources' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-sources/sources.gradle'.
Baseline: Configuring FindBugs tasks
Skipping adding extra manifest elements from the contacts plugin as it has not been applied
Skipping adding extra manifest elements from the info plugin as it has not been applied
Skipping adding extra scm elements from the info plugin as it has not been applied
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-hadoop' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-hadoop/hadoop.gradle'.
Baseline: Configuring FindBugs tasks
Skipping adding extra manifest elements from the contacts plugin as it has not been applied
Skipping adding extra manifest elements from the info plugin as it has not been applied
Skipping adding extra scm elements from the info plugin as it has not been applied
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-bridge' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-bridge/bridge.gradle'.
Baseline: Configuring FindBugs tasks
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-processors' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-processors/processors.gradle'.
Baseline: Configuring FindBugs tasks
Skipping adding extra manifest elements from the contacts plugin as it has not been applied
Skipping adding extra manifest elements from the info plugin as it has not been applied
Skipping adding extra scm elements from the info plugin as it has not been applied
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-core' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-core/core.gradle'.
Baseline: Configuring FindBugs tasks
Skipping adding extra manifest elements from the contacts plugin as it has not been applied
Skipping adding extra manifest elements from the info plugin as it has not been applied
Skipping adding extra scm elements from the info plugin as it has not been applied
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-bootstrapper-jre' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-bootstrapper/bootstrapper-jre.gradle'.
Evaluating project ':XXXXXXXXX-coordinator' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-coordinator/coordinator.gradle'.
Baseline: Configuring FindBugs tasks
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-web-ui' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-web-ui/web-ui.gradle'.
Baseline: Configuring FindBugs tasks
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-db-agent' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-db-agent/db-agent.gradle'.
Baseline: Configuring FindBugs tasks
Baseline: Configuring Checkstyle tasks
Baseline: Configuring Eclipse Checkstyle
Baseline: Configuring Eclipse FindBugs
BaselineIdea: Configuring IDEA Module for Java version: 1.8
Evaluating project ':XXXXXXXXX-ete' using build file '/home/ubuntu/XXXXXXXXX/XXXXXXXXX-ete/ete.gradle'.
Baseline: Configuring FindBugs tasks
```
