### PR TITLE
[fix] Add hack to work around new errorprone issue

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -30,7 +30,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.ExtensionAware;
-import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -61,10 +61,10 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
 
                                 // TODO(dsanduleac): #401 - remove once baseline-error-prone re-exposes CheckSeverity
-                                ExtensionContainer optionsExtensions =
-                                        ((ExtensionAware) errorProneOptions).getExtensions();
-                                if (optionsExtensions.findByName("CheckSeverity") == null) {
-                                    optionsExtensions.add("CheckSeverity", CheckSeverity.class);
+                                ExtraPropertiesExtension optionsProperties =
+                                        ((ExtensionAware) errorProneOptions).getExtensions().getExtraProperties();
+                                if (!optionsProperties.has("CheckSeverity")) {
+                                    optionsProperties.set("CheckSeverity", CheckSeverity.class);
                                 }
                             }));
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -30,6 +30,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -58,6 +59,13 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
                                 errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
                                 errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
+
+                                // TODO(dsanduleac): #401 - remove once baseline-error-prone re-exposes CheckSeverity
+                                ExtensionContainer optionsExtensions =
+                                        ((ExtensionAware) errorProneOptions).getExtensions();
+                                if (optionsExtensions.findByName("CheckSeverity") == null) {
+                                    optionsExtensions.add("CheckSeverity", CheckSeverity.class);
+                                }
                             }));
 
             // In case of java 8 we need to add errorprone javac compiler to bootstrap classpath of tasks that perform


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

New error-prone plugin pulled in by #391 doesn't expose the `CheckSeverity` enum when configuring its `ErrorProneOptions` extension. Therefore, if users try to use that enum, their gradle script will not compile anymore.

Tracking the removal of this hack in #401.

## After this PR
<!-- Describe at a high-level why this approach is better. -->

Re-expose the `CheckSeverity` class as a dynamically-configured property on ErrorProneOptions (via gradle's `ExtraPropertiesExtension` API).

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
