### PR TITLE
[feature] errorprone check for SafeLoggable exceptions

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -51,8 +51,13 @@ public class PreferSafeLoggableExceptions extends BugChecker implements BugCheck
                 .filter(arg -> ASTHelpers.isSameType(ASTHelpers.getType(arg),
                         state.getTypeFromString("java.lang.String"), state))
                 .reduce((one, two) -> one);
-        // if (!messageArg.isPresent() || compileTimeConstExpressionMatcher.matches(messageArg.get(), state)) {
+
         if (!messageArg.isPresent()) {
+            return Description.NO_MATCH;
+        }
+
+        if (!compileTimeConstExpressionMatcher.matches(messageArg.get(), state)) {
+            // ignore exceptions with non-constant messages to minimise the hits
             return Description.NO_MATCH;
         }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -20,6 +20,7 @@ import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
@@ -62,8 +63,13 @@ public class PreferSafeLoggableExceptions extends BugChecker implements BugCheck
         }
 
         if (Matchers.isSameType(IllegalArgumentException.class).matches(tree.getIdentifier(), state)) {
+            SuggestedFix fix = SuggestedFix.builder()
+                    .replace(tree.getIdentifier(), "SafeIllegalArgumentException")
+                    .addImport("com.palantir.logsafe.exceptions.SafeIllegalArgumentException")
+                    .build();
             return buildDescription(tree)
                     .setMessage("Prefer SafeIllegalArgumentException from com.palantir.safe-logging:preconditions")
+                    .addFix(fix)
                     .build();
         }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 @BugPattern(
         name = "PreferSafeLoggableExceptions",
         category = BugPattern.Category.ONE_OFF,
-        severity = BugPattern.SeverityLevel.ERROR,
+        severity = BugPattern.SeverityLevel.SUGGESTION,
         summary = "Throw SafeLoggable exceptions to ensure the message will not be redacted")
 public class PreferSafeLoggableExceptions extends BugChecker implements BugChecker.NewClassTreeMatcher {
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.NewClassTree;
+import java.io.IOException;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "PreferSafeLoggableExceptions",
+        category = BugPattern.Category.ONE_OFF,
+        severity = BugPattern.SeverityLevel.ERROR,
+        summary = "Throw SafeLoggable exceptions to ensure the message will not be redacted")
+public class PreferSafeLoggableExceptions extends BugChecker implements BugChecker.NewClassTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+    private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
+            new CompileTimeConstantExpressionMatcher();
+
+    // https://github.com/palantir/safe-logging/tree/develop/preconditions/src/main/java/com/palantir/logsafe/exceptions
+    @Override
+    public Description matchNewClass(NewClassTree tree, VisitorState state) {
+        // List<? extends ExpressionTree> args = tree.getArguments();
+        // Optional<? extends ExpressionTree> messageArg = args.stream()
+        //         .filter(arg -> ASTHelpers.isSameType(ASTHelpers.getType(arg),
+        //                 state.getTypeFromString("java.lang.String"), state))
+        //         .reduce((one, two) -> two);
+        //
+        // if (!messageArg.isPresent() || compileTimeConstExpressionMatcher.matches(messageArg.get(), state)) {
+        //     return Description.NO_MATCH;
+        // }
+
+        if (Matchers.isSameType(IllegalArgumentException.class).matches(tree.getIdentifier(), state)) {
+            return buildDescription(tree)
+                    .setMessage("Prefer SafeIllegalArgumentException from com.palantir.safe-logging:preconditions")
+                    .build();
+        }
+
+        if (Matchers.isSameType(IllegalStateException.class).matches(tree.getIdentifier(), state)) {
+            return buildDescription(tree)
+                    .setMessage("Prefer SafeIllegalStateException from com.palantir.safe-logging:preconditions")
+                    .build();
+        }
+
+        if (Matchers.isSameType(IOException.class).matches(tree.getIdentifier(), state)) {
+            return buildDescription(tree)
+                    .setMessage("Prefer SafeIOException from com.palantir.safe-logging:preconditions")
+                    .build();
+        }
+
+        if (Matchers.isSameType(NullPointerException.class).matches(tree.getIdentifier(), state)) {
+            return buildDescription(tree)
+                    .setMessage("Prefer SafeNullPointerException from com.palantir.safe-logging:preconditions")
+                    .build();
+        }
+
+        if (Matchers.isSameType(RuntimeException.class).matches(tree.getIdentifier(), state)) {
+            return buildDescription(tree)
+                    .setMessage("Prefer SafeRuntimeException from com.palantir.safe-logging:preconditions")
+                    .build();
+        }
+
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -24,9 +24,12 @@ import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.NewClassTree;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -43,15 +46,15 @@ public class PreferSafeLoggableExceptions extends BugChecker implements BugCheck
     // https://github.com/palantir/safe-logging/tree/develop/preconditions/src/main/java/com/palantir/logsafe/exceptions
     @Override
     public Description matchNewClass(NewClassTree tree, VisitorState state) {
-        // List<? extends ExpressionTree> args = tree.getArguments();
-        // Optional<? extends ExpressionTree> messageArg = args.stream()
-        //         .filter(arg -> ASTHelpers.isSameType(ASTHelpers.getType(arg),
-        //                 state.getTypeFromString("java.lang.String"), state))
-        //         .reduce((one, two) -> two);
-        //
+        List<? extends ExpressionTree> args = tree.getArguments();
+        Optional<? extends ExpressionTree> messageArg = args.stream()
+                .filter(arg -> ASTHelpers.isSameType(ASTHelpers.getType(arg),
+                        state.getTypeFromString("java.lang.String"), state))
+                .reduce((one, two) -> one);
         // if (!messageArg.isPresent() || compileTimeConstExpressionMatcher.matches(messageArg.get(), state)) {
-        //     return Description.NO_MATCH;
-        // }
+        if (!messageArg.isPresent()) {
+            return Description.NO_MATCH;
+        }
 
         if (Matchers.isSameType(IllegalArgumentException.class).matches(tree.getIdentifier(), state)) {
             return buildDescription(tree)

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.errorprone;
 
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,26 @@ public class PreferSafeLoggableExceptionsTest {
                 "// BUG: Diagnostic contains: Prefer SafeIllegalArgumentException",
                 "Exception foo = new IllegalArgumentException(\"Foo\");",
                 "}").doTest();
+    }
+
+    @Test
+    public void auto_fix_illegal_argument_exception() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggableExceptions(), getClass())
+                .addInputLines(
+                        "Bean.java",
+                        "class Bean {",
+                        "  Exception foo = new IllegalArgumentException(\"Foo\");",
+                        "}",
+                        "")
+                .addOutputLines(
+                        "Bean.java",
+                        "import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;",
+                        "",
+                        "class Bean {",
+                        "  Exception foo = new SafeIllegalArgumentException(\"Foo\");",
+                        "}",
+                        "")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
@@ -40,6 +40,15 @@ public class PreferSafeLoggableExceptionsTest {
     }
 
     @Test
+    public void illegal_argument_exception_without_message_doesnt_match() {
+        compilationHelper.addSourceLines(
+                "Bean.java",
+                "class Bean {",
+                "Exception foo = new IllegalArgumentException(new RuntimeException());",
+                "}").doTest();
+    }
+
+    @Test
     public void illegal_state_exception() {
         compilationHelper.addSourceLines(
                 "Bean.java",
@@ -50,12 +59,30 @@ public class PreferSafeLoggableExceptionsTest {
     }
 
     @Test
+    public void illegal_state_exception_without_message_doesnt_match() {
+        compilationHelper.addSourceLines(
+                "Bean.java",
+                "class Bean {",
+                "Exception foo = new IllegalStateException(new RuntimeException());",
+                "}").doTest();
+    }
+
+    @Test
     public void io_exception() {
         compilationHelper.addSourceLines(
                 "Bean.java",
                 "class Bean {",
                 "// BUG: Diagnostic contains: Prefer SafeIOException",
                 "Exception foo = new java.io.IOException(\"Foo\");",
+                "}").doTest();
+    }
+
+    @Test
+    public void io_exception_without_message_doesnt_match() {
+        compilationHelper.addSourceLines(
+                "Bean.java",
+                "class Bean {",
+                "Exception foo = new java.io.IOException(new RuntimeException());",
                 "}").doTest();
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
@@ -70,6 +70,26 @@ public class PreferSafeLoggableExceptionsTest {
     }
 
     @Test
+    public void auto_fix_illegal_state_exception() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggableExceptions(), getClass())
+                .addInputLines(
+                        "Bean.java",
+                        "class Bean {",
+                        "  Exception foo = new IllegalArgumentException(\"Foo\");",
+                        "}",
+                        "")
+                .addOutputLines(
+                        "Bean.java",
+                        "import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;",
+                        "",
+                        "class Bean {",
+                        "  Exception foo = new SafeIllegalArgumentException(\"Foo\");",
+                        "}",
+                        "")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
     public void illegal_state_exception() {
         compilationHelper.addSourceLines(
                 "Bean.java",
@@ -93,7 +113,7 @@ public class PreferSafeLoggableExceptionsTest {
         compilationHelper.addSourceLines(
                 "Bean.java",
                 "class Bean {",
-                "// BUG: Diagnostic contains: Prefer SafeIOException",
+                "// BUG: Diagnostic contains: Prefer SafeIoException",
                 "Exception foo = new java.io.IOException(\"Foo\");",
                 "}").doTest();
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PreferSafeLoggableExceptionsTest {
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(PreferSafeLoggableExceptions.class, getClass());
+    }
+
+    @Test
+    public void illegal_argument_exception() {
+        compilationHelper.addSourceLines(
+                "Bean.java",
+                "class Bean {",
+                "// BUG: Diagnostic contains: Prefer SafeIllegalArgumentException",
+                "Exception foo = new IllegalArgumentException(\"Foo\");",
+                "}").doTest();
+    }
+
+    @Test
+    public void illegal_state_exception() {
+        compilationHelper.addSourceLines(
+                "Bean.java",
+                "class Bean {",
+                "// BUG: Diagnostic contains: Prefer SafeIllegalStateException",
+                "Exception foo = new IllegalStateException(\"Foo\");",
+                "}").doTest();
+    }
+
+    @Test
+    public void io_exception() {
+        compilationHelper.addSourceLines(
+                "Bean.java",
+                "class Bean {",
+                "// BUG: Diagnostic contains: Prefer SafeIOException",
+                "Exception foo = new java.io.IOException(\"Foo\");",
+                "}").doTest();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
@@ -109,6 +109,15 @@ public class PreferSafeLoggableExceptionsTest {
     }
 
     @Test
+    public void illegal_state_exception_with_non_constant_message_doesnt_match() {
+        compilationHelper.addSourceLines(
+                "Bean.java",
+                "class Bean {",
+                "Exception foo = new IllegalStateException(\"I am a non-constant string\" + Math.random());",
+                "}").doTest();
+    }
+
+    @Test
     public void io_exception() {
         compilationHelper.addSourceLines(
                 "Bean.java",


### PR DESCRIPTION
## Before this PR

People might write code like this that uses regular RuntimeExceptions etc:
```
throw new RuntimeException("Something went wrong", cause);
```

Exceptions like these will be redacted because they are not SafeLoggable.

## After this PR

People will get a 'suggestion' to use safe loggable exceptions. I've also implemented the auto-fix thing, so if we ever wire that up properly it should give people a one-click fix.

fixes https://github.com/palantir/gradle-baseline/issues/344