### PR TITLE
Require that Files#list appear within a try-with-resources block

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesListUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesListUsage.java
@@ -1,0 +1,79 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.Category;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.TryTree;
+import com.sun.source.util.TreePath;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "UnclosedFilesListUsage",
+        category = Category.ONE_OFF,
+        severity = SeverityLevel.ERROR,
+        summary = "Ensure a stream returned by java.nio.file.Files#list is closed.")
+public final class UnclosedFilesListUsage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final MethodMatchers.MethodNameMatcher filesListMatcher = MethodMatchers.staticMethod()
+            .onClass("java.nio.file.Files")
+            .withNameMatching(Pattern.compile("list"));
+
+    private static final Matcher<Tree> tryResourcesMatcher = (Matcher<Tree>)
+            (methodInvocationTree, state) -> Optional.ofNullable(state.findEnclosing(TryTree.class))
+                    .map(TryTree::getResources)
+                    .map(resourcesTrees -> resourcesTrees.stream()
+                            .map(resourcesTree -> findPathToEnclosingTree(state.getPath(), resourcesTree))
+                            .anyMatch(Optional::isPresent))
+                    .orElse(false);
+
+    private static Optional<TreePath> findPathToEnclosingTree(TreePath initialPath, Tree tree) {
+        TreePath enclosingPath = initialPath;
+        while (enclosingPath != null) {
+            if (enclosingPath.getLeaf().equals(tree)) {
+                return Optional.of(enclosingPath);
+            }
+            enclosingPath = enclosingPath.getParentPath();
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!Matchers.allOf(filesListMatcher, Matchers.not(tryResourcesMatcher)).matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+        return buildDescription(tree)
+                .setMessage("java.nio.file.Files#list must be used within a try-with-resources block")
+                .build();
+    }
+
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesStreamUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesStreamUsage.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
         name = "UnclosedFilesStreamUsage",
         category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
-        summary = "Ensure a stream returned by java.nio.file.Files#{list,walk} "
+        summary = "Ensure a stream returned by java.nio.file.Files#{find,lines,list,walk} "
                 + "is closed to prevent leaking file descriptors.")
 public final class UnclosedFilesStreamUsage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
@@ -46,7 +46,7 @@ public final class UnclosedFilesStreamUsage extends BugChecker implements BugChe
 
     private static final MethodMatchers.MethodNameMatcher filesStreamMatcher = MethodMatchers.staticMethod()
             .onClass("java.nio.file.Files")
-            .withNameMatching(Pattern.compile("list|walk"));
+            .withNameMatching(Pattern.compile("find|lines|list|walk"));
 
     private static final Matcher<Tree> tryResourcesMatcher = (Matcher<Tree>)
             (methodInvocationTree, state) -> Optional.ofNullable(state.findEnclosing(TryTree.class))

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesStreamUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesStreamUsage.java
@@ -73,7 +73,8 @@ public final class UnclosedFilesStreamUsage extends BugChecker implements BugChe
             return Description.NO_MATCH;
         }
         return buildDescription(tree)
-                .setMessage("java.nio.file.Files must be called within a try-with-resources block")
+                .setMessage("Methods returning a Stream<> in java.nio.file.Files must be called "
+                        + "within a try-with-resources block")
                 .build();
     }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesStreamUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesStreamUsage.java
@@ -35,17 +35,17 @@ import java.util.regex.Pattern;
 
 @AutoService(BugChecker.class)
 @BugPattern(
-        name = "UnclosedFilesListUsage",
+        name = "UnclosedFilesStreamUsage",
         category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
-        summary = "Ensure a stream returned by java.nio.file.Files#list is closed.")
-public final class UnclosedFilesListUsage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+        summary = "Ensure a stream returned by java.nio.file.Files#{list,walk} is closed.")
+public final class UnclosedFilesStreamUsage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
     private static final long serialVersionUID = 1L;
 
-    private static final MethodMatchers.MethodNameMatcher filesListMatcher = MethodMatchers.staticMethod()
+    private static final MethodMatchers.MethodNameMatcher filesStreamMatcher = MethodMatchers.staticMethod()
             .onClass("java.nio.file.Files")
-            .withNameMatching(Pattern.compile("list"));
+            .withNameMatching(Pattern.compile("list|walk"));
 
     private static final Matcher<Tree> tryResourcesMatcher = (Matcher<Tree>)
             (methodInvocationTree, state) -> Optional.ofNullable(state.findEnclosing(TryTree.class))
@@ -68,11 +68,11 @@ public final class UnclosedFilesListUsage extends BugChecker implements BugCheck
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (!Matchers.allOf(filesListMatcher, Matchers.not(tryResourcesMatcher)).matches(tree, state)) {
+        if (!Matchers.allOf(filesStreamMatcher, Matchers.not(tryResourcesMatcher)).matches(tree, state)) {
             return Description.NO_MATCH;
         }
         return buildDescription(tree)
-                .setMessage("java.nio.file.Files#list must be used within a try-with-resources block")
+                .setMessage("java.nio.file.Files must be called within a try-with-resources block")
                 .build();
     }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesStreamUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnclosedFilesStreamUsage.java
@@ -38,7 +38,8 @@ import java.util.regex.Pattern;
         name = "UnclosedFilesStreamUsage",
         category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
-        summary = "Ensure a stream returned by java.nio.file.Files#{list,walk} is closed.")
+        summary = "Ensure a stream returned by java.nio.file.Files#{list,walk} "
+                + "is closed to prevent leaking file descriptors.")
 public final class UnclosedFilesStreamUsage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
     private static final long serialVersionUID = 1L;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnclosedFilesListUsageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnclosedFilesListUsageTests.java
@@ -26,11 +26,11 @@ public final class UnclosedFilesListUsageTests {
 
     @Before
     public void before() {
-        compilationHelper = CompilationTestHelper.newInstance(UnclosedFilesListUsage.class, getClass());
+        compilationHelper = CompilationTestHelper.newInstance(UnclosedFilesStreamUsage.class, getClass());
     }
 
     @Test
-    public void testThrowsOnNoTryWithResources() {
+    public void testThrowsOnListWithNoTryWithResources() {
         compilationHelper
                 .addSourceLines(
                         "Test.java",
@@ -39,8 +39,27 @@ public final class UnclosedFilesListUsageTests {
                         "class Test {",
                         "  void f(String param) {",
                         "    try {",
-                        "      // BUG: Diagnostic contains: must be used within a try-with-resources block",
+                        "      // BUG: Diagnostic contains: java.nio.file.Files must be called within a try-with",
                         "      Files.list(Paths.get(\"/tmp\"));",
+                        "    } catch (java.io.IOException e) {",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testThrowsOnWalkWithNoTryWithResources() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.nio.file.Files;",
+                        "import java.nio.file.Paths;",
+                        "class Test {",
+                        "  void f(String param) {",
+                        "    try {",
+                        "      // BUG: Diagnostic contains: java.nio.file.Files must be called within a try-with",
+                        "      Files.walk(Paths.get(\"/tmp\"));",
                         "    } catch (java.io.IOException e) {",
                         "    }",
                         "  }",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnclosedFilesListUsageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnclosedFilesListUsageTests.java
@@ -1,0 +1,70 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class UnclosedFilesListUsageTests {
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(UnclosedFilesListUsage.class, getClass());
+    }
+
+    @Test
+    public void testThrowsOnNoTryWithResources() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.nio.file.Files;",
+                        "import java.nio.file.Paths;",
+                        "class Test {",
+                        "  void f(String param) {",
+                        "    try {",
+                        "      // BUG: Diagnostic contains: must be used within a try-with-resources block",
+                        "      Files.list(Paths.get(\"/tmp\"));",
+                        "    } catch (java.io.IOException e) {",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void positive() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.nio.file.Files;",
+                        "import java.nio.file.Path;",
+                        "import java.nio.file.Paths;",
+                        "import java.util.stream.Stream;",
+                        "class Test {",
+                        "  void f(String param) {",
+                        "    try (Stream<Path> files = Files.list(Paths.get(\"/tmp\"))) {",
+                        "    } catch (java.io.IOException e) {",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnclosedFilesListUsageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnclosedFilesListUsageTests.java
@@ -30,7 +30,7 @@ public final class UnclosedFilesListUsageTests {
     }
 
     @Test
-    public void testThrowsOnListWithNoTryWithResources() {
+    public void testThrowsOnList_noTryWithResources() {
         compilationHelper
                 .addSourceLines(
                         "Test.java",
@@ -49,7 +49,7 @@ public final class UnclosedFilesListUsageTests {
     }
 
     @Test
-    public void testThrowsOnWalkWithNoTryWithResources() {
+    public void testThrowsOnWalk_noTryWithResources() {
         compilationHelper
                 .addSourceLines(
                         "Test.java",
@@ -62,6 +62,33 @@ public final class UnclosedFilesListUsageTests {
                         "      Files.walk(Paths.get(\"/tmp\"));",
                         "    } catch (java.io.IOException e) {",
                         "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testThrowsOnWalk_aDifferentTryWithResources() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.io.IOException;",
+                        "import java.io.StringWriter;",
+                        "import java.io.Writer;",
+                        "import java.nio.file.Files;",
+                        "import java.nio.file.Path;",
+                        "import java.nio.file.Paths;",
+                        "import java.util.stream.Stream;",
+                        "class Test {",
+                        "  void f(String param) {",
+                        "    try (Writer writer = new StringWriter()) {",
+                        "      // BUG: Diagnostic contains: java.nio.file.Files must be called within a try-with",
+                        "      Stream<Path> files = Files.list(Paths.get(\"/tmp\"));",
+                        "      files.forEach(path -> {",
+                        "        try { writer.write(path.toString()); }",
+                        "        catch (IOException e) {}",
+                        "      });",
+                        "    } catch (IOException e) {}",
                         "  }",
                         "}")
                 .doTest();


### PR DESCRIPTION
It's a common mistake to use `Files#list` without closing the returned Stream. This check ensures that this method is only ever used inside a try-with-resources block and therefore the stream is auto-closed.

We could one day be more lenient here and allow it to be outside iff the `close` method is called on the returned value. But that's harder to implement and perhaps not necessary initially.