### PR TITLE
[fix] Use exact matching for unused pin check

### DIFF
--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
@@ -288,4 +288,21 @@ class BaselineVersionsIntegrationTest  extends AbstractPluginTest {
         buildSucceed()
     }
 
+    def 'Unused check should use exact matching'() {
+        when:
+        setupVersionsProps("""
+            com.google.guava:guava-testlib = 23.0
+            com.google.guava:guava = 22.0
+        """.stripIndent())
+        buildFile << standardBuildFile(projectDir)
+        buildFile << """
+        dependencies {
+            compile 'com.google.guava:guava'
+            compile 'com.google.guava:guava-testlib'
+        }""".stripIndent()
+
+        then:
+        buildSucceed()
+    }
+
 }


### PR DESCRIPTION
#423 modified this check to use `Pattern#asPredicate` which uses `Matcher#find` which checks if there is a subsequence that matches, not if the entire pattern matches.

This causes issues when one artifact is a substring of another.