### PR TITLE
Split PreconditionsConstantMessage logsafe validation into LogSafePreconditionsConstantMessage

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessage.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,18 +34,19 @@ import java.util.regex.Pattern;
 
 @AutoService(BugChecker.class)
 @BugPattern(
-        name = "PreconditionsConstantMessage",
+        name = "LogSafePreconditionsConstantMessage",
         category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
-        summary = "Allow only constant messages to Preconditions.checkX() methods")
-public final class PreconditionsConstantMessage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+        summary = "Allow only constant messages to logsafe Preconditions.checkX() methods")
+public final class LogSafePreconditionsConstantMessage
+        extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
     private static final long serialVersionUID = 1L;
 
     private static final Matcher<ExpressionTree> PRECONDITIONS_METHOD =
             Matchers.anyOf(
                     MethodMatchers.staticMethod()
-                            .onClassAny("com.google.common.base.Preconditions")
+                            .onClassAny("com.palantir.logsafe.Preconditions")
                             .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull")));
 
     private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
@@ -70,6 +71,6 @@ public final class PreconditionsConstantMessage extends BugChecker implements Bu
 
         return buildDescription(tree).setMessage(
                 "Preconditions.checkX() statement uses a non-constant message. "
-                        + "Consider using a template string with '%s'.").build();
+                        + "Dynamic components are required to be wrapped with either SafeArg or UnsafeArg.").build();
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessage.java
@@ -46,7 +46,7 @@ public final class LogSafePreconditionsConstantMessage
     private static final Matcher<ExpressionTree> PRECONDITIONS_METHOD =
             Matchers.anyOf(
                     MethodMatchers.staticMethod()
-                            .onClassAny("com.palantir.logsafe.Preconditions")
+                            .onClass("com.palantir.logsafe.Preconditions")
                             .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull")));
 
     private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
@@ -45,7 +45,7 @@ public final class PreconditionsConstantMessage extends BugChecker implements Bu
     private static final Matcher<ExpressionTree> PRECONDITIONS_METHOD =
             Matchers.anyOf(
                     MethodMatchers.staticMethod()
-                            .onClassAny("com.google.common.base.Preconditions")
+                            .onClass("com.google.common.base.Preconditions")
                             .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull")));
 
     private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessageTests.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
 import org.junit.Test;
 
-public final class PreconditionsConstantMessageTests extends PreconditionsTests {
+public final class LogSafePreconditionsConstantMessageTests extends PreconditionsTests {
 
     private CompilationTestHelper compilationHelper;
 
     @Before
     public void before() {
-        compilationHelper = CompilationTestHelper.newInstance(PreconditionsConstantMessage.class, getClass());
+        compilationHelper = CompilationTestHelper.newInstance(LogSafePreconditionsConstantMessage.class, getClass());
     }
 
     @Override
@@ -37,13 +37,15 @@ public final class PreconditionsConstantMessageTests extends PreconditionsTests 
     @Test
     public void positive() throws Exception {
         String diagnostic = "non-constant message";
-        failGuava(diagnostic, "Preconditions.checkArgument(param != \"string\", \"constant\" + param);");
-        failGuava(diagnostic, "Preconditions.checkState(param != \"string\", \"constant\" + param);");
-        failGuava(diagnostic, "Preconditions.checkNotNull(param, \"constant\" + param);");
 
-        failGuava(diagnostic,
+        failLogSafe(diagnostic, "Preconditions.checkArgument(param != \"string\", \"constant\" + param);");
+        failLogSafe(diagnostic, "Preconditions.checkState(param != \"string\", \"constant\" + param);");
+        failLogSafe(diagnostic, "Preconditions.checkNotNull(param, \"constant\" + param);");
+
+        failLogSafe(diagnostic,
                 "Preconditions.checkArgument(param != \"string\", String.format(\"constant %s\", param));");
-        failGuava(diagnostic, "Preconditions.checkState(param != \"string\", String.format(\"constant %s\", param));");
-        failGuava(diagnostic, "Preconditions.checkNotNull(param, String.format(\"constant %s\", param));");
+        failLogSafe(diagnostic,
+                "Preconditions.checkState(param != \"string\", String.format(\"constant %s\", param));");
+        failLogSafe(diagnostic, "Preconditions.checkNotNull(param, String.format(\"constant %s\", param));");
     }
 }


### PR DESCRIPTION
This provides a more accurate failure message when logsafe
preconditions fail to use constant strings.
Suppressing guava preconditions constant string validation will
no longer also suppress validation for logsafe preconditions.