### PR TITLE
Support Checkstyle suppression comment format

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -44,6 +44,11 @@
     </module>
     <module name="SuppressWarningsFilter"/> <!-- baseline-gradle: README.md -->
     <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->
+    <module name="SuppressionCommentFilter">
+        <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+        <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+        <property name="checkFormat" value="$1"/>
+    </module>
     <module name="TreeWalker">
         <module name="AbbreviationAsWordInName"> <!-- Java Style Guide: Camel case : defined -->
             <property name="ignoreFinal" value="false"/>


### PR DESCRIPTION
Allow checkstyle errors to be suppressed by specifying the error. e.g.

// CHECKSTYLE.OFF: AvoidStarImport
import java.util.*;
// CHECKSTYLE.ON: AvoidStarImport

- ensures you suppress the error you think you are
- easy for others looking at your code to understand why it's there

Same principles as @SuppressWarnings("foo") so makes sense to have it for comments too