### PR TITLE
Todo bracket capture is no longer greedy

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -328,7 +328,7 @@
             <property name="message" value="Redundant ''static'' modifier."/>
         </module>
         <module name="RegexpSinglelineJava">
-            <property name="format" value="(\/\/TODO)|(\/\/ TODO:)|(\/\/ TODO\(\))|(\/\/ TODO\(.*\):[^ ])|(\/\/ TODO\(.*\)[^:])"/>
+            <property name="format" value="(\/\/TODO)|(\/\/ TODO:)|(\/\/ TODO\(\))|(\/\/ TODO\(.*+\):[^ ])|(\/\/ TODO\(.*+\)[^:])"/>
             <property name="message" value="TODO format: // TODO(flastname): explanation"/>
         </module>
         <module name="RegexpSinglelineJava">

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -328,7 +328,7 @@
             <property name="message" value="Redundant ''static'' modifier."/>
         </module>
         <module name="RegexpSinglelineJava">
-            <property name="format" value="(\/\/TODO)|(\/\/ TODO:)|(\/\/ TODO\(\))|(\/\/ TODO\(.*+\):[^ ])|(\/\/ TODO\(.*+\)[^:])"/>
+            <property name="format" value="(\/\/TODO)|(\/\/ TODO:)|(\/\/ TODO\(\))|(\/\/ TODO\(.*+\):[^ ])|(\/\/ TODO\(.*+\)[^:])|(\/\/ TODO\(.*[\s\(\)]+.*\):)"/>
             <property name="message" value="TODO format: // TODO(flastname): explanation"/>
         </module>
         <module name="RegexpSinglelineJava">


### PR DESCRIPTION
Failing case:

```
// TODO(felixdesouza): This is a comment (with some more information).
```

By default `.*` is greedy, it's going to match the last parentheses, despite us complying with the rule.

What we want is the `Possessive` quantifier i.e. `.*+`, which will be lazy, **but not** backtrack. 

This matches the semantics we want: TODO followed by a left bracket, then a name, then a right bracket. Only failure mode would be brackets inside the name, but that's nonsensical so I think this change is okay.