### PR TITLE
Logsafe errorprone check

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Baseline configures the following checks in addition to the [error-prone's out-o
 checks](https://errorprone.info):
 
 - Slf4jConstantLogMessage: Allow only compile-time constant slf4j log message strings.
+- Slf4jLogsafeArgs: Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages.
 
 
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Error-prone rules can be suppressed on a per-line or per-block basis just like C
 @SuppressWarnings("Slf4jConstantLogMessage")
 ```
 
-Rules can be suppressed at the project level, or have their severity modified, by adding the following to the project's build.gradle:
+Rules can be suppressed at the project level, or have their severity modified, by adding the following to the project's `build.gradle`:
 
 ```groovy
 tasks.withType(JavaCompile) {
@@ -245,18 +245,15 @@ tasks.withType(JavaCompile) {
 }
 ```
 
-More information on error-prone severity handling can be found at [errorprone.info/docs/flags]([http://errorprone.info/docs/flags)
+More information on error-prone severity handling can be found at [errorprone.info/docs/flags](http://errorprone.info/docs/flags).
 
 #### Baseline error-prone checks
 Baseline configures the following checks in addition to the [error-prone's out-of-the-box
 checks](https://errorprone.info):
 
 - Slf4jConstantLogMessage: Allow only compile-time constant slf4j log message strings.
-- Slf4jLogsafeArgs: Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages. More information on Safe Logging can be found at [github.com/palantir/safe-logging](https://github.com/palantir/safe-logging)
-
-
-
-
+- Slf4jLogsafeArgs: Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages. More information on
+Safe Logging can be found at [github.com/palantir/safe-logging](https://github.com/palantir/safe-logging).
 
 ### Copyright Checks
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,22 @@ dependencies {
 }
 ```
 
-Tip: Warnings on generated code can be suppressed as follows:
+#### Error-prone suppressions
+
+Error-prone rules can be suppressed on a per-line or per-block basis just like Checkstyle rules:
+
+```Java
+@SuppressWarnings("Slf4jConstantLogMessage")
+```
+
+Rules can be suppressed at the project level, or have their severity modified, by adding the following to the project's build.gradle:
+
+```groovy
+tasks.withType(JavaCompile) {
+    options.compilerArgs += ['-Xep:Slf4jLogsafeArgs:OFF']
+}
+```
+Warnings on generated code can be suppressed as follows:
 
 ```groovy
 tasks.withType(JavaCompile) {
@@ -230,12 +245,14 @@ tasks.withType(JavaCompile) {
 }
 ```
 
+More information on error-prone severity handling can be found at [errorprone.info/docs/flags]([http://errorprone.info/docs/flags)
+
 #### Baseline error-prone checks
 Baseline configures the following checks in addition to the [error-prone's out-of-the-box
 checks](https://errorprone.info):
 
 - Slf4jConstantLogMessage: Allow only compile-time constant slf4j log message strings.
-- Slf4jLogsafeArgs: Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages.
+- Slf4jLogsafeArgs: Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages. More information on Safe Logging can be found at [github.com/palantir/safe-logging](https://github.com/palantir/safe-logging)
 
 
 

--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 
     testCompile 'com.fasterxml.jackson.core:jackson-annotations'
     testCompile 'com.google.errorprone:error_prone_test_helpers'
+    testCompile 'com.palantir.safe-logging:safe-logging'
     testCompile 'org.slf4j:slf4j-api'
     testCompile 'org.apache.commons:commons-lang3'
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessage.java
@@ -38,6 +38,8 @@ import java.util.regex.Pattern;
 @BugPattern(
         name = "Slf4jConstantLogMessage",
         category = Category.ONE_OFF,
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,
         summary = "Allow only compile-time constant slf4j log message strings.")
 public final class Slf4jConstantLogMessage extends BugChecker implements MethodInvocationTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
         category = Category.ONE_OFF,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = SeverityLevel.ERROR,
+        severity = SeverityLevel.WARNING,
         summary = "Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages.")
 public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -78,10 +78,10 @@ public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocati
 
         if (badArgs.isEmpty()) {
             return Description.NO_MATCH;
+        } else {
+            return buildDescription(tree)
+                    .setMessage("slf4j log statement does not use logsafe parameters for arguments " + badArgs)
+                    .build();
         }
-
-        return buildDescription(tree)
-                .setMessage("slf4j log statement does not use logsafe parameters for arguments " + badArgs)
-                .build();
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -38,6 +38,8 @@ import java.util.regex.Pattern;
 @BugPattern(
         name = "Slf4jLogsafeArgs",
         category = Category.ONE_OFF,
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,
         summary = "Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages.")
 public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocationTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.Category;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "LogWithSafeArgs",
+        category = Category.ONE_OFF,
+        severity = SeverityLevel.ERROR,
+        summary = "Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages.")
+public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocationTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Matcher<ExpressionTree> LOG_METHOD =
+            Matchers.anyOf(
+                    MethodMatchers.instanceMethod()
+                            .onDescendantOf("org.slf4j.Logger")
+                            .withNameMatching(Pattern.compile("trace|debug|info|warn|error")));
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!LOG_METHOD.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        List<? extends ExpressionTree> allArgs = tree.getArguments();
+        int lastIndex = allArgs.size() - 1;
+        int startArg = ASTHelpers.isCastable(
+                ASTHelpers.getType(allArgs.get(0)),
+                state.getTypeFromString("org.slf4j.Marker"),
+                state) ? 2 : 1;
+        int endArg = ASTHelpers.isCastable(
+                ASTHelpers.getType(allArgs.get(lastIndex)),
+                state.getTypeFromString("java.lang.Exception"),
+                state) ? lastIndex - 1 : lastIndex;
+
+        Builder<Integer> badArgsBuilder = new Builder<>();
+        for (int i = startArg; i <= endArg; i++) {
+            if (!ASTHelpers.isCastable(ASTHelpers.getType(allArgs.get(i)),
+                    state.getTypeFromString("com.palantir.logsafe.Arg"), state)) {
+                badArgsBuilder.add(i);
+            }
+        }
+        List<Integer> badArgs = badArgsBuilder.build();
+
+        if (badArgs.isEmpty()) {
+            return Description.NO_MATCH;
+        }
+
+        return buildDescription(tree)
+                .setMessage("slf4j log statement does not use logsafe parameters for arguments " + badArgs)
+                .build();
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
 
 @AutoService(BugChecker.class)
 @BugPattern(
-        name = "LogWithSafeArgs",
+        name = "Slf4jLogsafeArgs",
         category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         summary = "Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages.")

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgsTest.java
@@ -18,14 +18,14 @@ package com.palantir.baseline.errorprone;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
-import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
 public final class Slf4jLogsafeArgsTest {
 
+    private static final ImmutableList<String> LOG_LEVELS = ImmutableList.of("trace", "debug", "info", "warn", "error");
+
     private CompilationTestHelper compilationHelper;
-    private List<String> logLevels = ImmutableList.of("trace", "debug", "info", "warn", "error");
 
     @Before
     public void before() {
@@ -33,8 +33,7 @@ public final class Slf4jLogsafeArgsTest {
     }
 
     private void test(String logArgs, String failingArgs) throws Exception {
-
-        logLevels.forEach(logLevel -> compilationHelper
+        LOG_LEVELS.forEach(logLevel -> compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import com.palantir.logsafe.SafeArg;",
@@ -89,7 +88,7 @@ public final class Slf4jLogsafeArgsTest {
 
     @Test
     public void testPassingLogsafeArgs() throws Exception {
-        compilationHelper
+        LOG_LEVELS.forEach(logLevel -> compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import com.palantir.logsafe.SafeArg;",
@@ -104,42 +103,55 @@ public final class Slf4jLogsafeArgsTest {
                         "  void f() {",
                         "",
                         "    // log.<>(String)",
-                        "    log.trace(\"constant\");",
-                        "    log.trace(\"constant\" + compileTimeConstant);",
+                        "    log." + logLevel + "(\"constant\");",
+                        "    log." + logLevel + "(\"constant\" + compileTimeConstant);",
                         "",
                         "    // log.<>(String, Arg<T>)",
-                        "    log.trace(\"constant {}\", SafeArg.of(\"name\", \"string\"));",
+                        "    log." + logLevel + "(\"constant {}\", SafeArg.of(\"name\", \"string\"));",
                         "",
                         "    // log.<>(String, Arg<T>, Arg<T>)",
-                        "    log.trace(\"constant {} {}\", SafeArg.of(\"name\", \"string\"), UnsafeArg.of(\"name2\", \"string2\"));",
+                        "    log." + logLevel + "(\"constant {} {}\",",
+                        "        SafeArg.of(\"name\", \"string\"),",
+                        "        UnsafeArg.of(\"name2\", \"string2\"));",
                         "",
                         "    // log.<>(Marker, String)",
-                        "    log.trace(new DummyMarker(), \"constant\");",
+                        "    log." + logLevel + "(new DummyMarker(), \"constant\");",
                         "",
                         "    // log.<>(Marker, String, Arg<T>)",
-                        "    log.trace(new DummyMarker(), \"constant {}\", SafeArg.of(\"name\", \"string\"));",
+                        "    log." + logLevel + "(new DummyMarker(), \"constant {}\",",
+                        "        SafeArg.of(\"name\", \"string\"));",
                         "",
                         "    // log.<>(Marker, String, Arg<T>, Arg<T>)",
-                        "    log.trace(\"constant {} {}\", SafeArg.of(\"name\", \"string\"), UnsafeArg.of(\"name2\", \"string2\"));",
+                        "    log." + logLevel + "(\"constant {} {}\",",
+                        "        SafeArg.of(\"name\", \"string\"),",
+                        "        UnsafeArg.of(\"name2\", \"string2\"));",
                         "",
                         "    // log.<>(String, Exception)",
-                        "    log.trace(\"constant\", new Exception());",
-                        "    log.trace(\"constant\" + compileTimeConstant, new Exception());",
+                        "    log." + logLevel + "(\"constant\", new Exception());",
+                        "    log." + logLevel + "(\"constant\" + compileTimeConstant, new Exception());",
                         "",
                         "    // log.<>(String, Arg<T>, Exception)",
-                        "    log.trace(\"constant {}\", SafeArg.of(\"name\", \"string\"), new Exception());",
+                        "    log." + logLevel + "(\"constant {}\", SafeArg.of(\"name\", \"string\"), new Exception());",
                         "",
                         "    // log.<>(String, Arg<T>, Arg<T>, Exception)",
-                        "    log.trace(\"constant {} {}\", SafeArg.of(\"name\", \"string\"), UnsafeArg.of(\"name2\", \"string2\"), new Exception());",
+                        "    log." + logLevel + "(\"constant {} {}\",",
+                        "        SafeArg.of(\"name\", \"string\"),",
+                        "        UnsafeArg.of(\"name2\", \"string2\"),",
+                        "        new Exception());",
                         "",
                         "    // log.<>(Marker, String, Exception)",
-                        "    log.trace(new DummyMarker(), \"constant\", new Exception());",
+                        "    log." + logLevel + "(new DummyMarker(), \"constant\", new Exception());",
                         "",
                         "    // log.<>(Marker, String, Arg<T>, Exception)",
-                        "    log.trace(new DummyMarker(), \"constant {}\", SafeArg.of(\"name\", \"string\"), new Exception());",
+                        "    log." + logLevel + "(new DummyMarker(), \"constant {}\",",
+                        "        SafeArg.of(\"name\", \"string\"),",
+                        "        new Exception());",
                         "",
                         "    // log.<>(Marker, String, Arg<T>, Arg<T>, Exception)",
-                        "    log.trace(\"constant {} {}\", SafeArg.of(\"name\", \"string\"), UnsafeArg.of(\"name2\", \"string2\"), new Exception());",
+                        "    log." + logLevel + "(\"constant {} {}\",",
+                        "        SafeArg.of(\"name\", \"string\"),",
+                        "        UnsafeArg.of(\"name2\", \"string2\"),",
+                        "        new Exception());",
                         "",
                         "  }",
                         "",
@@ -154,7 +166,6 @@ public final class Slf4jLogsafeArgsTest {
                         "    public boolean contains(String name) { return false; }",
                         "  }",
                         "}")
-                .doTest();
+                .doTest());
     }
-
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgsTest.java
@@ -83,7 +83,7 @@ public final class Slf4jLogsafeArgsTest {
                 "[2]");
 
         // log.<>(String, Object, Arg<T>, Exception)"
-        test("\"constant {} {}\", \"string\", SafeArg.of(\"name\", \"string\")", "[1]");
+        test("\"constant {} {}\", \"string\", SafeArg.of(\"name\", \"string\"), new Exception()", "[1]");
     }
 
     @Test
@@ -122,7 +122,7 @@ public final class Slf4jLogsafeArgsTest {
                         "        SafeArg.of(\"name\", \"string\"));",
                         "",
                         "    // log.<>(Marker, String, Arg<T>, Arg<T>)",
-                        "    log." + logLevel + "(\"constant {} {}\",",
+                        "    log." + logLevel + "(new DummyMarker(), \"constant {} {}\",",
                         "        SafeArg.of(\"name\", \"string\"),",
                         "        UnsafeArg.of(\"name2\", \"string2\"));",
                         "",
@@ -148,7 +148,7 @@ public final class Slf4jLogsafeArgsTest {
                         "        new Exception());",
                         "",
                         "    // log.<>(Marker, String, Arg<T>, Arg<T>, Exception)",
-                        "    log." + logLevel + "(\"constant {} {}\",",
+                        "    log." + logLevel + "(new DummyMarker(), \"constant {} {}\",",
                         "        SafeArg.of(\"name\", \"string\"),",
                         "        UnsafeArg.of(\"name2\", \"string2\"),",
                         "        new Exception());",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgsTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.CompilationTestHelper;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class Slf4jLogsafeArgsTest {
+
+    private CompilationTestHelper compilationHelper;
+    private List<String> logLevels = ImmutableList.of("trace", "debug", "info", "warn", "error");
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(Slf4jLogsafeArgs.class, getClass());
+    }
+
+    private void test(String logArgs, String failingArgs) throws Exception {
+
+        logLevels.forEach(logLevel -> compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.logsafe.UnsafeArg;",
+                        "import java.util.ArrayList;",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "import org.slf4j.Marker;",
+                        "import java.util.Iterator;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(String param) {",
+                        "    // BUG: Diagnostic contains: does not use logsafe parameters for arguments " + failingArgs,
+                        "    log." + logLevel + "(" + logArgs + ");",
+                        "  }",
+                        "",
+                        "  class DummyMarker implements Marker {",
+                        "    public String getName() { return null; }",
+                        "    public void add(Marker reference) {}",
+                        "    public boolean remove(Marker reference) { return true; }",
+                        "    public boolean hasChildren() { return false; }",
+                        "    public boolean hasReferences() { return false; }",
+                        "    public Iterator<Marker> iterator() { return null; }",
+                        "    public boolean contains(Marker other) { return false; }",
+                        "    public boolean contains(String name) { return false; }",
+                        "  }",
+                        "}")
+                .doTest());
+    }
+
+    @Test
+    public void testFailingLogsafeArgs() throws Exception {
+        // log.<>(String, Object)"
+        test("\"constant {}\", \"string\"", "[1]");
+
+        // log.<>(String, Object, Object)"
+        test("\"constant {}\", \"string\", new ArrayList(1){}", "[1, 2]");
+
+        // log.<>(String, Object, Arg<T>)"
+        test("\"constant {} {}\", \"string\", SafeArg.of(\"name\", \"string\")", "[1]");
+
+        // log.<>(Marker, String, Object, Arg<T>)"
+        test("new DummyMarker(), \"constant {} {}\", \"string\", SafeArg.of(\"name\", \"string\")", "[2]");
+
+        // log.<>(Marker, String, Object, Arg<T>, Exception)"
+        test("new DummyMarker(), \"constant {} {}\", \"string\", UnsafeArg.of(\"name\", \"string\"), new Exception()",
+                "[2]");
+
+        // log.<>(String, Object, Arg<T>, Exception)"
+        test("\"constant {} {}\", \"string\", SafeArg.of(\"name\", \"string\")", "[1]");
+    }
+
+    @Test
+    public void testPassingLogsafeArgs() throws Exception {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.logsafe.UnsafeArg;",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "import org.slf4j.Marker;",
+                        "import java.util.Iterator;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  private static final String compileTimeConstant = \"constant\";",
+                        "  void f() {",
+                        "",
+                        "    // log.<>(String)",
+                        "    log.trace(\"constant\");",
+                        "    log.trace(\"constant\" + compileTimeConstant);",
+                        "",
+                        "    // log.<>(String, Arg<T>)",
+                        "    log.trace(\"constant {}\", SafeArg.of(\"name\", \"string\"));",
+                        "",
+                        "    // log.<>(String, Arg<T>, Arg<T>)",
+                        "    log.trace(\"constant {} {}\", SafeArg.of(\"name\", \"string\"), UnsafeArg.of(\"name2\", \"string2\"));",
+                        "",
+                        "    // log.<>(Marker, String)",
+                        "    log.trace(new DummyMarker(), \"constant\");",
+                        "",
+                        "    // log.<>(Marker, String, Arg<T>)",
+                        "    log.trace(new DummyMarker(), \"constant {}\", SafeArg.of(\"name\", \"string\"));",
+                        "",
+                        "    // log.<>(Marker, String, Arg<T>, Arg<T>)",
+                        "    log.trace(\"constant {} {}\", SafeArg.of(\"name\", \"string\"), UnsafeArg.of(\"name2\", \"string2\"));",
+                        "",
+                        "    // log.<>(String, Exception)",
+                        "    log.trace(\"constant\", new Exception());",
+                        "    log.trace(\"constant\" + compileTimeConstant, new Exception());",
+                        "",
+                        "    // log.<>(String, Arg<T>, Exception)",
+                        "    log.trace(\"constant {}\", SafeArg.of(\"name\", \"string\"), new Exception());",
+                        "",
+                        "    // log.<>(String, Arg<T>, Arg<T>, Exception)",
+                        "    log.trace(\"constant {} {}\", SafeArg.of(\"name\", \"string\"), UnsafeArg.of(\"name2\", \"string2\"), new Exception());",
+                        "",
+                        "    // log.<>(Marker, String, Exception)",
+                        "    log.trace(new DummyMarker(), \"constant\", new Exception());",
+                        "",
+                        "    // log.<>(Marker, String, Arg<T>, Exception)",
+                        "    log.trace(new DummyMarker(), \"constant {}\", SafeArg.of(\"name\", \"string\"), new Exception());",
+                        "",
+                        "    // log.<>(Marker, String, Arg<T>, Arg<T>, Exception)",
+                        "    log.trace(\"constant {} {}\", SafeArg.of(\"name\", \"string\"), UnsafeArg.of(\"name2\", \"string2\"), new Exception());",
+                        "",
+                        "  }",
+                        "",
+                        "  class DummyMarker implements Marker {",
+                        "    public String getName() { return null; }",
+                        "    public void add(Marker reference) {}",
+                        "    public boolean remove(Marker reference) { return true; }",
+                        "    public boolean hasChildren() { return false; }",
+                        "    public boolean hasReferences() { return false; }",
+                        "    public Iterator<Marker> iterator() { return null; }",
+                        "    public boolean contains(Marker other) { return false; }",
+                        "    public boolean contains(String name) { return false; }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+}

--- a/versions.props
+++ b/versions.props
@@ -4,6 +4,7 @@ com.google.errorprone:error_prone_core = 2.0.19
 com.google.errorprone:error_prone_test_helpers = 2.0.19
 com.google.guava:guava = 21.0
 com.palantir.baseline:* = 0.14.0
+com.palantir.safe-logging:safe-logging = 0.1.3
 org.slf4j:slf4j-api = 1.7.24
 net.ltgt.gradle:gradle-errorprone-plugin = 0.0.10
 


### PR DESCRIPTION
Requires `com.palantir.logsafe.arg` for slf4j log arguments:

Failing example:
```
log.warn("Could not find job with ID {}", jobId);
```
Passing example:
```
log.warn("Could not find job with ID {}", Safeargs.of(jobId));
```

I'm curious if anyone knows a way to prevent this check if safe-logging is not on the classpath?