### PR TITLE
Revert #428 and #419 

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -19,8 +19,6 @@ package com.palantir.baseline.plugins;
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.plugins.JavaPluginConvention;
 
 class BaselineFormat extends AbstractBaselinePlugin {
 
@@ -31,16 +29,8 @@ class BaselineFormat extends AbstractBaselinePlugin {
             project.getPluginManager().apply("com.diffplug.gradle.spotless");
 
             project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
-                // Configure a lazy FileCollection then pass it as the target
-                ConfigurableFileCollection allJavaFiles = project.files();
-                project
-                        .getConvention()
-                        .getPlugin(JavaPluginConvention.class)
-                        .getSourceSets()
-                        .matching(sourceSet -> !sourceSet.getName().startsWith("generated"))
-                        .all(sourceSet -> allJavaFiles.from(sourceSet.getAllJava()));
-
-                java.target(allJavaFiles);
+                // TODO(dfox): apply this to all source sets, not just 'main' and 'test'
+                java.target("src/main/java/**/*.java", "src/main/test/**/*.java");
                 java.removeUnusedImports();
                 // use empty string to specify one group for all non-static imports
                 java.importOrder("");

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -70,43 +70,43 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
             public class Test { void test() {} }
         '''.stripIndent()
     }
-
-    def 'format task works on new source sets'() {
-        when:
-        buildFile << standardBuildFile
-        buildFile << '''
-            sourceSets { foo }
-        '''.stripIndent()
-        file('src/foo/java/test/Test.java') << validJavaFile
-
-        then:
-        BuildResult result = with('format').build()
-        result.task(":format").outcome == TaskOutcome.SUCCESS
-        result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
-        file('src/foo/java/test/Test.java').text == '''
-            package test;
-            public class Test { void test() {} }
-        '''.stripIndent()
-    }
-
-    def 'format task works on other language java sources'() {
-        when:
-        buildFile << standardBuildFile
-        buildFile << '''
-            apply plugin: 'groovy'
-            sourceSets { foo }
-        '''.stripIndent()
-        file('src/foo/groovy/test/Test.java') << validJavaFile
-
-        then:
-        BuildResult result = with('format').build()
-        result.task(":format").outcome == TaskOutcome.SUCCESS
-        result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
-        file('src/foo/groovy/test/Test.java').text == '''
-            package test;
-            public class Test { void test() {} }
-        '''.stripIndent()
-    }
+//
+//    def 'format task works on new source sets'() {
+//        when:
+//        buildFile << standardBuildFile
+//        buildFile << '''
+//            sourceSets { foo }
+//        '''.stripIndent()
+//        file('src/foo/java/test/Test.java') << validJavaFile
+//
+//        then:
+//        BuildResult result = with('format').build()
+//        result.task(":format").outcome == TaskOutcome.SUCCESS
+//        result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
+//        file('src/foo/java/test/Test.java').text == '''
+//            package test;
+//            public class Test { void test() {} }
+//        '''.stripIndent()
+//    }
+//
+//    def 'format task works on other language java sources'() {
+//        when:
+//        buildFile << standardBuildFile
+//        buildFile << '''
+//            apply plugin: 'groovy'
+//            sourceSets { foo }
+//        '''.stripIndent()
+//        file('src/foo/groovy/test/Test.java') << validJavaFile
+//
+//        then:
+//        BuildResult result = with('format').build()
+//        result.task(":format").outcome == TaskOutcome.SUCCESS
+//        result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
+//        file('src/foo/groovy/test/Test.java').text == '''
+//            package test;
+//            public class Test { void test() {} }
+//        '''.stripIndent()
+//    }
 
     def 'format ignores generated files'() {
         when:


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
https://github.com/palantir/gradle-baseline/pull/428 didn't account for generated src in main.  As a result, dev workflow is still broken
## After this PR
<!-- Describe at a high-level why this approach is better. -->
Revert to the behavior before https://github.com/palantir/gradle-baseline/pull/419 until we have a better long term solution
<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
