### PR TITLE
Improve generated code compiler arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ dependencies {
 Tip: Warnings on generated code can be suppressed as follows:
 
 ```groovy
-compileJava {
+tasks.withType(JavaCompile) {
     options.compilerArgs += ['-XepDisableWarningsInGeneratedCode']
 }
 ```


### PR DESCRIPTION
The default README only described how to disable errorprone warnings in non-test code.