### PR TITLE
[fix] Mention requirement for gradle 4.10 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ See also the [Baseline Java Style Guide and Best Practises](./docs).
 
 
 ## Usage
+The baseline set of plugins requires at least Gradle 4.9.
+
 It is recommended to add `apply plugin: 'com.palantir.baseline'` to your root project's build.gradle.  Individual plugins will be automatically applied to appropriate subprojects.
 
 ```Gradle

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See also the [Baseline Java Style Guide and Best Practises](./docs).
 
 
 ## Usage
-The baseline set of plugins requires at least Gradle 4.9.
+The baseline set of plugins requires at least Gradle 4.10.0.
 
 It is recommended to add `apply plugin: 'com.palantir.baseline'` to your root project's build.gradle.  Individual plugins will be automatically applied to appropriate subprojects.
 


### PR DESCRIPTION
## Before this PR

We don't explicitly mention the version of gradle you need to use Baseline.

## After this PR

We mention this in the readme.

Fixes #367 

## TODO

- [ ] Run tests against gradle 4.10 to ensure compatibility (at least a basic application of `com.palantir.gradle-baseline`)