### PR TITLE
Revert "Add suppressions for integration tests as well"

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
@@ -8,10 +8,10 @@
  for your changes to take effect in its Checkstyle integration. -->
 <suppressions>
     <!-- Suppress test classes -->
-    <suppress files="[/\\]src[/\\].*(integration)?[Tt]est[/\\](java|groovy)[/\\]" checks="Javadoc*" />
-    <suppress files="[/\\]src[/\\].*(integration)?[Tt]est[/\\](java|groovy)[/\\]" checks="VariableDeclarationUsageDistance" />
-    <suppress files="[/\\]src[/\\].*(integration)?[Tt]est[/\\](java|groovy)[/\\]" checks="VisibilityModifier" />
-    <suppress files="[/\\]src[/\\].*(integration)?[Tt]est[/\\](java|groovy)[/\\]" checks="AvoidStaticImport" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="Javadoc*" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="VisibilityModifier" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="AvoidStaticImport" />
 
     <!-- JavadocStyle enforces existence of package-info.java package-level Javadoc; we consider this a bug. -->
     <suppress files="package-info.java" checks="JavadocStyle" />


### PR DESCRIPTION
Reverts palantir/gradle-baseline#304

This pr is silly and I was looking at the wrong thing for suppressions