### PR TITLE
Do not rely on internal gradle classes

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -128,6 +128,10 @@
             <message key="import.illegal" value="Must not import repackaged classes."/>
         </module>
         <module name="IllegalImport">
+            <property name="illegalPkgs" value="^org\.gradle\..*internal"/>
+            <message key="import.illegal" value="Do not rely on gradle internal classes as these may change in minor releases - use org.gradle.api versions instead."/>
+        </module>
+        <module name="IllegalImport">
             <property name="illegalPkgs" value="org.apache.commons.lang"/>
             <message key="import.illegal" value="lang is deprecated, use lang3 instead."/>
         </module>


### PR DESCRIPTION
We've had internal gradle plugins break when we upgraded gradle from 4.7 -> 4.8.  Need to stop people relying on these classes!

It seems that checkstyle actually does support regexes (http://checkstyle.sourceforge.net/config_imports.html):

```xml
<module name="IllegalImport">
  <property name="regexp" value="true"/>
  <property name="illegalClasses"
    value="^java\.util\.(List|Arrays), ^java\.sql\.Connection"/>
</module>
```

Seems nicer than including all these badboys:

```
org.gradle.ide.xcode.tasks.internal
org.gradle.ide.xcode.internal
org.gradle.ide.visualstudio.tasks.internal
org.gradle.ide.visualstudio.internal
org.gradle.tooling.internal
org.gradle.tooling.provider.model.internal
org.gradle.tooling.model.internal
org.gradle.tooling.events.test.internal
org.gradle.tooling.events.internal
org.gradle.tooling.events.task.internal
org.gradle.cache.internal
org.gradle.util.internal
org.gradle.normalization.internal
org.gradle.plugins.ide.eclipse.internal
org.gradle.plugins.ide.eclipse.model.internal
org.gradle.plugins.ide.internal
org.gradle.plugins.ide.idea.internal
org.gradle.plugins.ide.idea.model.internal
org.gradle.plugins.signing.signatory.internal
org.gradle.plugins.ear.descriptor.internal
org.gradle.plugins.javascript.jshint.internal
org.gradle.plugins.javascript.envjs.internal
org.gradle.plugins.javascript.envjs.http.simple.internal
org.gradle.plugins.javascript.rhino.worker.internal
org.gradle.plugins.javascript.coffeescript.compile.internal
org.gradle.platform.base.internal
org.gradle.platform.base.component.internal
org.gradle.plugin.internal
org.gradle.plugin.management.internal
org.gradle.plugin.use.resolve.internal
org.gradle.plugin.use.resolve.service.internal
org.gradle.plugin.use.internal
org.gradle.internal
org.gradle.jvm.test.internal
org.gradle.jvm.platform.internal
org.gradle.jvm.internal
org.gradle.jvm.toolchain.internal
org.gradle.testfixtures.internal
org.gradle.language.assembler.plugins.internal
org.gradle.language.assembler.internal
org.gradle.language.internal
org.gradle.language.jvm.internal
org.gradle.language.java.internal
org.gradle.language.twirl.internal
org.gradle.language.scala.internal
org.gradle.language.cpp.tasks.internal
org.gradle.language.cpp.internal
org.gradle.language.swift.tasks.internal
org.gradle.language.swift.internal
org.gradle.language.javascript.internal
org.gradle.language.objectivecpp.internal
org.gradle.language.rc.plugins.internal
org.gradle.language.rc.internal
org.gradle.language.c.internal
org.gradle.language.nativeplatform.internal
org.gradle.language.base.internal
org.gradle.language.objectivec.internal
org.gradle.buildinit.tasks.internal
org.gradle.buildinit.plugins.internal
org.gradle.composite.internal
org.gradle.testing.base.internal
org.gradle.vcs.internal
org.gradle.vcs.git.internal
org.gradle.scala.internal
org.gradle.deployment.internal
org.gradle.model.collection.internal
org.gradle.model.internal
org.gradle.model.dsl.internal
org.gradle.api.reporting.dependents.internal
org.gradle.api.reporting.internal
org.gradle.api.reporting.dependencies.internal
org.gradle.api.reporting.components.internal
org.gradle.api.reporting.model.internal
org.gradle.api.tasks.util.internal
org.gradle.api.tasks.diagnostics.internal
org.gradle.api.tasks.bundling.internal
org.gradle.api.tasks.javadoc.internal
org.gradle.api.publication.maven.internal
org.gradle.api.specs.internal
org.gradle.api.plugins.announce.internal
org.gradle.api.plugins.quality.internal
org.gradle.api.plugins.antlr.internal
org.gradle.api.plugins.internal
org.gradle.api.plugins.buildcomparison.render.internal
org.gradle.api.plugins.buildcomparison.outcome.internal
org.gradle.api.plugins.buildcomparison.gradle.internal
org.gradle.api.plugins.buildcomparison.compare.internal
org.gradle.api.resources.internal
org.gradle.api.distribution.internal
org.gradle.api.internal
org.gradle.api.java.archives.internal
org.gradle.api.publish.ivy.internal
org.gradle.api.publish.maven.internal
org.gradle.api.publish.internal
org.gradle.api.execution.internal
org.gradle.workers.internal
org.gradle.groovy.scripts.internal
org.gradle.external.javadoc.internal
org.gradle.play.plugins.ide.internal
org.gradle.play.internal
org.gradle.caching.configuration.internal
org.gradle.caching.internal
org.gradle.caching.local.internal
org.gradle.caching.http.internal
org.gradle.nativeplatform.test.xctest.internal
org.gradle.nativeplatform.test.internal
org.gradle.nativeplatform.test.cunit.internal
org.gradle.nativeplatform.test.cpp.internal
org.gradle.nativeplatform.test.googletest.internal
org.gradle.nativeplatform.platform.internal
org.gradle.nativeplatform.internal
org.gradle.nativeplatform.toolchain.internal
org.gradle.swiftpm.internal
org.gradle.process.internal
com.amazonaws.internal
```