### PR TITLE
[improvement] Resolves deprecation warning for use of DefaultTask.newInputFile()

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
@@ -42,7 +42,7 @@ import org.gradle.api.tasks.options.Option;
 public class CheckBomConflictTask extends DefaultTask {
 
     private final Property<Boolean> shouldFix = getProject().getObjects().property(Boolean.class);
-    private final RegularFileProperty propsFileProperty = newInputFile();
+    private final RegularFileProperty propsFileProperty = getProject().getObjects().fileProperty();
 
     public CheckBomConflictTask() {
         shouldFix.set(false);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
@@ -42,7 +42,7 @@ import org.gradle.api.tasks.options.Option;
 public class CheckNoUnusedPinTask extends DefaultTask {
 
     private final Property<Boolean> shouldFix = getProject().getObjects().property(Boolean.class);
-    private final RegularFileProperty propsFileProperty = newInputFile();
+    private final RegularFileProperty propsFileProperty = getProject().getObjects().fileProperty();
 
     public CheckNoUnusedPinTask() {
         shouldFix.set(false);


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

```
The DefaultTask.newInputFile() method has been deprecated.
This is scheduled to be removed in Gradle 6.0.
Please use the ObjectFactory.fileProperty() method instead.
2 usages
    CheckBomConflictTask.java:45
    CheckNoUnusedPinTask.java:45
```

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Use non-deprecated file property factory method to avoid breakage when gradle 6.0 comes out.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
See tritium build scan flagging deprecation: https://scans.gradle.com/s/pflkoibzlelue/deprecations#deprecation-0