### PR TITLE
[fix] Add errorprone javac only if compiler is Java 8

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import net.ltgt.gradle.errorprone.CheckSeverity;
 import net.ltgt.gradle.errorprone.ErrorProneOptions;
 import net.ltgt.gradle.errorprone.ErrorPronePlugin;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
@@ -63,7 +64,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
             // In case of java 8 we need to add errorprone javac compiler to bootstrap classpath of tasks that perform
             // compilation or code analysis. ErrorProneJavacPluginPlugin handles JavaCompile cases via errorproneJavac
             // configuration and we do similar thing for Test and Javadoc type tasks
-            if (!javaConvention.getSourceCompatibility().isJava9Compatible()) {
+            if (!JavaVersion.current().isJava9Compatible()) {
                 project.getDependencies().add(ErrorPronePlugin.JAVAC_CONFIGURATION_NAME,
                         "com.google.errorprone:javac:" + ERROR_PRONE_JAVAC_VERSION);
                 project.getConfigurations()


### PR DESCRIPTION
## Before this PR

We were deciding whether or not to add the errorprone javac implementation based on the configured `sourceCompatibility` of the project.
However, if the compiler is Java 9+, the source compatibility doesn't matter - you'd never need to add this compiler. Additionally, the `sun.boot.class.path` won't be set, so our code that configures the test/javadoc tasks would break on parsing the bootstrapClasspath with a NullPointerException.
See the [check](https://github.com/tbroyer/gradle-errorprone-plugin/blob/d36cf009776592cd6bed22d49a3265583a3d8d2f/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt#L79) that the ErrorPronePlugin itself performs.

## After this PR

Only add the errorprone javac compiler to the bootstrap classpaths of Test/Javadoc tasks if the compiler itself is older than Java 9.