### PR TITLE
[fix] checkstyle path for Checkstyle-IDEA 5.21.1+

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -107,7 +107,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
         }
 
         project.logger.debug "Baseline: Configuring Checkstyle for Idea"
-        def checkstyleFile = "LOCAL_FILE:\$PRJ_DIR\$.baseline/checkstyle/checkstyle.xml"
+        def checkstyleFile = "LOCAL_FILE:\$PROJECT_DIR\$/.baseline/checkstyle/checkstyle.xml"
         node.append(new XmlParser().parseText("""
             <component name="CheckStyle-IDEA">
               <option name="configuration">


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
As of Checkstyle-IDEA 5.21.1, $PRJ_DIR$ is replaced with the IDEA
variable $PROJECT_DIR$, which does not include a trailing slash.
Thus a trailing slash is required when substituting $PRJ_DIR$ into a
path. Baseline currently generates an invalid checkstyle.xml path
for Checkstyle-IDEA 5.21.1+.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Add the missing trailing slash when producing the checkstyle.xml path.

Because the use of $PRJ_DIR$ in Checkstyle-IDEA is deprecated, also
switch to using $PROJECT_DIR$.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
See https://github.com/jshiell/checkstyle-idea/issues/404