### PR TITLE
Clarify that PreconditionsConstantMessage allows for a template string

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
@@ -69,6 +69,6 @@ public final class PreconditionsConstantMessage extends BugChecker implements Bu
         }
 
         return buildDescription(tree).setMessage(
-                "Preconditions.checkX() statement uses a non-constant message. Consider using a template string").build();
+                "Preconditions.checkX() statement uses a non-constant message. Consider using a template string with '%s'.").build();
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
@@ -69,6 +69,6 @@ public final class PreconditionsConstantMessage extends BugChecker implements Bu
         }
 
         return buildDescription(tree).setMessage(
-                "Preconditions.checkX() statement uses a non-constant message").build();
+                "Preconditions.checkX() statement uses a non-constant message. Consider using a template string").build();
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
@@ -69,6 +69,7 @@ public final class PreconditionsConstantMessage extends BugChecker implements Bu
         }
 
         return buildDescription(tree).setMessage(
-                "Preconditions.checkX() statement uses a non-constant message. Consider using a template string with '%s'.").build();
+                "Preconditions.checkX() statement uses a non-constant message. "
+                        + "Consider using a template string with '%s'.").build();
     }
 }


### PR DESCRIPTION
From the current error message, I thought it truly wanted a constant, since I didn't realize Preconditions supported templates