### PR TITLE
[fix] CheckBomConflictTask, CheckNoUnusedPinTask now work with --fix

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
@@ -74,7 +74,11 @@ public class CheckBomConflictTask extends DefaultTask {
     }
 
     @Option(option = "fix", description = "Whether to apply the suggested fix to versions.props")
-    public final void setShouldFix(Provider<Boolean> shouldFix) {
+    public final void setShouldFix(boolean shouldFix) {
+        this.shouldFix.set(shouldFix);
+    }
+
+    final void setShouldFix(Provider<Boolean> shouldFix) {
         this.shouldFix.set(shouldFix);
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
@@ -59,7 +59,11 @@ public class CheckNoUnusedPinTask extends DefaultTask {
     }
 
     @Option(option = "fix", description = "Whether to apply the suggested fix to versions.props")
-    public final void setShouldFix(Provider<Boolean> shouldFix) {
+    public final void setShouldFix(boolean shouldFix) {
+        this.shouldFix.set(shouldFix);
+    }
+
+    final void setShouldFix(Provider<Boolean> shouldFix) {
         this.shouldFix.set(shouldFix);
     }
 


### PR DESCRIPTION
## Before this PR

Calling 

```
./gradlew checkBomConflict --fix
```

fails with

```
Option 'fix' cannot be casted to type 'org.gradle.api.provider.Provider' in class 'com.palantir.baseline.plugins.versions.CheckBomConflictTask'.
```

## After this PR

It works as expected, just like `checkVersionsProps --fix` currently works.