### PR TITLE
IDEA dependency on CheckStyle-IDEA plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ respective baseline-xyz plugins are applied).
    - Code style and code formatting rules conforming with Baseline style
    - Checkstyle configuration
 
-  Note that the Checkstyle-IDEA plugin is required to run the Baseline Checkstyle within IntelliJ.
+  Note that the CheckStyle-IDEA plugin is required to run the Baseline Checkstyle within IntelliJ.
 
 
 
@@ -192,7 +192,7 @@ The Eclipse plugin is compatible with the following versions: Checkstyle 7.5+, J
 ### IntelliJ Plugin (com.palantir.baseline-idea)
 
 Run `./gradlew idea` to (re-) generate IntelliJ project and module files from the templates in `.baseline`. The
-generated project is pre-configured with Baseline code style settings and support for the Checkstyle-IDEA plugin.
+generated project is pre-configured with Baseline code style settings and support for the CheckStyle-IDEA plugin.
 
 The `com.palantir.baseline-idea` plugin automatically applies the `idea` plugin.
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -124,6 +124,9 @@ class BaselineIdea extends AbstractBaselinePlugin {
               </option>
             </component>
             """.stripIndent()))
+
+        def externalDependencies = matchOrCreateChild(node, 'component', [name: 'ExternalDependencies'])
+        matchOrCreateChild(externalDependencies, 'plugin', [id: 'CheckStyle-IDEA'])
     }
 
     /**


### PR DESCRIPTION
Adding this gives the following warning when you open the .ipr file:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/1619162/43912346-df80023c-9bf9-11e8-95ba-4d1318ab716e.png">

and then you can install the plugin by clicking on "Install required plugins"
<img width="891" alt="image" src="https://user-images.githubusercontent.com/1619162/43912382-f90c2104-9bf9-11e8-8e22-59849493878b.png">
