### PR TITLE
[improvement] Ignore palantir-prefixed shaded jars

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -127,7 +127,7 @@
             <message key="import.illegal" value="Must not import repackaged classes."/>
         </module>
         <module name="IllegalImport"> <!-- Java Coding Guidelines: Import the canonical package -->
-            <property name="illegalPkgs" value=".*\.(repackaged|shaded|thirdparty)"/>
+            <property name="illegalPkgs" value="^((?!palantir).)*\.(repackaged|shaded|thirdparty)"/>
             <property name="regexp" value="true" />
             <message key="import.illegal" value="Must not import repackaged classes."/>
         </module>


### PR DESCRIPTION
If a project purposefully uses a shaded dependency, slapping `//CHECKSTYLE:OFF IllegalImport` everywhere is tedious. It seems unlikely that there would be a `import com.palantir.shaded.` thing that is likely used by mistake.

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Any imports of internally shaded libs, like `com.palantir.shaded.foo`, would trigger the checkstyle failure.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Palantir-specific shaded imports are no longer flagged.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
