### PR TITLE
Simplify format of TODO regex

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -324,7 +324,7 @@
             <property name="message" value="Redundant ''static'' modifier."/>
         </module>
         <module name="RegexpSinglelineJava">
-            <property name="format" value="(\/\/TODO)|(\/\/ TODO:)|(\/\/ TODO\(\))|(\/\/ TODO\(.*+\):[^ ])|(\/\/ TODO\(.*+\)[^:])|(\/\/ TODO\(.*[\s\(\)]+.*\):)"/>
+            <property name="format" value="\/\/TODO|\/\/ TODO(?!\([^()\s]+\): )"/>
             <property name="message" value="TODO format: // TODO(flastname): explanation"/>
         </module>
         <module name="RegexpSinglelineJava">


### PR DESCRIPTION
 * Rather than try to invididually describe every incorrect case (which actually
   misses cases), use a negative look-ahead to match against anything which isn't
   correct.  A single OR is still needed as anything without a space between the
   comment markers and the TODO is incorrect regardless of what proceeds it.