### PR TITLE
Block the usage of Guava caches

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -165,6 +165,10 @@
         <module name="IllegalType"> <!-- Java Coding Guide: Limit coupling on concrete classes -->
             <property name="illegalClassNames" value="java.util.ArrayList, java.util.HashSet, java.util.HashMap, java.util.LinkedList, java.util.LinkedHashMap, java.util.LinkedHashSet, java.util.TreeSet, java.util.TreeMap, com.google.common.collect.ArrayListMultimap, com.google.common.collect.ForwardingListMultimap, com.google.common.collect.ForwardingMultimap, com.google.common.collect.ForwardingSetMultimap, com.google.common.collect.ForwardingSortedSetMultimap, com.google.common.collect.HashMultimap, com.google.common.collect.LinkedHashMultimap, com.google.common.collect.LinkedListMultimap, com.google.common.collect.TreeMultimap"/>
         </module>
+        <module name="IllegalType">
+            <property name="illegalClassNames" value="com.google.common.cache.CacheBuilder, com.google.common.cache.Cache, com.google.common.cache.LoadingCache"/>
+            <message key="illegal.type" value="Do not use Guava caches, they are outperformed by and harder to use than Caffeine caches"/>
+        </module>
         <module name="ImportOrder"> <!-- Java Style Guide: Ordering and spacing -->
             <property name="groups" value="/.*/"/>
             <property name="option" value="top"/>


### PR DESCRIPTION
Guava caches should not be used.

They're mostly used because people are lazy or uninformed - they either
don't know that Caffeine is better or don't have it on their classpath
and don't want to add the extra line.

Caffeine is a lot better than Guava. Its advantages include:

1. By using ConcurrentHashMap instead of a custom (and primitive) map,
it sees significantly better performance and lower contention.
2. By using ConcurrentHashMap, you no longer have to accurately set a
concurrency level (which no one does).
3. By using the Windowed Tiny-LFU eviction policy, it sees dramatically
higher cache hit rates on real workflows: https://github.com/ben-manes/caffeine/wiki/Efficiency
4. By being written for Java 8, its cache loaders etc are generally
functional interfaces.

We should be using Caffeine everywhere.

As one example of this, I switched out a Guava cache for a Caffeine
cache inside AtlasDB, and saw the hit rate rise from around 0.5 to
around 0.8 on one of our higher traffic internal deployments.