### PR TITLE
Fix reverse dependency inside configureEach

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
@@ -55,17 +55,16 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                                     javaConvention.getTargetCompatibility().toString())));
             project.getPluginManager().apply(ScalaStylePlugin.class);
             TaskCollection<ScalaStyleTask> scalaStyleTasks = project.getTasks().withType(ScalaStyleTask.class);
+            scalaStyleTasks.configureEach(scalaStyleTask -> {
+                scalaStyleTask.setConfigLocation(project.getRootDir().toPath()
+                        .resolve(Paths.get("project", "scalastyle_config.xml")).toString());
+                scalaStyleTask.setIncludeTestSourceDirectory(true);
+                scalaStyleTask.setFailOnWarning(true);
+                javaConvention.getSourceSets()
+                        .forEach(sourceSet -> sourceSet.getAllSource().getSrcDirs()
+                                .forEach(resourceDir -> scalaStyleTask.source(resourceDir.toString())));
+            });
             project.getTasks().named("check").configure(task -> task.dependsOn(scalaStyleTasks));
-            scalaStyleTasks
-                    .configureEach(scalaStyleTask -> {
-                        scalaStyleTask.setConfigLocation(project.getRootDir().toPath()
-                                .resolve(Paths.get("project", "scalastyle_config.xml")).toString());
-                        scalaStyleTask.setIncludeTestSourceDirectory(true);
-                        scalaStyleTask.setFailOnWarning(true);
-                        javaConvention.getSourceSets()
-                                .forEach(sourceSet -> sourceSet.getAllSource().getSrcDirs()
-                                        .forEach(resourceDir -> scalaStyleTask.source(resourceDir.toString())));
-                    });
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
@@ -55,6 +55,7 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                                     javaConvention.getTargetCompatibility().toString())));
             project.getPluginManager().apply(ScalaStylePlugin.class);
             TaskCollection<ScalaStyleTask> scalaStyleTasks = project.getTasks().withType(ScalaStyleTask.class);
+            project.getTasks().named("check").configure(task -> task.dependsOn(scalaStyleTasks));
             scalaStyleTasks
                     .configureEach(scalaStyleTask -> {
                         scalaStyleTask.setConfigLocation(project.getRootDir().toPath()
@@ -65,7 +66,6 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                                 .forEach(sourceSet -> sourceSet.getAllSource().getSrcDirs()
                                         .forEach(resourceDir -> scalaStyleTask.source(resourceDir.toString())));
                     });
-            project.getTasks().named("check").configure(task -> task.dependsOn(scalaStyleTasks));
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
@@ -30,6 +30,7 @@ import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.ScalaSourceSet;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 
@@ -53,7 +54,8 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                                     javaConvention.getSourceSets().named(SourceSet.MAIN_SOURCE_SET_NAME).get(),
                                     javaConvention.getTargetCompatibility().toString())));
             project.getPluginManager().apply(ScalaStylePlugin.class);
-            project.getTasks().withType(ScalaStyleTask.class)
+            TaskCollection<ScalaStyleTask> scalaStyleTasks = project.getTasks().withType(ScalaStyleTask.class);
+            scalaStyleTasks
                     .configureEach(scalaStyleTask -> {
                         scalaStyleTask.setConfigLocation(project.getRootDir().toPath()
                                 .resolve(Paths.get("project", "scalastyle_config.xml")).toString());
@@ -62,8 +64,8 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                         javaConvention.getSourceSets()
                                 .forEach(sourceSet -> sourceSet.getAllSource().getSrcDirs()
                                         .forEach(resourceDir -> scalaStyleTask.source(resourceDir.toString())));
-                        project.getTasks().named("check").configure(task -> task.dependsOn(scalaStyleTask.getPath()));
                     });
+            project.getTasks().named("check").configure(task -> task.dependsOn(scalaStyleTasks));
         });
     }
 


### PR DESCRIPTION
## Before this PR

BaselineScalastyle fails to apply on gradle 5.0-M1:
```
Caused by: org.gradle.api.internal.AbstractMutationGuard$IllegalMutationException: DefaultTaskContainer#NamedDomainObjectProvider.configure(Action) on task set cannot be executed in the current context.
        ...
        at org.gradle.api.internal.tasks.DefaultTaskCollection$ExistingTaskProvider.configure(DefaultTaskCollection.java:186)
        at com.palantir.baseline.plugins.BaselineScalastyle.lambda$null$8(BaselineScalastyle.java:65)
```