### PR TITLE
Ban Runtime#addShutdownHook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ checks](https://errorprone.info):
 - `Slf4jLogsafeArgs`: Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages. More information on
 Safe Logging can be found at [github.com/palantir/safe-logging](https://github.com/palantir/safe-logging).
 - `PreferSafeLoggableExceptions`: Users should throw `SafeRuntimeException` instead of `RuntimeException` so that messages will not be needlessly redacted when logs are collected:
+- `ShutdownHook`: Applications should not use `Runtime#addShutdownHook`.
 
 ```diff
 -throw new RuntimeException("explanation", e); // this message will be redacted when logs are collected

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ShutdownHook.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ShutdownHook.java
@@ -22,12 +22,10 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.predicates.TypePredicates;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.Tree;
 import java.util.regex.Pattern;
 
 @AutoService(BugChecker.class)
@@ -48,9 +46,6 @@ public final class ShutdownHook extends BugChecker implements BugChecker.MethodI
     private static final Matcher<ExpressionTree> shutdownHookMethods = MethodMatchers.instanceMethod()
             .onClass(TypePredicates.isExactType("java.lang.Runtime"))
             .withNameMatching(Pattern.compile("addShutdownHook|removeShutdownHook"));
-
-    private static final Matcher<Tree> containsShutdownHookMethod = Matchers.contains(
-            Matchers.toType(ExpressionTree.class, shutdownHookMethods));
 
     @Override
     public Description matchMethodInvocation(

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ShutdownHook.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ShutdownHook.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.predicates.TypePredicates;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import java.util.regex.Pattern;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "ShutdownHook",
+        category = BugPattern.Category.ONE_OFF,
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.ERROR,
+        summary = "use your webserver's managed resource functionality instead of "
+                + "using Runtime#addShutdownHook directly.")
+public final class ShutdownHook extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+    private static final String errorMsg = "Use your webserver's managed resource functionality "
+            + "instead of using java.lang.Runtime#addShutdownHook directly.";
+
+    private static final Matcher<ExpressionTree> shutdownHookMethods = MethodMatchers.instanceMethod()
+            .onClass(TypePredicates.isExactType("java.lang.Runtime"))
+            .withNameMatching(Pattern.compile("addShutdownHook|removeShutdownHook"));
+
+    private static final Matcher<Tree> containsShutdownHookMethod = Matchers.contains(
+            Matchers.toType(ExpressionTree.class, shutdownHookMethods));
+
+    @Override
+    public Description matchMethodInvocation(
+            MethodInvocationTree tree, VisitorState state) {
+        if (!shutdownHookMethods.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        return buildDescription(tree)
+                .setMessage(errorMsg)
+                .build();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ShutdownHookTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ShutdownHookTests.java
@@ -17,7 +17,6 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,23 +34,39 @@ public class ShutdownHookTests {
     }
 
     @Test
-    public void testUsesShutdownHooks() {
-        test("addShutdownHook(new Thread())", Optional.of(errorMsg));
-        test("removeShutdownHook(new Thread())", Optional.of(errorMsg));
-    }
-
-    @Test
-    public void testDoesNotUseShutdownHooks() {
-        test("availableProcessors()", Optional.empty());
-    }
-
-    private void test(String method, Optional<String> error) {
+    public void testRemoveShutdownHook() {
         compilationHelper.addSourceLines(
                 "Test.java",
                 "class Test {",
                 "  void f(String param) {",
-                "// " + error.orElse(""),
-                "    Runtime.getRuntime()." + method + ";",
+                "// " + errorMsg,
+                "    Runtime.getRuntime().removeShutdownHook(new Thread());",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    public void testUsesAddShutdownHook() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "class Test {",
+                "  void f(String param) {",
+                "// " + errorMsg,
+                "    Runtime.getRuntime().addShutdownHook(new Thread());",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    public void testDoesNotUseShutdownHooks() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "class Test {",
+                "  void f(String param) {",
+                "// ",
+                "    Runtime.getRuntime().availableProcessors();",
                 "  }",
                 "}"
         ).doTest();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ShutdownHookTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ShutdownHookTests.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShutdownHookTests {
+
+    private static final String errorMsg = "BUG: Diagnostic contains: "
+            + "Use your webserver's managed resource functionality "
+            + "instead of using java.lang.Runtime#addShutdownHook directly.";
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(ShutdownHook.class, getClass());
+    }
+
+    @Test
+    public void testUsesShutdownHooks() {
+        test("addShutdownHook(new Thread())", Optional.of(errorMsg));
+        test("removeShutdownHook(new Thread())", Optional.of(errorMsg));
+    }
+
+    @Test
+    public void testDoesNotUseShutdownHooks() {
+        test("availableProcessors()", Optional.empty());
+    }
+
+    private void test(String method, Optional<String> error) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "class Test {",
+                "  void f(String param) {",
+                "// " + error.orElse(""),
+                "    Runtime.getRuntime()." + method + ";",
+                "  }",
+                "}"
+        ).doTest();
+    }
+}

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
@@ -14,7 +14,6 @@
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="AvoidStaticImport" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" id="BanSystemOut" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" id="BanSystemErr" />
-    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" id="BanShutdownHooks" />
 
     <!-- JavadocStyle enforces existence of package-info.java package-level Javadoc; we consider this a bug. -->
     <suppress files="package-info.java" checks="JavadocStyle" />

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
@@ -14,6 +14,7 @@
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" checks="AvoidStaticImport" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" id="BanSystemOut" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" id="BanSystemErr" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java|groovy)[/\\]" id="BanShutdownHooks" />
 
     <!-- JavadocStyle enforces existence of package-info.java package-level Javadoc; we consider this a bug. -->
     <suppress files="package-info.java" checks="JavadocStyle" />

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -370,6 +370,11 @@
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>
             <property name="message" value="Test setup/teardown methods are called before(), beforeClass(), after(), afterClass(), but not setUp, teardown, etc."/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="BanShutdownHooks"/>
+            <property name="format" value=".*addShutdownHook\("/>
+            <property name="message" value="Use your webserver's managed resource functionality instead of using Runtime#addShutdownHook directly."/>
+        </module>
         <module name="RightCurly"> <!-- Java Style Guide: Nonempty blocks: K & R style -->
             <property name="option" value="same"/>
             <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -40,7 +40,7 @@
         <property name="message" value="Whitespace at end-of-line"/>
     </module>
     <module name="RegexpMultiline"> <!-- Java Style Guide: Vertical Whitespace -->
-	<property name="fileExtensions" value="java"/>
+        <property name="fileExtensions" value="java"/>
         <property name="format" value="^\n\n$"/>
         <property name="message" value="Two consecutive blank lines are not permitted."/>
     </module>
@@ -369,11 +369,6 @@
         <module name="RegexpSinglelineJava">
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>
             <property name="message" value="Test setup/teardown methods are called before(), beforeClass(), after(), afterClass(), but not setUp, teardown, etc."/>
-        </module>
-        <module name="RegexpSinglelineJava">
-            <property name="id" value="BanShutdownHooks"/>
-            <property name="format" value=".*addShutdownHook\("/>
-            <property name="message" value="Use your webserver's managed resource functionality instead of using Runtime#addShutdownHook directly."/>
         </module>
         <module name="RightCurly"> <!-- Java Style Guide: Nonempty blocks: K & R style -->
             <property name="option" value="same"/>


### PR DESCRIPTION
## Before this PR
Use of Runtime#addShutdownHook is allowed, which in libraries can cause memory leaks if the library does not deregister the hooks promptly.

## After this PR
Devs are prompted to not use the shutdown hook functionality directly, but instead rely on their webserver's managed lifecycle functionality.
