### PR TITLE
Exclude 'errorprone' configuration from nebula

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -72,6 +72,9 @@ public final class BaselineVersions implements Plugin<Project> {
 
         extension.setStrategy(RecommendationStrategies.OverrideTransitives); // default is 'ConflictResolved'
 
+        // Should be ErrorPronePlugin.CONFIGURATION_NAME but can't be sure they won't break this so hard-coding it
+        extension.excludeConfigurations("errorprone");
+
         File rootVersionsPropsFile = rootVersionsPropsFile(project);
         extension.propertiesFile(ImmutableMap.of("file", rootVersionsPropsFile));
 


### PR DESCRIPTION
## Before this PR

If you had nebula force guava to a low version (< 23.6-jre) then the new errorprone would break with a `MethodNotFoundException`:

```
An exception has occurred in the compiler ((version info not available)). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program and the following diagnostic in your report. Thank you.
java.lang.NoSuchMethodError: com.google.common.base.Verify.verify(ZLjava/lang/String;Ljava/lang/Object;)V
	at com.google.errorprone.ErrorProneAnalyzer.finished(ErrorProneAnalyzer.java:132)
	at com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:120)
```

## After this PR

Nebula recommendations no longer apply to the `errorprone` configuration, since there's no reason why the project's runtime dependencies should be the same as the dependencies that errorprone uses - their classpaths are completely orthogonal.