### PR TITLE
[improvement] IntelliJ automatically wraps at 120 characters

### DIFF
--- a/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
+++ b/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
@@ -116,12 +116,14 @@
           <option name="OPTIMIZE_IMPORTS_ON_THE_FLY" value="true" />
           <option name="PARENT_SETTINGS_INSTALLED" value="true" />
           <option name="RESOURCE_LIST_WRAP" value="5" />
+          <option name="RIGHT_MARGIN" value="120" />
           <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
           <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
           <option name="TERNARY_OPERATION_WRAP" value="5" />
           <option name="THROWS_KEYWORD_WRAP" value="1" />
           <option name="THROWS_LIST_WRAP" value="1" />
           <option name="WHILE_BRACE_FORCE" value="3" />
+          <option name="WRAP_ON_TYPING" value="1" />
           <arrangement>
             <rules>
               <section>


### PR DESCRIPTION
Corrected version of #464 

Wraps at 120 lines, tested by importing locally.