### PR TITLE
Intellij OPTIMIZE_IMPORTS_ON_THE_FLY

### DIFF
--- a/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
+++ b/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
@@ -55,6 +55,7 @@
         <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
         <option name="METHOD_PARAMETERS_WRAP" value="1" />
         <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+        <option name="OPTIMIZE_IMPORTS_ON_THE_FLY" value="true" />
         <option name="OTHER_INDENT_OPTIONS">
           <value>
             <option name="INDENT_SIZE" value="4" />
@@ -66,7 +67,7 @@
             <option name="LABEL_INDENT_ABSOLUTE" value="false" />
             <option name="USE_RELATIVE_INDENTS" value="false" />
           </value>
-         </option>
+        </option>
         <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
           <value />
         </option>
@@ -101,6 +102,7 @@
           <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
           <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
           <option name="METHOD_PARAMETERS_WRAP" value="1" />
+          <option name="OPTIMIZE_IMPORTS_ON_THE_FLY" value="true" />
           <option name="PARENT_SETTINGS_INSTALLED" value="true" />
           <option name="RESOURCE_LIST_WRAP" value="5" />
           <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />


### PR DESCRIPTION
Checkstyle will freak out if you have unused imports, but by default, people's IDEs will leave these unused imports hanging around!

This settings makes intellij clean up unused imports for a file when you touch it.

<img width="1140" alt="screen shot 2018-05-14 at 15 32 22" src="https://user-images.githubusercontent.com/3473798/40019045-168f4ac4-578c-11e8-98f5-d8211f2d1ccd.png">


I found this by doing File -> Export Settings... and then digging around in the resultant archive.