### PR TITLE
Replacing SimpleTemplateEngine with basic string replace to improve performance in mergeProperties

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
@@ -31,36 +31,37 @@ class BaselineEclipse extends AbstractBaselinePlugin {
      */
     static def mergeProperties(Properties from, Properties into, Map binding) {
         from.stringPropertyNames().each { property ->
-            def propertyValue = replace(from.getProperty(property), binding)
-            into.setProperty(property, propertyValue)
+            try {
+                def propertyValue = replace(from.getProperty(property), binding)
+                into.setProperty(property, propertyValue)
+            }
+            catch(Exception e) {
+                e.printStackTrace()
+            }
         }
     }
 
     static String replace(String str, Map binding) {
         StringBuilder sb = new StringBuilder()
         int start = 0
-        while (start < str.length()) {
-            int begin = str.indexOf("\${", start)
-            if (begin < 0) {
-                sb.append(str.substring(start))
-                break
-            }
 
-            int end = str.indexOf('}', begin)
-            if (end < 0) {
-                sb.append(str.substring(start))
-                break
-            }
+        int begin = str.indexOf("\${", start)
+        if (begin < 0) {
+            sb.append(str.substring(start))
+            return sb.toString()
+        }
 
-            String replacement = binding.get(str.substring(begin + 2, end))
-            if (replacement != null) {
-                sb.append(str.substring(start, begin))
-                sb.append(replacement)
-                start = end + 1
-            } else {
-                sb.append(str.substring(start, begin + 2))
-                start += 2
-            }
+        int end = str.indexOf('}', begin)
+        if (end < 0) {
+            throw new Exception("Missing '}' for property: " + str)
+        }
+
+        String replacement = binding.get(str.substring(begin + 2, end))
+        if (replacement != null) {
+            sb.append(str.substring(start, begin))
+            sb.append(replacement)
+        } else {
+            throw new Exception("Replacement missing from binding for property: " + str)
         }
         return sb.toString()
     }


### PR DESCRIPTION
Tested against our Emcee project (which has 97 projects). `./gradlew eclipse` runtime drops from 4 minutes to 40 seconds.
