### PR TITLE
[improvement] Ban internal palantir packages

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -136,7 +136,7 @@
             <property name="regexp" value="true" />
             <message key="import.illegal" value="Do not rely on gradle internal classes as these may change in minor releases - use org.gradle.api versions instead."/>
         </module>
-	<module name="IllegalImport">
+        <module name="IllegalImport">
             <property name="id" value="BanPalantirInternal"/>
             <property name="illegalPkgs" value="^com\.palantir\.(internal|.*\.internal)"/>
             <property name="regexp" value="true" />

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -132,13 +132,14 @@
             <message key="import.illegal" value="Must not import repackaged classes."/>
         </module>
         <module name="IllegalImport">
+            <property name="id" value="BanGradleInternal"/>
             <property name="illegalPkgs" value="^org\.gradle\.(internal|.*\.internal)"/>
             <property name="regexp" value="true" />
             <message key="import.illegal" value="Do not rely on gradle internal classes as these may change in minor releases - use org.gradle.api versions instead."/>
         </module>
         <module name="IllegalImport">
             <property name="id" value="BanPalantirInternal"/>
-            <property name="illegalPkgs" value="^com\.palantir\.(internal|.*\.internal)(\.|$)"/>
+            <property name="illegalPkgs" value="^com\.palantir\.(internal|.*\.internal)"/>
             <property name="regexp" value="true" />
             <message key="import.illegal" value="Do not rely on internal classes as these may change in minor releases."/>
         </module>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -136,6 +136,12 @@
             <property name="regexp" value="true" />
             <message key="import.illegal" value="Do not rely on gradle internal classes as these may change in minor releases - use org.gradle.api versions instead."/>
         </module>
+	<module name="IllegalImport">
+            <property name="id" value="BanPalantirInternal"/>
+            <property name="illegalPkgs" value="^com\.palantir\.(internal|.*\.internal)"/>
+            <property name="regexp" value="true" />
+            <message key="import.illegal" value="Do not rely on internal classes as these may change in minor releases."/>
+        </module>
         <module name="IllegalImport">
             <property name="illegalPkgs" value="sun"/>
             <message key="import.illegal" value="Must not use Oracle's Java implementation details. See http://www.oracle.com/technetwork/java/faq-sun-packages-142232.html ."/>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -138,7 +138,7 @@
         </module>
         <module name="IllegalImport">
             <property name="id" value="BanPalantirInternal"/>
-            <property name="illegalPkgs" value="^com\.palantir\.(internal|.*\.internal)"/>
+            <property name="illegalPkgs" value="^com\.palantir\.(internal|.*\.internal)(\.|$)"/>
             <property name="regexp" value="true" />
             <message key="import.illegal" value="Do not rely on internal classes as these may change in minor releases."/>
         </module>


### PR DESCRIPTION
## Before this PR

You could use `com.palantir.<product>.internal` classes.

## After this PR

Checkstyle will prevent you from importing classes from any `com.palantir.<product>.internal` package.