### PR TITLE
Upgrade error-prone's EqualsHashCode and EqualsIncompatibleType from Warn -> Error

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
@@ -19,6 +19,7 @@ package com.palantir.baseline.plugins
 import net.ltgt.gradle.errorprone.ErrorPronePlugin
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.tasks.compile.JavaCompile
 
 class BaselineErrorProne extends AbstractBaselinePlugin {
 
@@ -29,6 +30,13 @@ class BaselineErrorProne extends AbstractBaselinePlugin {
         project.dependencies {
             // TODO(rfink): This is somewhat ugly. Is there a better to add the processor dependency on the library?
             errorprone "com.palantir.baseline:baseline-error-prone:${extractVersionString()}"
+        }
+
+        tasks.withType(JavaCompile) {
+            options.compilerArgs += [
+                    "-XepDisableWarningsInGeneratedCode",
+                    "-Werror"
+            ]
         }
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
@@ -32,7 +32,7 @@ class BaselineErrorProne extends AbstractBaselinePlugin {
             errorprone "com.palantir.baseline:baseline-error-prone:${extractVersionString()}"
         }
 
-        tasks.withType(JavaCompile) {
+        project.tasks.withType(JavaCompile) {
             options.compilerArgs += [
                     "-XepDisableWarningsInGeneratedCode",
                     "-Werror"

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.groovy
@@ -35,7 +35,8 @@ class BaselineErrorProne extends AbstractBaselinePlugin {
         project.tasks.withType(JavaCompile) {
             options.compilerArgs += [
                     "-XepDisableWarningsInGeneratedCode",
-                    "-Werror"
+                    "-Xep:EqualsHashCode:ERROR",
+                    "-Xep:EqualsIncompatibleType:ERROR",
             ]
         }
     }


### PR DESCRIPTION
Fixes #297

Enables [`EqualsHashCode`](http://errorprone.info/bugpattern/EqualsHashCode) and [`EqualsIncompatibleType`](http://errorprone.info/bugpattern/EqualsIncompatibleType) as `ERROR` for Errorprone.