### PR TITLE
Allow static imports of Collections and Collectors

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -74,6 +74,7 @@
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
             <property name="excludes" value="
+                java.util.Collections.*,java.util.Collectors.*,
                 org.junit.Assert.*,org.junit.Assume.*,
                 org.hamcrest.CoreMatchers.*,org.hamcrest.Matchers.*,org.hamcrest.MatcherAssert.*,
                 org.hamcrest.core.AllOf.*,org.hamcrest.core.Is.*,org.hamcrest.core.StringContains.*,org.hamcrest.core.IsEqual.*,


### PR DESCRIPTION
Collectors and Collections are classes that are pleasant to use as static imports. We can avoid boilerplate by allowing their use, and disallowing them is not helpful because the method names aren't likely to be confused with other things.

Example usage

```java
return foos.stream().flatMap(Collection::stream).collect(toList());
```

```java
when(foo.doSomething()).thenReturn(emptyMap());
```