### PR TITLE
Attempt to fix 4g memory limit on CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,12 +12,9 @@ buildscript {
         classpath 'com.netflix.nebula:nebula-dependency-recommender:5.0.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.4'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.17.1'
+        classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.5.3'
+        classpath 'gradle.plugin.org.inferred:gradle-processors:1.2.12'
     }
-}
-
-plugins {
-    id 'com.palantir.git-version' version '0.5.3'
-    id 'org.inferred.processors' version '1.2.12'
 }
 
 apply plugin: 'java'
@@ -26,6 +23,7 @@ apply plugin: 'com.palantir.baseline-idea'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.palantir.circle.style'
+
 
 tasks.test.dependsOn tasks.publishToMavenLocal
 
@@ -40,9 +38,10 @@ allprojects {
         maven { url "https://plugins.gradle.org/m2/" }
     }
 
+    apply plugin: 'com.palantir.git-version'
     apply plugin: 'org.inferred.processors'
-
     apply plugin: 'nebula.dependency-recommender'
+
     dependencyRecommendations {
         strategy OverrideTransitives
         propertiesFile file: project.rootProject.file('versions.props')

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
         classpath 'com.palantir.baseline:gradle-baseline-java:0.17.1'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.5.3'
         classpath 'gradle.plugin.org.inferred:gradle-processors:1.2.12'
+        classpath 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin:0.3.0'
     }
 }
 
@@ -38,6 +39,7 @@ allprojects {
         maven { url "https://plugins.gradle.org/m2/" }
     }
 
+    apply plugin: 'com.palantir.configuration-resolver'
     apply plugin: 'com.palantir.git-version'
     apply plugin: 'org.inferred.processors'
     apply plugin: 'nebula.dependency-recommender'

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,10 @@ machine:
   environment:
     TERM: dumb
 
+dependencies:
+  override:
+    - ./gradlew resolveConfigurations --parallel
+
 test:
   override:
     - ./gradlew publishToMavenLocal  # ensure artifacts are available to tests

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/AbstractPluginTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/AbstractPluginTest.groovy
@@ -31,6 +31,7 @@ class AbstractPluginTest extends Specification {
 
     def setup() {
         buildFile = file('build.gradle')
+        file("gradle.properties") << "org.gradle.daemon=false"
         println("Build directory: \n" + projectDir.absolutePath)
         multiProject = new MultiProjectIntegrationHelper(projectDir, file("settings.gradle"))
     }


### PR DESCRIPTION
We had a develop build and a tag build fail due to hitting a 4G memory limit:

- https://circleci.com/gh/palantir/gradle-baseline/336
- https://circleci.com/gh/palantir/gradle-baseline/337

This fix has worked already for sls-packaging, so hoping it'll help here! https://github.com/palantir/sls-packaging/pull/266