### PR TITLE
Suggest avoiding default case in switch statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,12 @@ checks](https://errorprone.info):
 - `Slf4jLogsafeArgs`: Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages. More information on
 Safe Logging can be found at [github.com/palantir/safe-logging](https://github.com/palantir/safe-logging).
 - `PreferSafeLoggableExceptions`: Users should throw `SafeRuntimeException` instead of `RuntimeException` so that messages will not be needlessly redacted when logs are collected:
+    ```diff
+    -throw new RuntimeException("explanation", e); // this message will be redacted when logs are collected
+    +throw new SafeRuntimeException("explanation", e); // this message will be preserved (allowing easier debugging)
+    ```
 - `ShutdownHook`: Applications should not use `Runtime#addShutdownHook`.
-
-```diff
--throw new RuntimeException("explanation", e); // this message will be redacted when logs are collected
-+throw new SafeRuntimeException("explanation", e); // this message will be preserved (allowing easier debugging)
-```
-
+- `SwitchStatementDefaultCase`: Switch statements should avoid using default cases. Default cases prevent the [MissingCasesInEnumSwitch](http://errorprone.info/bugpattern/MissingCasesInEnumSwitch.html) check from detecting when an enum value is not explicitly handled. This check is important to help avoid incorrect behavior when new enum values are introduced.
 
 ## com.palantir.baseline-checkstyle
 Checkstyle rules can be suppressed on a per-line or per-block basis. (It is good practice to first consider formatting

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCase.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCase.java
@@ -35,7 +35,7 @@ import java.util.Objects;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = LinkType.CUSTOM,
         severity = SeverityLevel.SUGGESTION,
-        summary = "Avoid default cases in switch statements to correctly handle new enum variants")
+        summary = "Avoid default cases in switch statements to correctly handle new enum values")
 public final class SwitchStatementDefaultCase extends BugChecker implements BugChecker.SwitchTreeMatcher {
 
     @Override

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCase.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCase.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.Category;
+import com.google.errorprone.BugPattern.LinkType;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.SwitchTree;
+import java.util.Objects;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "SwitchStatementDefaultCase",
+        category = Category.ONE_OFF,
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = LinkType.CUSTOM,
+        severity = SeverityLevel.SUGGESTION,
+        summary = "Avoid default cases in switch statements to correctly handle new enum variants")
+public final class SwitchStatementDefaultCase extends BugChecker implements BugChecker.SwitchTreeMatcher {
+
+    @Override
+    public Description matchSwitch(SwitchTree tree, VisitorState state) {
+        if (hasDefaultCase(tree)) {
+            return buildDescription(tree)
+                    .setMessage("Avoid using default case in switch statement.")
+                    .build();
+        }
+
+        return Description.NO_MATCH;
+    }
+
+    private boolean hasDefaultCase(SwitchTree tree) {
+        return tree.getCases().stream()
+                .map(CaseTree::getExpression)
+                .anyMatch(Objects::isNull);
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCaseTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCaseTest.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SwitchStatementDefaultCaseTest {
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(SwitchStatementDefaultCase.class, getClass());
+    }
+
+    @Test
+    public void testDefaultCase() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "  enum Case { ONE, TWO, THREE }",
+                        "  void m(Case c) {",
+                        "    // BUG: Diagnostic contains: Avoid using default case in switch statement.",
+                        "    switch (c) {",
+                        "      case ONE:",
+                        "      case TWO:",
+                        "      case THREE:",
+                        "      default:",
+                        "        break;",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testNoDefaultCase() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "  enum Case { ONE, TWO, THREE }",
+                        "  void m(Case c) {",
+                        "    switch (c) {",
+                        "      case ONE:",
+                        "      case TWO:",
+                        "      case THREE:",
+                        "        break;",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+}


### PR DESCRIPTION
Fixes #480

A severity of `WARNING` is probably too strong for this check.