### PR TITLE
Don't apply baseline-error-prone checks to baseline error prone project

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -14,4 +14,9 @@ dependencies {
     testCompile 'org.apache.commons:commons-lang3'
 
     processor 'com.google.auto.service:auto-service'
+    errorprone 'com.google.errorprone:error_prone_core'
+}
+
+configurations.errorprone {
+    exclude module: 'baseline-error-prone'
 }


### PR DESCRIPTION
This avoids circular dependency due to bootclasspath setting

@iamdanfox @ferozco 