### PR TITLE
com.palantir.baseline-circleci transitively applies configuration-resolver plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,15 @@ configurations.all {
 
 ### CircleCi Plugin (com.palantir.baseline-circleci)
 
-Applies [`com.palantir.circle.style`](https://github.com/palantir/gradle-circle-style) plugin which configures junit xml test output to be written to $CIRCLE_TEST_REPORTS directory.
-Additionally enables html reports for tests and stores the output in $CIRCLE_ARTIFACTS and if gradle is run with `--profile`
-the profiling output is also persisted in $CIRCLE_ARTIFACTS.
+Automatically applies the following plugins:
 
+- [`com.palantir.circle.style`](https://github.com/palantir/gradle-circle-style) - this configures checkstyle xml output to be written to the `$CIRCLE_TEST_REPORTS` directory.
+- [`com.palantir.configuration-resolver`](https://github.com/palantir/gradle-configuration-resolver-plugin) - this adds a `./gradlew resolveConfigurations` task which is useful for caching on CI.
+
+Also, the plugin:
+
+1. stores the HTML output of tests in `$CIRCLE_ARTIFACTS/junit`
+1. stores the HTML reports from `--profile` into `$CIRCLE_ARTIFACTS/reports`
 
 ### Copyright Checks
 

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile gradleApi()
     compile 'com.google.guava:guava'
     compile 'gradle.plugin.com.palantir:gradle-circle-style'
+    compile 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin'
     compile 'net.ltgt.gradle:gradle-errorprone-plugin'
 
     testCompile gradleTestKit()

--- a/versions.props
+++ b/versions.props
@@ -4,6 +4,7 @@ com.google.errorprone:error_prone_core = 2.0.19
 com.google.errorprone:error_prone_test_helpers = 2.0.19
 com.google.guava:guava = 21.0
 com.palantir.baseline:* = 0.24.0
+com.palantir.configurationresolver:gradle-configuration-resolver-plugin = 0.3.0
 com.palantir.safe-logging:* = 1.4.0
 org.slf4j:slf4j-api = 1.7.24
 gradle.plugin.com.palantir:gradle-circle-style = 1.1.4


### PR DESCRIPTION
The vast majority of our internal repos have the same code, I figure we might as well just make this happen automatically for anyone who applies the `com.palantir.baseline-circleci` plugin.

```gradle
buildscript {
  dependencies {
    classpath 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin:0.3.0'
  }
}

allprojects {
  // ...
  apply plugin: 'com.palantir.configuration-resolver'
}
```