### PR TITLE
[fix] Eclipse Checkstyle plugin no longer applies CheckstyleNature

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java
@@ -76,7 +76,6 @@ public final class BaselineCheckstyle extends AbstractBaselinePlugin {
         project.getPluginManager().withPlugin("eclipse", plugin -> {
             EclipseProject eclipseProject = project.getExtensions().getByType(EclipseModel.class).getProject();
             eclipseProject.buildCommand("net.sf.eclipsecs.core.CheckstyleBuilder");
-            eclipseProject.natures("net.sf.eclipsecs.core.CheckstyleNature");
         });
     }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineCheckstyleTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineCheckstyleTest.groovy
@@ -60,13 +60,4 @@ class BaselineCheckstyleTest extends Specification {
             assert task.getSource().getFiles().contains(file)
         }
     }
-
-    def appliesEclipseNatures() {
-        when:
-        project.plugins.apply 'eclipse'
-        project.plugins.apply BaselineEclipse
-
-        then:
-        project.eclipse.project.natures.contains("net.sf.eclipsecs.core.CheckstyleNature")
-    }
 }


### PR DESCRIPTION
Before: Eclipse warnings for unknown project nature declared in .project files
After: no Eclipse warnings

Tested with Eclipse 2018-09 and latest applied EclipseCS plugin from Eclipse Marketplace