### PR TITLE
Error-prone 2.0.19 -> 2.3.1

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -9,3 +9,9 @@ sourceCompatibility = 1.8
 if (System.env.CI) {
     test.reports.junitXml.destination = file("/tmp/store_test_results/${project.name}")
 }
+
+configurations.errorprone {
+    resolutionStrategy {
+        force('com.google.guava:guava:23.5-jre')
+    }
+}

--- a/versions.props
+++ b/versions.props
@@ -1,7 +1,7 @@
 com.google.auto.service:auto-service = 1.0-rc3
 com.google.errorprone:error_prone_annotations = 2.3.1
-com.google.errorprone:error_prone_core = 2.0.19
-com.google.errorprone:error_prone_test_helpers = 2.0.19
+com.google.errorprone:error_prone_core = 2.3.1
+com.google.errorprone:error_prone_test_helpers = 2.3.1
 com.google.guava:guava = 21.0
 com.palantir.baseline:* = 0.20.1
 com.palantir.safe-logging:* = 1.4.0


### PR DESCRIPTION
The error-prone releases page lists a ton of cool new static checks: https://github.com/google/error-prone/releases e.g.

- [FieldCanBeFinal] This field is only assigned during initialization; consider making it final
- [StringSplit] detects String.split(String), which has surprising behaviour.

There are other 'strong opinions' that might cause some problems.  Possibly worth doing an RC to assess the impact of this...

- [TypeParameterNaming] Type parameters must be a single letter with an optional numeric suffix, or an UpperCamelCase name followed by the letter 'T'.