### PR TITLE
 [fix] Ignore errors in generated code

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -37,7 +37,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
                         .getConvention()
                         .getPlugin(JavaPluginConvention.class)
                         .getSourceSets()
-                        .matching(sourceSet -> sourceSet.getName().startsWith("generated"))
+                        .matching(sourceSet -> !sourceSet.getName().startsWith("generated"))
                         .all(sourceSet -> allJavaFiles.from(sourceSet.getAllJava()));
 
                 java.target(allJavaFiles);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -40,7 +40,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
                         .all(sourceSet -> allJavaFiles.from(sourceSet.getAllJava()));
 
                 java.target(allJavaFiles);
-                java.ignoreErrorForPath("**/generated*/**");
+                // java.ignoreErrorForPath("**/generated*/**");
                 java.removeUnusedImports();
                 // use empty string to specify one group for all non-static imports
                 java.importOrder("");

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -40,6 +40,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
                         .all(sourceSet -> allJavaFiles.from(sourceSet.getAllJava()));
 
                 java.target(allJavaFiles);
+                java.ignoreErrorForPath("**/generated*/**");
                 java.removeUnusedImports();
                 // use empty string to specify one group for all non-static imports
                 java.importOrder("");

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -40,12 +40,6 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
     public class Test { void test() {} }
     '''.stripIndent()
 
-    def validGeneratedJavaFile = '''
-    package test;
-    import java.lang.Void;
-    public class Test { Void test() {} }
-    '''.stripIndent()
-
     def 'can apply plugin'() {
         when:
         buildFile << standardBuildFile
@@ -117,10 +111,17 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
     def 'format ignores generated files'() {
         when:
         buildFile << standardBuildFile
-        file('src/generated/java/test/Test.java') << validGeneratedJavaFile
+        buildFile << '''
+            sourceSets { generated }
+        '''.stripIndent()
+        file('src/generated/java/test/Test.java') << '''
+            package test;
+            import java.lang.Void;
+            public class Test { Void test() {} }
+        '''.stripIndent()
 
         then:
-        BuildResult result = with(':spotlessJavaCheck').build();
+        BuildResult result = with('spotlessJavaCheck').build();
         result.task(":spotlessJava").outcome == TaskOutcome.SUCCESS
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -38,7 +38,13 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
     package test;
     import com.java.tests;
     public class Test { void test() {} }
-        '''.stripIndent()
+    '''.stripIndent()
+
+    def validGeneratedJavaFile = '''
+    package test;
+    import java.lang.Void;
+    public class Test { Void test() {} }
+    '''.stripIndent()
 
     def 'can apply plugin'() {
         when:
@@ -106,5 +112,15 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
             package test;
             public class Test { void test() {} }
         '''.stripIndent()
+    }
+
+    def 'format ignores generated files'() {
+        when:
+        buildFile << standardBuildFile
+        file('src/generated/java/test/Test.java') << validGeneratedJavaFile
+
+        then:
+        BuildResult result = with(':spotlessJavaCheck').build();
+        result.task(":spotlessJava").outcome == TaskOutcome.SUCCESS
     }
 }


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
A recent changed caused the spotless plugin to be applied to all java source files which would fail on generated code which we don't want to validate or format.

## After this PR
Java source sets that begin with `generated` will be ignored by the spotless plugin.