### PR TITLE
[improvement] Checkstyle bans ObjectMapper#findAndRegisterModules()

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -279,6 +279,11 @@
             <property name="format" value="CoreMatchers\.equalTo"/>
             <property name="message" value="Use Assert.assertEquals()."/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="BanJacksonFindAndRegisterModulesMethod"/>
+            <property name="format" value="findAndRegisterModules"/>
+            <property name="message" value="Use ObjectMapper#registerModule(<yourModule>) explicitly. ObjectMapper#findAndRegisterModules() is dangerous because it will change behaviour depending on which modules are on your classpath (including transitive dependencies)."/>
+        </module>
         <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Use appropriate assertion methods -->
             <property name="format" value="CoreMatchers\.notNull"/>
             <property name="message" value="Use better assertion method(s): Assert.assertEquals(), assertNull(), assertSame(), etc."/>


### PR DESCRIPTION
## Before this PR

A few products internally use ObjectMapper's `findAndRegisterModules` method.  This resulted in changed behaviour when I upgraded jackson version and different modules appeared on the classpath.

https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.9.6/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java#L1027

## After this PR

This method is banned because I think it is a foot-gun.