### PR TITLE
Allow jars to contain module-info.class files

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/ClassUniquenessAnalyzer.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/ClassUniquenessAnalyzer.java
@@ -76,6 +76,12 @@ public final class ClassUniquenessAnalyzer {
                         continue;
                     }
 
+                    if (entry.getName().equals("module-info.class")) {
+                        // Java 9 allows jars to have a module-info.class file in the root,
+                        // we shouldn't complain about these.
+                        continue;
+                    }
+
                     String className = entry.getName().replaceAll("/", ".").replaceAll(".class", "");
                     HashingInputStream inputStream = new HashingInputStream(Hashing.sha256(), jarInputStream);
                     ByteStreams.exhaust(inputStream);


### PR DESCRIPTION
I ran this internally and got a false positive here:

```
1 Identically named classes with differing impls found in [org.ow2.asm:asm-commons:6.0, org.ow2.asm:asm:6.0, org.ow2.asm:asm-tree:6.0]: [module-info]


* What went wrong:
Execution failed for task ':foo:checkClassUniqueness'.
> 'runtime' contains multiple copies of identically named classes - this may cause different runtime behaviour depending on classpath ordering.
  To resolve this, try excluding one of the following jars:
  
        (1 classes)   org.ow2.asm:asm-commons:6.0 org.ow2.asm:asm:6.0         org.ow2.asm:asm-tree:6.0  
```

This matches what nebula-lint has already done: https://github.com/nebula-plugins/gradle-lint-plugin/issues/139