### PR TITLE
[fix] BaselineVersions: resolve configurations without downloading artifacts

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -138,8 +138,8 @@ public final class BaselineVersions implements Plugin<Project> {
                                 .map(mcid -> ((ModuleComponentIdentifier) mcid).getModuleIdentifier())
                                 .map(mid -> mid.getGroup() + ":" + mid.getName());
                     } catch (Exception e) {
-                        throw new RuntimeException("Error during resolution of the artifacts of all "
-                                + "configuration from all subprojects", e);
+                        throw new RuntimeException(String.format("Error during resolution of the dependency graph of "
+                                + "configuration %s", configuration), e);
                     }
                 })
                 .collect(Collectors.toSet());

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
@@ -65,7 +65,7 @@ public class CheckBomConflictTask extends DefaultTask {
 
     @Input
     public final Set<String> getResolvedArtifacts() {
-        return BaselineVersions.getAllProjectsResolvedArtifacts(getProject());
+        return BaselineVersions.getAllProjectsResolvedModuleIdentifiers(getProject());
     }
 
     @InputFile

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
@@ -56,7 +56,7 @@ public class CheckNoUnusedPinTask extends DefaultTask {
 
     @Input
     public final Set<String> getResolvedArtifacts() {
-        return BaselineVersions.getAllProjectsResolvedArtifacts(getProject());
+        return BaselineVersions.getAllProjectsResolvedModuleIdentifiers(getProject());
     }
 
     @InputFile


### PR DESCRIPTION
## Before this PR

`checkVersionsProps` task would resolve and download the artifacts of all configurations in all projects. This can be very slow and it is unnecessary since all we need is the module identifiers (`group:name`) that were resolved.

## After this PR

We only resolve the dependency graph (without downloading artifacts) and look at the resolved [components](https://github.com/gradle/gradle/blob/a64dee21188920c6725db433ef61a7aecb532457/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolutionResult.java#L74) that are external dependencies to derive the information we need.