### PR TITLE
Gradle-processors 2.0.0

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -14,4 +14,5 @@ dependencies {
     testCompile 'org.apache.commons:commons-lang3'
 
     annotationProcessor 'com.google.auto.service:auto-service'
+    compileOnly 'com.google.auto.service:auto-service'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
 plugins {
     id 'com.palantir.git-version' version '0.11.0'
-    id 'org.inferred.processors' version '1.3.0'
+    id 'org.inferred.processors' version '2.0.0'
 }
 
 apply plugin: 'com.palantir.baseline'

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testCompile 'org.assertj:assertj-core'
 
     annotationProcessor 'org.inferred:freebuilder'
+    compileOnly 'org.inferred:freebuilder'
 }
 
 tasks.test.dependsOn tasks.findByPath(':gradle-baseline-java-config:publishToMavenLocal')

--- a/gradle-circle-style/build.gradle
+++ b/gradle-circle-style/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compile 'com.google.guava:guava'
 
   annotationProcessor 'org.inferred:freebuilder'
+  compileOnly 'org.inferred:freebuilder'
 
   testCompile 'com.google.guava:guava'
   testCompile 'junit:junit'


### PR DESCRIPTION
gradle-processors 2.0.0 removes the hack where `annotationClasspath` dependencies would end up on the `compileOnly` configuration too.
This is because they's usually a lightweight dependency containing just the annotations which you'd put on `compileOnly`, while the full annotation processor impl would go into `annotationProcessor`.
Ironically, there's no such split for any of the annotation processors used in this repository.