### PR TITLE
Make the maximum file size length 200 lines

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -16,6 +16,7 @@
 
     <module name="FileLength"> <!-- Java Style Guide: File length: 2000 lines -->
         <property name="fileExtensions" value="java"/>
+        <property name="max" value="200"/>
     </module>
     <module name="FileTabCharacter"/> <!-- Java Style Guide: Whitespace characters -->
     <module name="NewlineAtEndOfFile"> <!-- Java Style Guide: Line ending: LF -->


### PR DESCRIPTION
As discussed internally, a reasonable default for file length is
200 lines.
