### PR TITLE
Bintray plugin 1.6 -> 1.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'gradle.plugin.com.palantir:gradle-circle-style:1.1.2'
         classpath 'com.gradle.publish:plugin-publish-plugin:0.9.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:5.2.0'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.4'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.20.1'


### PR DESCRIPTION
This is necessary to make publishing work again with gradle 4.8.

Matches https://github.com/palantir/http-remoting/pull/728