### PR TITLE
Allow static imports in tests

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
@@ -11,6 +11,7 @@
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="Javadoc*" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="VariableDeclarationUsageDistance" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="VisibilityModifier" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="AvoidStaticImport" />
 
     <!-- JavadocStyle enforces existence of package-info.java package-level Javadoc; we consider this a bug. -->
     <suppress files="package-info.java" checks="JavadocStyle" />

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -75,14 +75,7 @@
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
             <property name="excludes" value="
                 java.util.Collections.*,java.util.stream.Collectors.*,
-                org.junit.Assert.*,org.junit.Assume.*,
-                org.hamcrest.CoreMatchers.*,org.hamcrest.Matchers.*,org.hamcrest.MatcherAssert.*,
-                org.hamcrest.core.AllOf.*,org.hamcrest.core.Is.*,org.hamcrest.core.StringContains.*,org.hamcrest.core.IsEqual.*,
-                org.hamcrest.collection.IsMapContaining.*,
-                org.mockito.ArgumentMatchers.*,org.mockito.Mockito.*,org.mockito.Matchers.*,
-                org.assertj.core.api.Assertions.*,
-                org.assertj.guava.api.Assertions.*,
-                com.google.common.base.Preconditions.*,com.google.common.truth.Truth.*,
+                com.google.common.base.Preconditions.*,
                 org.apache.commons.lang3.Validate.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -74,7 +74,8 @@
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
             <property name="excludes" value="
-                java.util.Collections.*,java.util.stream.Collectors.*,
+                java.util.Collections.*,
+                java.util.stream.Collectors.*,
                 com.google.common.base.Preconditions.*,
                 org.apache.commons.lang3.Validate.*"/>
         </module>


### PR DESCRIPTION
Follow-up to https://github.com/palantir/gradle-baseline/pull/239

Rationale is that many testing libraries rely on static imports - maintaining an increasingly large list of exceptions just suggests that banning static imports in test code doesn't make sense in the first place.