### PR TITLE
Only apply the baseline-eclipse plugin on Java projects

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -39,13 +39,15 @@ public final class Baseline implements Plugin<Project> {
         rootProject.allprojects(proj -> {
             proj.getPluginManager().apply(BaselineCheckstyle.class);
             proj.getPluginManager().apply(BaselineScalastyle.class);
-            proj.getPluginManager().apply(BaselineEclipse.class);
             proj.getPluginManager().apply(BaselineIdea.class);
             proj.getPluginManager().apply(BaselineErrorProne.class);
             proj.getPluginManager().apply(BaselineVersions.class);
             proj.getPluginManager().apply(BaselineFormat.class);
             // TODO(dfox): enable this when it has been validated on a few real projects
             // proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);
+        });
+        rootProject.subprojects(proj -> {
+            proj.getPluginManager().apply(BaselineEclipse.class);
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -39,15 +39,13 @@ public final class Baseline implements Plugin<Project> {
         rootProject.allprojects(proj -> {
             proj.getPluginManager().apply(BaselineCheckstyle.class);
             proj.getPluginManager().apply(BaselineScalastyle.class);
+            proj.getPluginManager().apply(BaselineEclipse.class);
             proj.getPluginManager().apply(BaselineIdea.class);
             proj.getPluginManager().apply(BaselineErrorProne.class);
             proj.getPluginManager().apply(BaselineVersions.class);
             proj.getPluginManager().apply(BaselineFormat.class);
             // TODO(dfox): enable this when it has been validated on a few real projects
             // proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);
-        });
-        rootProject.subprojects(proj -> {
-            proj.getPluginManager().apply(BaselineEclipse.class);
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
@@ -18,7 +18,6 @@ package com.palantir.baseline.plugins
 
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.plugins.ide.eclipse.EclipsePlugin
 
 /**
  * Configures the Gradle 'eclipse' task with Baseline settings.
@@ -68,10 +67,9 @@ class BaselineEclipse extends AbstractBaselinePlugin {
     void apply(Project project) {
         this.project = project
 
-        project.plugins.apply EclipsePlugin
-
         // Configure Eclipse JDT Core by merging in Baseline settings.
-        project.plugins.withType(EclipsePlugin, { plugin ->
+        project.plugins.withType(JavaPlugin, { plugin ->
+            project.plugins.apply EclipsePlugin
             project.afterEvaluate {
                 project.eclipse {
                     if (jdt != null) {
@@ -131,19 +129,14 @@ class BaselineEclipse extends AbstractBaselinePlugin {
             }
 
             // Run eclipseTemplate when eclipse task is run
-            eclipseTemplate.onlyIf {
-                project.plugins.hasPlugin(JavaPlugin)
-            }
             project.tasks.eclipse.dependsOn(eclipseTemplate)
 
             // Override default Eclipse JRE.
-            if (project.plugins.hasPlugin(JavaPlugin)) {
-                project.tasks.eclipseClasspath.doFirst {
-                    String eclipseClassPath = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-" + project.sourceCompatibility;
-                    project.eclipse.classpath {
-                        containers.clear()
-                        containers.add(eclipseClassPath)
-                    }
+            project.tasks.eclipseClasspath.doFirst {
+                String eclipseClassPath = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-" + project.sourceCompatibility;
+                project.eclipse.classpath {
+                    containers.clear()
+                    containers.add(eclipseClassPath)
                 }
             }
         }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
@@ -18,6 +18,7 @@ package com.palantir.baseline.plugins
 
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.plugins.ide.eclipse.EclipsePlugin
 
 /**
  * Configures the Gradle 'eclipse' task with Baseline settings.

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEclipseIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEclipseIntegrationTest.groovy
@@ -50,15 +50,6 @@ class BaselineEclipseIntegrationTest extends AbstractPluginTest {
         result.task(':eclipseTemplate').outcome == TaskOutcome.SUCCESS
     }
 
-    def 'Eclipse task works without Java plugin'() {
-        when:
-        buildFile << noJavaBuildFile
-
-        then:
-        def result = with('eclipse').build()
-        result.task(':eclipseTemplate').outcome == TaskOutcome.SKIPPED
-    }
-
     def 'Eclipse task sets jdt core properties'() {
         when:
         buildFile << standardBuildFile

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTest.groovy
@@ -36,16 +36,25 @@ class BaselineTest extends Specification {
         expect:
         assert project.pluginManager.hasPlugin('com.palantir.baseline-circleci')
         assert project.pluginManager.hasPlugin('com.palantir.baseline-config')
-        hasAllPlugins(project)
+        assert !project.pluginManager.hasPlugin('com.palantir.baseline-eclipse')
+        hasAllProjectPlugins(project)
         hasAllPlugins(subProject)
     }
 
     void hasAllPlugins(Project p) {
+        hasAllProjectPlugins(p)
+        hasEclipsePlugins(p)
+    }
+
+    void hasAllProjectPlugins(Project p) {
         assert p.pluginManager.hasPlugin('com.palantir.baseline-checkstyle')
-        assert p.pluginManager.hasPlugin('com.palantir.baseline-eclipse')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-error-prone')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-idea')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-versions')
+    }
+
+    void hasEclipsePlugins(Project p) {
+        assert p.pluginManager.hasPlugin('com.palantir.baseline-eclipse')
     }
 
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTest.groovy
@@ -36,25 +36,18 @@ class BaselineTest extends Specification {
         expect:
         assert project.pluginManager.hasPlugin('com.palantir.baseline-circleci')
         assert project.pluginManager.hasPlugin('com.palantir.baseline-config')
-        assert !project.pluginManager.hasPlugin('com.palantir.baseline-eclipse')
-        hasAllProjectPlugins(project)
+        // eclipse plugin not applied to root project because it is not a java project
+        assert !project.pluginManager.hasPlugin('eclipse')
+        hasAllPlugins(project)
         hasAllPlugins(subProject)
     }
 
     void hasAllPlugins(Project p) {
-        hasAllProjectPlugins(p)
-        hasEclipsePlugins(p)
-    }
-
-    void hasAllProjectPlugins(Project p) {
         assert p.pluginManager.hasPlugin('com.palantir.baseline-checkstyle')
+        assert p.pluginManager.hasPlugin('com.palantir.baseline-eclipse')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-error-prone')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-idea')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-versions')
-    }
-
-    void hasEclipsePlugins(Project p) {
-        assert p.pluginManager.hasPlugin('com.palantir.baseline-eclipse')
     }
 
 }


### PR DESCRIPTION
# Before this PR
All subprojects are hidden when importing from a repo where the `com.palantir.baseline` plugin is applied to the root project, even when the root project is not a Java project.

# After this PR
Only apply the baseline-eclipse (and the underlying Gradle eclipse plugin) on Java projects, else no-op; when root projects are not Java projects, the baseline-eclipse plugin has no effect.