### PR TITLE
suppress test classes that are in a "tests" folder

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
@@ -8,10 +8,10 @@
  for your changes to take effect in its Checkstyle integration. -->
 <suppressions>
     <!-- Suppress test classes -->
-    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="Javadoc*" />
-    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="VariableDeclarationUsageDistance" />
-    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="VisibilityModifier" />
-    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="AvoidStaticImport" />
+    <suppress files="[/\\]src[/\\].*[Tt]ests?[/\\](java|groovy)[/\\]" checks="Javadoc*" />
+    <suppress files="[/\\]src[/\\].*[Tt]ests?[/\\](java|groovy)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]ests?[/\\](java|groovy)[/\\]" checks="VisibilityModifier" />
+    <suppress files="[/\\]src[/\\].*[Tt]ests?[/\\](java|groovy)[/\\]" checks="AvoidStaticImport" />
 
     <!-- JavadocStyle enforces existence of package-info.java package-level Javadoc; we consider this a bug. -->
     <suppress files="package-info.java" checks="JavadocStyle" />


### PR DESCRIPTION
for example, integration tests that live in `src/integrationTests/java`

noticed because after https://github.com/palantir/gradle-baseline/pull/240, static imports in classes within my `integrationTests` folder were causing checkstyle violations - figured we want to make the `s` optional for test all suppression rules