### PR TITLE
Upgrade baseline and publish to plugins.gradle.org

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -144,6 +144,7 @@
             <message key="import.illegal" value="math is deprecated, use math3 instead."/>
         </module>
         <module name="IllegalImport">
+            <property name="id" value="BanLoggingImplementations"/>
             <property name="illegalPkgs" value="org.apache.log4j, org.apache.logging.log4j, java.util.logging, ch.qos.logback"/>
             <message key="import.illegal" value="Use SLF4J instead of a logging framework directly."/>
         </module>
@@ -164,6 +165,11 @@
         </module>
         <module name="IllegalType"> <!-- Java Coding Guide: Limit coupling on concrete classes -->
             <property name="illegalClassNames" value="java.util.ArrayList, java.util.HashSet, java.util.HashMap, java.util.LinkedList, java.util.LinkedHashMap, java.util.LinkedHashSet, java.util.TreeSet, java.util.TreeMap, com.google.common.collect.ArrayListMultimap, com.google.common.collect.ForwardingListMultimap, com.google.common.collect.ForwardingMultimap, com.google.common.collect.ForwardingSetMultimap, com.google.common.collect.ForwardingSortedSetMultimap, com.google.common.collect.HashMultimap, com.google.common.collect.LinkedHashMultimap, com.google.common.collect.LinkedListMultimap, com.google.common.collect.TreeMultimap"/>
+        </module>
+        <module name="IllegalType">
+            <property name="id" value="BanGuavaCaches"/>
+            <property name="illegalClassNames" value="com.google.common.cache.CacheBuilder, com.google.common.cache.Cache, com.google.common.cache.LoadingCache"/>
+            <message key="illegal.type" value="Do not use Guava caches, they are outperformed by and harder to use than Caffeine caches"/>
         </module>
         <module name="ImportOrder"> <!-- Java Style Guide: Ordering and spacing -->
             <property name="groups" value="/.*/"/>
@@ -333,7 +339,7 @@
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="\/\/TODO|\/\/ TODO(?!\([^()\s]+\): )"/>
-            <property name="message" value="TODO format: // TODO(flastname): explanation"/>
+            <property name="message" value="TODO format: // TODO(#issue): explanation"/>
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,7 @@ jobs:
           path: /tmp/store_test_results
 
       - deploy:
-          command: |
-            if [[ "${CIRCLE_TAG}" =~ [0-9]+(\.[0-9]+)+(-[a-zA-Z]+[0-9]*)* ]]; then
-              ./gradlew --info bintrayUpload
-            fi
+          command: ./gradlew --info --continue publish
 
   docs:
     docker:

--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -13,11 +13,3 @@ dependencies {
 
     processor 'com.google.auto.service:auto-service'
 }
-
-tasks.withType(JavaCompile) {
-    options.compilerArgs += ["-Xbootclasspath/p:${configurations.errorprone.asPath}"]
-}
-
-tasks.withType(Test) {
-    jvmArgs "-Xbootclasspath/p:${configurations.errorprone.asPath}"
-}

--- a/build.gradle
+++ b/build.gradle
@@ -6,32 +6,29 @@ buildscript {
     }
 
     dependencies {
-        classpath 'gradle.plugin.com.palantir:gradle-circle-style:1.1.4'
-        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3'
-        classpath 'com.netflix.nebula:nebula-dependency-recommender:6.0.0'
-        classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.4'
-        classpath 'com.palantir.baseline:gradle-baseline-java:0.26.1'
-        classpath 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin:0.3.0'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.10.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.netflix.nebula:nebula-publishing-plugin:8.2.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:0.28.0'
     }
 }
 
 plugins {
-    id 'com.palantir.git-version' version '0.5.3'
-    id 'org.inferred.processors' version '1.2.12'
+    id 'com.palantir.git-version' version '0.11.0'
+    id 'org.inferred.processors' version '1.2.16'
 }
 
 apply plugin: 'java'
 apply plugin: 'com.palantir.baseline-config'
 apply plugin: 'com.palantir.baseline-idea'
+apply plugin: 'com.palantir.baseline-circleci'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
-apply plugin: 'com.palantir.circle.style'
 
 tasks.test.dependsOn tasks.publishToMavenLocal
 
 dependencies {
-    baseline group: 'com.palantir.baseline', name: 'gradle-baseline-java-config', ext: 'zip'
+    baseline 'com.palantir.baseline:gradle-baseline-java-config@zip'
 }
 
 allprojects {
@@ -42,13 +39,7 @@ allprojects {
     }
 
     apply plugin: 'org.inferred.processors'
-    apply plugin: 'com.palantir.configuration-resolver'
-
-    apply plugin: 'nebula.dependency-recommender'
-    dependencyRecommendations {
-        strategy OverrideTransitives
-        propertiesFile file: project.rootProject.file('versions.props')
-    }
+    apply plugin: 'com.palantir.baseline-versions'
 
     group = 'com.palantir.baseline'
     version System.env.CIRCLE_TAG ?: gitVersion()

--- a/gradle-baseline-java-config/build.gradle
+++ b/gradle-baseline-java-config/build.gradle
@@ -11,20 +11,22 @@ task zipConfig(type: Zip) {
     }
 }
 
-bintrayUpload.dependsOn { generatePomFileForConfigPublicationPublication }
-bintrayUpload.dependsOn { zipConfig }
-
 bintray {
-    user = System.getenv('BINTRAY_USERNAME')
-    key = System.getenv('BINTRAY_PASSWORD')
+    user = System.env.BINTRAY_USERNAME
+    key = System.env.BINTRAY_PASSWORD
     publish = true
     pkg {
         repo = 'releases'
-        name = 'gradle-baseline'
+        name = rootProject.name
         userOrg = 'palantir'
         licenses = ['Apache-2.0']
         publications = ['ConfigPublication']
     }
+}
+
+publish.dependsOn bintrayUpload
+bintrayUpload.onlyIf {
+    versionDetails().isCleanTag
 }
 
 publishing {

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -1,15 +1,24 @@
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
+apply plugin: 'com.gradle.plugin-publish'
 apply from: "${rootDir}/gradle/publish-libs.gradle"
 apply from: "${rootDir}/gradle/java.gradle"
 
+configurations {
+    pluginCompile
+}
+
 dependencies {
     compile gradleApi()
-    compile 'com.google.guava:guava'
-    compile 'gradle.plugin.com.palantir:gradle-circle-style'
-    compile 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin'
-    compile 'com.netflix.nebula:nebula-dependency-recommender'
-    compile 'net.ltgt.gradle:gradle-errorprone-plugin'
+    pluginCompile 'com.google.guava:guava'
+    pluginCompile 'gradle.plugin.com.palantir:gradle-circle-style'
+    pluginCompile 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin'
+    pluginCompile 'com.netflix.nebula:nebula-dependency-recommender'
+    pluginCompile 'net.ltgt.gradle:gradle-errorprone-plugin'
+
+    configurations.pluginCompile.resolvedConfiguration.firstLevelModuleDependencies.each {
+        compile "${it.moduleGroup}:${it.moduleName}:${it.moduleVersion}"
+    }
 
     testCompile gradleTestKit()
     testCompile 'com.netflix.nebula:nebula-test' // for better temp directory junit rule only
@@ -30,7 +39,6 @@ task createVersionFile {
 }
 compileGroovy.dependsOn createVersionFile
 
-apply plugin: "com.gradle.plugin-publish"
 pluginBundle {
     website = 'https://github.com/palantir/gradle-baseline'
     vcsUrl = 'https://github.com/palantir/gradle-baseline'
@@ -69,3 +77,10 @@ pluginBundle {
     }
 }
 
+// Configure the publishPlugins task
+tasks.publish.dependsOn publishPlugins
+publishPlugins.onlyIf {
+    versionDetails().isCleanTag
+}
+project.ext.'gradle.publish.key' = System.env.GRADLE_KEY
+project.ext.'gradle.publish.secret' = System.env.GRADLE_SECRET

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/AbstractPluginTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/AbstractPluginTest.groovy
@@ -46,7 +46,6 @@ class AbstractPluginTest extends Specification {
             .withProjectDir(projectDir)
             .withArguments(tasks)
             .withPluginClasspath()
-            .withDebug(true)
     }
 
     String exec(String task) {

--- a/gradle/publish-libs.gradle
+++ b/gradle/publish-libs.gradle
@@ -1,30 +1,22 @@
-apply plugin: 'maven'
-apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'nebula.maven-publish'
 apply plugin: 'nebula.maven-resolved-dependencies'
 apply plugin: 'nebula.source-jar'
-apply plugin: 'com.jfrog.bintray'
-
-bintrayUpload.dependsOn { build }
-bintrayUpload.dependsOn { generatePomFileForNebulaPublication }
 
 bintray {
-    user = System.getenv('BINTRAY_USERNAME')
-    key = System.getenv('BINTRAY_PASSWORD')
+    user = System.env.BINTRAY_USERNAME
+    key = System.env.BINTRAY_PASSWORD
     publish = true
     pkg {
         repo = 'releases'
-        name = 'gradle-baseline'
+        name = rootProject.name
         userOrg = 'palantir'
         licenses = ['Apache-2.0']
         publications = ['nebula']
     }
 }
 
-publishing {
-    publications {
-        nebula(MavenPublication) {
-            from components.java
-        }
-    }
+publish.dependsOn bintrayUpload
+bintrayUpload.onlyIf {
+    versionDetails().isCleanTag
 }
-

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,6 @@
+rootProject.name = "gradle-baseline"
+enableFeaturePreview("STABLE_PUBLISHING")
+
 include "baseline-error-prone"
 include "gradle-baseline-java"
 include "gradle-baseline-java-config"

--- a/versions.props
+++ b/versions.props
@@ -1,10 +1,10 @@
-com.google.auto.service:auto-service = 1.0-rc3
+com.google.auto.service:auto-service = 1.0-rc4
 com.google.errorprone:error_prone_annotations = 2.3.1
 com.google.errorprone:error_prone_core = 2.3.1
 com.google.errorprone:error_prone_test_helpers = 2.3.1
 com.google.guava:guava = 21.0
 com.netflix.nebula:nebula-dependency-recommender = 6.1.1
-com.palantir.baseline:* = 0.26.1
+com.palantir.baseline:* = 0.28.0
 com.palantir.configurationresolver:gradle-configuration-resolver-plugin = 0.3.0
 com.palantir.safe-logging:* = 1.5.0
 gradle.plugin.com.palantir:gradle-circle-style = 1.1.4


### PR DESCRIPTION
Not sure why we weren't publishing to plugins.gradle.org before. @iamdanfox @dansanduleac not sure I am doing publishing right but it should be enough to just do full publish on top of bintrayUpload?