### PR TITLE
Correct project version in BaselineConfigIntegrationTest

### DIFF
--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
@@ -21,7 +21,7 @@ package com.palantir.baseline
  * This will also not behave well if the repo is dirty.
  */
 class BaselineConfigIntegrationTest extends AbstractPluginTest {
-    def projectVersion = "git describe --tags".execute().text.trim()
+    def projectVersion = "git describe --tags --first-parent".execute().text.trim()
     def standardBuildFile = """
         plugins {
             id 'com.palantir.baseline-config'


### PR DESCRIPTION
There was an issue with the way that we resolved the version of the current build