### PR TITLE
error-prone 2.3.1 -> 2.3.2

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -1,8 +1,8 @@
 com.github.stefanbirkner:system-rules = 1.18.0
 com.google.auto.service:auto-service = 1.0-rc4
-com.google.errorprone:error_prone_annotations = 2.3.1
-com.google.errorprone:error_prone_core = 2.3.1
-com.google.errorprone:error_prone_test_helpers = 2.3.1
+com.google.errorprone:error_prone_annotations = 2.3.2
+com.google.errorprone:error_prone_core = 2.3.2
+com.google.errorprone:error_prone_test_helpers = 2.3.2
 com.google.guava:guava = 23.6.1-jre
 com.netflix.nebula:nebula-dependency-recommender = 7.1.0
 com.palantir.configurationresolver:gradle-configuration-resolver-plugin = 0.3.0


### PR DESCRIPTION
## Before this PR

I was unable to use baseline-error-prone to compile a [project](https://github.com/palantir/conjure-java-runtime-api/pull/138) on Java 11:

```
> Task :service-config:compileJava FAILED
compiler message file broken: key=compiler.misc.msg.bug arguments=11, {1}, {2}, {3}, {4}, {5}, {6}, {7}
java.lang.NoSuchMethodError: com.sun.tools.javac.util.Log.error(Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;Ljava/lang/String;[Ljava/lang/Object;)
```

https://circleci.com/gh/palantir/conjure-java-runtime-api/429

Seems like I was hitting this bug: https://github.com/google/error-prone/issues/1091, fixed in 2.3.2: https://github.com/google/error-prone/pull/1083

## After this PR

Things should hopefully work 🤞
