### PR TITLE
[fix] Disable certain errorprone checks for gradle plugins

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -31,7 +31,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.ExtensionAware;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
@@ -65,7 +64,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                         ((ExtensionAware) javaCompile.getOptions()).getExtensions()
                                 .configure(ErrorProneOptions.class, errorProneOptions -> {
                                     errorProneOptions.check("Slf4jLogsafeArgs", CheckSeverity.OFF);
-                                    errorProneOptions.check("Slf4jConstantLogMessage", CheckSeverity.OFF);
+                                    errorProneOptions.check("PreferSafeLoggableExceptions", CheckSeverity.OFF);
                                 }));
             });
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -44,7 +44,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
     public void apply(Project project) {
         project.getPluginManager().withPlugin("java", plugin -> {
             project.getPluginManager().apply(ErrorPronePlugin.class);
-            JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
             String version = Optional.ofNullable(getClass().getPackage().getImplementationVersion())
                     .orElse("latest.release");
             project.getDependencies().add(
@@ -60,6 +59,15 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
                                 errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
                             }));
+
+            project.getPluginManager().withPlugin("java-gradle-plugin", appliedPlugin -> {
+                project.getTasks().withType(JavaCompile.class).configureEach(javaCompile ->
+                        ((ExtensionAware) javaCompile.getOptions()).getExtensions()
+                                .configure(ErrorProneOptions.class, errorProneOptions -> {
+                                    errorProneOptions.check("Slf4jLogsafeArgs", CheckSeverity.OFF);
+                                    errorProneOptions.check("Slf4jConstantLogMessage", CheckSeverity.OFF);
+                                }));
+            });
 
             // In case of java 8 we need to add errorprone javac compiler to bootstrap classpath of tasks that perform
             // compilation or code analysis. ErrorProneJavacPluginPlugin handles JavaCompile cases via errorproneJavac


### PR DESCRIPTION
Fixes #389 

## Before this PR

Gradle plugins would be subjected to certain error prone checks that are only really applicable to code that will run as part of deployed services:

* Slf4jLogsafeArgs
* PreferSafeLoggableExceptions

## After this PR

These checks are disabled for gradle plugin projects, i.e. projects that apply `java-gradle-plugin`.

cc @iamdanfox 
