### PR TITLE
Fix BaselineVersions regression

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -95,10 +95,10 @@ public final class BaselineVersions implements Plugin<Project> {
             // If we run with --parallel --fix, both checkNoUnusedPin and checkBomConflict will try to overwrite the
             // versions file at the same time. Therefore, make sure checkBomConflict runs first.
             checkNoUnusedPin.configure(task -> task.mustRunAfter(checkBomConflict));
-        }
 
-        project.getPluginManager().apply(BasePlugin.class);
-        project.getTasks().named("check").configure(task -> task.dependsOn("checkVersionsProps"));
+            project.getPluginManager().apply(BasePlugin.class);
+            project.getTasks().named("check").configure(task -> task.dependsOn("checkVersionsProps"));
+        }
     }
 
     private static File rootVersionsPropsFile(Project project) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
@@ -124,6 +124,22 @@ class BaselineVersionsIntegrationTest  extends AbstractPluginTest {
                 "  bom:            org.scala-lang:scala-library -> 2.12.5")
     }
 
+    def 'Trivially passes check on multiple projects'() {
+        buildFile << """
+            plugins {
+                id 'com.palantir.baseline-versions'
+            }
+            allprojects {
+                apply plugin: 'com.palantir.baseline-versions'
+            }
+        """.stripIndent()
+
+        multiProject.addSubproject('foo', "apply plugin: 'java'")
+
+        expect:
+        with('check').build()
+    }
+
     def 'Task should run as part of :check'() {
         when:
         buildFile << standardBuildFile(projectDir)


### PR DESCRIPTION
## Before this PR

#413 introduced a regression where we made `check` depend on a non-existent task in subprojects.

## After this PR

Fixed the regression.