### PR TITLE
Add minimal required build configuration for a working build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ It is recommended to add `apply plugin: 'com.palantir.baseline'` to your root pr
 ```Gradle
 buildscript {
     repositories {
+        gradlePluginPortal()
         maven { url  "http://palantir.bintray.com/releases" }
     }
 
     dependencies {
         classpath 'com.palantir.baseline:gradle-baseline-java:<version>'
+        classpath 'gradle.plugin.org.inferred:gradle-processors:2.1.0'
     }
 }
 


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Running with the given build script causes a few errors. The first is a missing dependency:
(`Could not find com.diffplug.spotless:spotless-plugin-gradle:3.14.0.` for me)

The second is a plugin missing from the classpath: `Plugin with id 'org.inferred.processors' not found.`

## After this PR
<!-- Describe at a high-level why this approach is better. -->
The build script in the readme now works out of the box on Gradle 4.10.2

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
