### PR TITLE
[improvement] Disallow System.out and System.err.

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
@@ -12,6 +12,8 @@
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="VariableDeclarationUsageDistance" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="VisibilityModifier" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="AvoidStaticImport" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" id="BanSystemOut" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" id="BanSystemErr" />
 
     <!-- JavadocStyle enforces existence of package-info.java package-level Javadoc; we consider this a bug. -->
     <suppress files="package-info.java" checks="JavadocStyle" />

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -335,8 +335,15 @@
             <property name="ignoreComments" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="id" value="BanSystemOut"/>
             <property name="format" value="System\.out\."/>
-            <property name="message" value="System.out usage is not generally allowed"/>
+            <property name="message" value="System.out usage is not generally allowed. Please use appropriate logging methods"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="BanSystemErr"/>
+            <property name="format" value="System\.err\."/>
+            <property name="message" value="System.err usage is not generally allowed. Please use appropriate logging methods"/>
             <property name="ignoreComments" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -335,6 +335,11 @@
             <property name="ignoreComments" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="System\.out\."/>
+            <property name="message" value="System.out usage is not generally allowed"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="\bCharsets\."/>
             <property name="message" value="Use JDK StandardCharsets instead of alternatives."/>
         </module>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -337,13 +337,13 @@
         <module name="RegexpSinglelineJava">
             <property name="id" value="BanSystemOut"/>
             <property name="format" value="System\.out\."/>
-            <property name="message" value="System.out usage is not generally allowed. Please use appropriate logging methods"/>
+            <property name="message" value="Logging with System.out is not allowed because it has no metadata and can't be configured at runtime. Please use an SLF4J logger instead, e.g. log.info(&quot;Message&quot;)."/>
             <property name="ignoreComments" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">
             <property name="id" value="BanSystemErr"/>
             <property name="format" value="System\.err\."/>
-            <property name="message" value="System.err usage is not generally allowed. Please use appropriate logging methods"/>
+            <property name="message" value="Logging with System.err is not allowed because it has no metadata and can't be configured at runtime. Please use an SLF4J logger instead, e.g. log.info(&quot;Message&quot;)."/>
             <property name="ignoreComments" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">


### PR DESCRIPTION
## Before this PR
It is possible to ship code that has System.out and System.err usage.

## After this PR
It is not possible to ship code that has System.out and System.err usage.

## Worries
When there are some CLIs that need it, the will need to disable this rule, which is probably the right tradeoff.
