### PR TITLE
Use errorprone plugin's built-in configuration

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
@@ -24,7 +24,7 @@ class BaselineErrorProne extends AbstractBaselinePlugin {
 
     void apply(Project project) {
         this.project = project
-        
+
         project.plugins.apply(ErrorPronePlugin)
         project.dependencies {
             // TODO(rfink): This is somewhat ugly. Is there a better to add the processor dependency on the library?

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
@@ -25,6 +25,7 @@ class BaselineErrorProne extends AbstractBaselinePlugin {
     void apply(Project project) {
         this.project = project
         
+        project.plugins.apply(ErrorPronePlugin)
         project.dependencies {
             // TODO(rfink): This is somewhat ugly. Is there a better to add the processor dependency on the library?
             errorprone "com.palantir.baseline:baseline-error-prone:${extractVersionString()}"

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
@@ -24,16 +24,10 @@ class BaselineErrorProne extends AbstractBaselinePlugin {
 
     void apply(Project project) {
         this.project = project
-
-        if (!project.configurations.findByName("processor")) {
-            throw new GradleException("Expected to find 'processor' configuration for dependencies of the annotation" +
-                    "processor classpath. Consider adding the 'org.inferred.processors' Gradle plugin.")
-        }
-
-        project.plugins.apply(ErrorPronePlugin)
+        
         project.dependencies {
             // TODO(rfink): This is somewhat ugly. Is there a better to add the processor dependency on the library?
-            processor "com.palantir.baseline:baseline-error-prone:${extractVersionString()}"
+            errorprone "com.palantir.baseline:baseline-error-prone:${extractVersionString()}"
         }
     }
 


### PR DESCRIPTION
Apply baseline-error-prone plugin using the errorprone configuration.

Resolve compilation problems when applying this plugin and working in Eclipse due to Eclipse classpath mangling with the processors plugin, which correctly applies the configuration's classpath to Eclipse's single classpath and where this plugin should not appear on the actual compilation classpath.

In particular, when using other processor plugins, this change will correct errors such as:

    Errors running builder 'Java Builder' on project 'glyph'.
        java.lang.ClassCastException: org.immutables.value.internal.$processor$.$Processor cannot be cast to javax.annotation.processing.Processor