### PR TITLE
[fix] Update broken fogcreek blog link

### DIFF
--- a/docs/best-practices/code-reviews/readme.md
+++ b/docs/best-practices/code-reviews/readme.md
@@ -14,7 +14,7 @@ The Internet provides a wealth of material on code reviews:
 [best practices](https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/),
 [more best practices](https://www.atlassian.com/agile/software-development/code-reviews),
 [statistics on code review effectiveness for catching bugs](https://blog.codinghorror.com/code-reviews-just-do-it/),
-and [examples of code reviews gone wrong](https://web.archive.org/web/20180313140443/https://blog.fogcreek.com/effective-code-reviews-9-tips-from-a-converted-skeptic/).
+and [examples of code reviews gone wrong](https://www.fogbugz.com/blog/9-effective-code-review-tips/).
 Oh, and of course there are
 [books](https://books.google.com/books/about/Peer_Reviews_in_Software.html?id=d7BQAAAAMAAJ),
 too. Long story short, this document presents Palantir's take on code reviews.

--- a/docs/best-practices/code-reviews/readme.md
+++ b/docs/best-practices/code-reviews/readme.md
@@ -14,7 +14,7 @@ The Internet provides a wealth of material on code reviews:
 [best practices](https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/),
 [more best practices](https://www.atlassian.com/agile/software-development/code-reviews),
 [statistics on code review effectiveness for catching bugs](https://blog.codinghorror.com/code-reviews-just-do-it/),
-and [examples of code reviews gone wrong](https://blog.fogcreek.com/effective-code-reviews-9-tips-from-a-converted-skeptic/).
+and [examples of code reviews gone wrong](https://web.archive.org/web/20180313140443/https://blog.fogcreek.com/effective-code-reviews-9-tips-from-a-converted-skeptic/).
 Oh, and of course there are
 [books](https://books.google.com/books/about/Peer_Reviews_in_Software.html?id=d7BQAAAAMAAJ),
 too. Long story short, this document presents Palantir's take on code reviews.


### PR DESCRIPTION

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

PR https://github.com/palantir/gradle-baseline/pull/493 [build failed](https://circleci.com/gh/palantir/gradle-baseline/1913) due to bit rot for no longer valid link
https://blog.fogcreek.com/effective-code-reviews-9-tips-from-a-converted-skeptic/ as [Fog Creek was acquired by Glitch](https://glitch.com/about/fog-creek-is-now-glitch/) and the [old Fog Creek blog now 404s](https://blog.fogcreek.com).

```
ERROR	https://blog.fogcreek.com/effective-code-reviews-9-tips-from-a-converted-skeptic/
  X509: certificate is valid for *.wpengine.com, wpengine.com, not blog.fogcreek.com
```

## After this PR
<!-- Describe at a high-level why this approach is better. -->

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->

This PR updates the link to point at https://www.fogbugz.com/blog/9-effective-code-review-tips/  from FogBugz (formerly part of FogCreek) that appears to be a shortened, similar version to the original ([recent version of the original page from the wayback machine](https://web.archive.org/web/20180814225126/https://blog.fogcreek.com/effective-code-reviews-9-tips-from-a-converted-skeptic/))