### PR TITLE
Configure the intellij checkstyle plugin to use the correct checkstyle version

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -108,11 +108,13 @@ class BaselineIdea extends AbstractBaselinePlugin {
 
         project.logger.debug "Baseline: Configuring Checkstyle for Idea"
         def checkstyleFile = "LOCAL_FILE:\$PRJ_DIR\$.baseline/checkstyle/checkstyle.xml"
+
         node.append(new XmlParser().parseText("""
             <component name="CheckStyle-IDEA">
               <option name="configuration">
                 <map>
                   <entry key="active-configuration" value="${checkstyleFile}:Baseline Checkstyle" />
+                  <entry key="checkstyle-version" value="${BaselineCheckstyle.DEFAULT_CHECKSTYLE_VERSION}" />
                   <entry key="check-nonjava-files" value="false" />
                   <entry key="check-test-classes" value="true" />
                   <entry key="location-0" value="${checkstyleFile}:Baseline Checkstyle" />

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -108,7 +108,6 @@ class BaselineIdea extends AbstractBaselinePlugin {
 
         project.logger.debug "Baseline: Configuring Checkstyle for Idea"
         def checkstyleFile = "LOCAL_FILE:\$PRJ_DIR\$.baseline/checkstyle/checkstyle.xml"
-
         node.append(new XmlParser().parseText("""
             <component name="CheckStyle-IDEA">
               <option name="configuration">


### PR DESCRIPTION
Currently, we do not set the CheckStyle-IDEA version, so it defaults to the latest, 8.1. There was a [breaking change introduced in 8.1](https://github.com/checkstyle/checkstyle/issues/4714) that makes the baseline checkstyle files invalid. This means you get an error message and the checkstyle plugin no longer works in IDEA. It's also sadness to have the IDE and gradle running different checkstyle versions.

![screen shot 2017-09-29 at 2 50 12 pm](https://user-images.githubusercontent.com/397795/31018875-878319d2-a525-11e7-88af-61a112a2897f.png)
