### PR TITLE
Fix versions.props handling of partially overlapping forces

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
@@ -152,7 +152,7 @@ public class CheckBomConflictTask extends DefaultTask {
                     + toRemove.stream()
                     .map(name -> String.format(" - '%s'", name))
                     .collect(Collectors.joining("\n")));
-            VersionsProps.writeVersionsProps(parsedVersionsProps, toRemove, getPropsFile().get().getAsFile());
+            VersionsProps.writeVersionsProps(parsedVersionsProps, toRemove.stream(), getPropsFile().get().getAsFile());
             return;
         }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
@@ -124,8 +124,8 @@ public class CheckBomConflictTask extends DefaultTask {
                 .collect(Collectors.toMap(
                         Pair::getLeft,
                         Pair::getRight,
-                        // Resolve conflicts by choosing the longer entry because it is more specific
-                        (propName1, propName2) -> propName1.length() > propName2.length() ? propName1 : propName2));
+                        // Resolve conflicts by choosing the latest matching entry, because that's how nebula works.
+                        (propName1, propName2) -> propName2));
 
         Set<String> versionPropsVindicatedLines = ImmutableSet.copyOf(resolvedConflicts.values());
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/util/VersionsProps.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/util/VersionsProps.java
@@ -116,10 +116,9 @@ public final class VersionsProps {
      * {@link ParsedVersionsProps#namesToLocationMap}.
      */
     public static void writeVersionsProps(
-            ParsedVersionsProps parsedVersionsProps, List<String> forcesToRemove, File propsFile) {
+            ParsedVersionsProps parsedVersionsProps, Stream<String> forcesToRemove, File propsFile) {
         List<String> lines = parsedVersionsProps.lines();
         Set<Integer> indicesToSkip = forcesToRemove
-                .stream()
                 .map(parsedVersionsProps.namesToLocationMap()::get)
                 .map(Preconditions::checkNotNull)
                 .collect(Collectors.toSet());

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
@@ -197,7 +197,7 @@ class BaselineVersionsIntegrationTest  extends AbstractPluginTest {
         when:
         setupVersionsProps("""
             org.slf4j:slf4j-api = 1.7.25
-            org.slf4j:* = 1.7.20  # this wins even though the line above looks more 'specific'
+            org.slf4j:* = 1.7.20
         """.stripIndent())
         buildFile << standardBuildFile(projectDir)
         buildFile << """
@@ -207,6 +207,8 @@ class BaselineVersionsIntegrationTest  extends AbstractPluginTest {
 
         then:
         buildAndFailWith('There are unused pins in your versions.props: \n[org.slf4j:slf4j-api]')
+        buildWithFixWorks()
+        file('versions.props').text.trim() == "org.slf4j:* = 1.7.20"
     }
 
     def 'Unused version should fail'() {


### PR DESCRIPTION
Fixes #379 properly

## Before this PR

In `checkBomConflict`, multiple forces from `versions.props` that match the same artifact would pick the longest force as the one that was "used".
This is not always the the one that nebula picks, because nebula just picks the last line that matches the artifact.

A similar mistake occurs in `checkNoUnusedPin` where _every_ force is individually treated as used if it matches even a single artifact, disregarding other forces in the file that might have overridden it.

## After this PR

* `checkBomConflict`: Resolve conflicts by associating an artifact with the last `versions.props` line that matches it.
* `checkNoUnusedPin`: when considering a resolved artifact, only treat the *last* matching force as used.

This now matches nebula's behaviour.