### PR TITLE
Reorder gradle in README so that baseline method is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ repositories {
     jcenter()
 }
 
+// Apply for baselineUpdateConfig task
+apply plugin: 'com.palantir.baseline-config'
+
 dependencies {
     // Adds a dependency on the Baseline configuration files. Typically use 
     // the same version as the plugin itself.
@@ -40,9 +43,6 @@ dependencies {
 }
 
 apply plugin: 'java'
-
-// Apply for baselineUpdateConfig task
-apply plugin: 'com.palantir.baseline-config'
 
 // Apply plugins selectively depending on required functionality.
 apply plugin: 'com.palantir.baseline-checkstyle'


### PR DESCRIPTION
As is, the `baseline` method is not available. It comes from the baseline-config, so putting that above the use of `baseline` fixes things.

I'm very much not a gradle-wiz, but @uschi2000 seemed to agree with this issue.