### PR TITLE
Ignore generated_schema folder in checkstyle

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
@@ -21,7 +21,8 @@
     <suppress files="\.(bdr|eot|gif|gzip|jar|json|otf|png|svg|ttf|woff|zip)$" checks="NewlineAtEndOfFile" />
 
     <!-- Generated code should not be subjected to checkstyle. -->
+    <suppress files="[/\\].*[/\\]generated[/\\]" checks="." />
+    <suppress files="[/\\].*[/\\]generated_schema[/\\]" checks="." />
     <suppress files="[/\\].*[/\\]generated_src[/\\]" checks="." />
     <suppress files="[/\\].*[/\\]generated_testSrc[/\\]" checks="." />
-    <suppress files="[/\\].*[/\\]generated[/\\]" checks="." />
 </suppressions>


### PR DESCRIPTION
We use generated-schema folders to store generated AtlasDB schema. Use
of AtlasDB is common enough that I propose we include this rule by
default.