### PR TITLE
Don't configure nebula propertiesFile if core bom support is on

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -77,7 +77,7 @@ public final class BaselineVersions implements Plugin<Project> {
         File rootVersionsPropsFile = rootVersionsPropsFile(project);
         extension.propertiesFile(ImmutableMap.of("file", rootVersionsPropsFile));
 
-        if (project != project.getRootProject()) {
+        if (project != project.getRootProject() && !Boolean.getBoolean("nebula.features.coreBomSupport")) {
             // allow nested projects to specify their own nested versions.props file
             if (project.file("versions.props").exists()) {
                 extension.propertiesFile(ImmutableMap.of("file", project.file("versions.props")));

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -31,6 +31,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -59,6 +61,7 @@ import org.gradle.api.tasks.TaskProvider;
  */
 public final class BaselineVersions implements Plugin<Project> {
 
+    private static final Logger log = Logging.getLogger(BaselineVersions.class);
     static final String GROUP = "com.palantir.baseline-versions";
 
     @Override
@@ -66,6 +69,11 @@ public final class BaselineVersions implements Plugin<Project> {
 
         // apply plugin: "nebula.dependency-recommender"
         project.getPluginManager().apply(DependencyRecommendationsPlugin.class);
+
+        if (Boolean.getBoolean("nebula.features.coreBomSupport")) {
+            log.info("Not configuring nebula.dependency-recommender because coreBomSupport is enabled");
+            return;
+        }
 
         // get dependencyRecommendations extension
         RecommendationProviderContainer extension = project
@@ -77,7 +85,7 @@ public final class BaselineVersions implements Plugin<Project> {
         File rootVersionsPropsFile = rootVersionsPropsFile(project);
         extension.propertiesFile(ImmutableMap.of("file", rootVersionsPropsFile));
 
-        if (project != project.getRootProject() && !Boolean.getBoolean("nebula.features.coreBomSupport")) {
+        if (project != project.getRootProject()) {
             // allow nested projects to specify their own nested versions.props file
             if (project.file("versions.props").exists()) {
                 extension.propertiesFile(ImmutableMap.of("file", project.file("versions.props")));
@@ -107,10 +115,10 @@ public final class BaselineVersions implements Plugin<Project> {
         File file = project.getRootProject().file("versions.props");
         if (!file.canRead()) {
             try {
-                project.getLogger().info("Could not find 'versions.props' file, creating...");
+                log.info("Could not find 'versions.props' file, creating...");
                 Files.createFile(file.toPath());
             } catch (IOException e) {
-                project.getLogger().warn("Unable to create empty versions.props file, please create this manually", e);
+                log.warn("Unable to create empty versions.props file, please create this manually", e);
             }
         }
         return file;


### PR DESCRIPTION
Using `propertiesFile` or any other recommendation source other than `mavenBom` will [always throw if core BOM support is on](https://github.com/nebula-plugins/nebula-dependency-recommender-plugin/blob/v7.1.2/src/main/groovy/netflix/nebula/dependency/recommender/provider/RecommendationProviderContainer.java#L96).

cc @robert3005 