### PR TITLE
Line comments are inline and with a single space

### DIFF
--- a/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
+++ b/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
@@ -101,6 +101,8 @@
           <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
           <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
           <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+          <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+          <option name="LINE_COMMENT_ADD_SPACE" value="true" />
           <option name="METHOD_PARAMETERS_WRAP" value="1" />
           <option name="OPTIMIZE_IMPORTS_ON_THE_FLY" value="true" />
           <option name="PARENT_SETTINGS_INSTALLED" value="true" />


### PR DESCRIPTION
The [Java code style guide](https://github.com/palantir/gradle-baseline/blob/develop/docs/java-style-guide/readme.md) implicitly suggests that line comments shouldn't start at the first column, but inline, and with a space following the `//`.
The two added settings will create this behaviour when using Intellij's `Comment with Line Comment` action.