### PR TITLE
[improvement] baseline-format collects java files from all source sets

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -36,7 +36,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
                         .getPlugin(JavaPluginConvention.class)
                         .getSourceSets()
                         .stream()
-                        .map(SourceSet::getJava)
+                        .map(SourceSet::getAllJava)
                         .toArray();
 
                 java.target(allJavaFiles);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -19,8 +19,8 @@ package com.palantir.baseline.plugins;
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.SourceSet;
 
 class BaselineFormat extends AbstractBaselinePlugin {
 
@@ -31,13 +31,13 @@ class BaselineFormat extends AbstractBaselinePlugin {
             project.getPluginManager().apply("com.diffplug.gradle.spotless");
 
             project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
-                Object[] allJavaFiles = project
+                // Configure a lazy FileCollection then pass it as the target
+                ConfigurableFileCollection allJavaFiles = project.files();
+                project
                         .getConvention()
                         .getPlugin(JavaPluginConvention.class)
                         .getSourceSets()
-                        .stream()
-                        .map(SourceSet::getAllJava)
-                        .toArray();
+                        .all(sourceSet -> allJavaFiles.from(sourceSet.getAllJava()));
 
                 java.target(allJavaFiles);
                 java.removeUnusedImports();

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -30,7 +30,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
         project.getPluginManager().withPlugin("java", plugin -> {
             project.getPluginManager().apply("com.diffplug.gradle.spotless");
 
-            project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
+            project.getConvention().getPlugin(SpotlessExtension.class).java(java -> {
                 Object[] allJavaFiles = project
                         .getExtensions()
                         .getByType(JavaPluginConvention.class)

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -30,10 +30,10 @@ class BaselineFormat extends AbstractBaselinePlugin {
         project.getPluginManager().withPlugin("java", plugin -> {
             project.getPluginManager().apply("com.diffplug.gradle.spotless");
 
-            project.getConvention().getPlugin(SpotlessExtension.class).java(java -> {
+            project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
                 Object[] allJavaFiles = project
-                        .getExtensions()
-                        .getByType(JavaPluginConvention.class)
+                        .getConvention()
+                        .getPlugin(JavaPluginConvention.class)
                         .getSourceSets()
                         .stream()
                         .map(SourceSet::getJava)

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -20,6 +20,7 @@ import com.diffplug.gradle.spotless.SpotlessExtension;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
 
 class BaselineFormat extends AbstractBaselinePlugin {
 
@@ -35,7 +36,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
                         .getByType(JavaPluginConvention.class)
                         .getSourceSets()
                         .stream()
-                        .map(sourceSet -> sourceSet.getAllSource().filter(file -> file.getName().endsWith(".java")))
+                        .map(SourceSet::getJava)
                         .toArray();
 
                 java.target(allJavaFiles);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -19,6 +19,7 @@ package com.palantir.baseline.plugins;
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.plugins.JavaPluginConvention;
 
 class BaselineFormat extends AbstractBaselinePlugin {
 
@@ -29,8 +30,15 @@ class BaselineFormat extends AbstractBaselinePlugin {
             project.getPluginManager().apply("com.diffplug.gradle.spotless");
 
             project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
-                // TODO(dfox): apply this to all source sets, not just 'main' and 'test'
-                java.target("src/main/java/**/*.java", "src/main/test/**/*.java");
+                Object[] allJavaFiles = project
+                        .getExtensions()
+                        .getByType(JavaPluginConvention.class)
+                        .getSourceSets()
+                        .stream()
+                        .map(sourceSet -> sourceSet.getAllSource().filter(file -> file.getName().endsWith(".java")))
+                        .toArray();
+
+                java.target(allJavaFiles);
                 java.removeUnusedImports();
                 // use empty string to specify one group for all non-static imports
                 java.importOrder("");

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -70,4 +70,22 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
             public class Test { void test() {} }
         '''.stripIndent()
     }
+
+    def 'format task works on new source sets'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+            sourceSets { foo }
+        '''.stripIndent()
+        file('src/foo/java/test/Test.java') << validJavaFile
+
+        then:
+        BuildResult result = with('format').build()
+        result.task(":format").outcome == TaskOutcome.SUCCESS
+        result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
+        file('src/foo/java/test/Test.java').text == '''
+            package test;
+            public class Test { void test() {} }
+        '''.stripIndent()
+    }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -88,4 +88,23 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
             public class Test { void test() {} }
         '''.stripIndent()
     }
+
+    def 'format task works on other language java sources'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+            apply plugin: 'groovy'
+            sourceSets { foo }
+        '''.stripIndent()
+        file('src/foo/groovy/test/Test.java') << validJavaFile
+
+        then:
+        BuildResult result = with('format').build()
+        result.task(":format").outcome == TaskOutcome.SUCCESS
+        result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
+        file('src/foo/groovy/test/Test.java').text == '''
+            package test;
+            public class Test { void test() {} }
+        '''.stripIndent()
+    }
 }


### PR DESCRIPTION
## Before this PR

baseline-format only targets java files in the main and test source dirs

## After this PR
 
it targets `*.java` files in all source dirs