### PR TITLE
[improvement] Allow disabling com.palantir.baseline-versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,23 +229,19 @@ dependencyRecommendations {
 Adds the following tasks:
 
 - `checkVersionsProps` - A catch-all task to lint your versions.props file.
-- `checkBomConflict`<sup>†</sup> - Ensures your versions.props pins don't force the same version that is already recommended by a BOM.
+- `checkBomConflict` - Ensures your versions.props pins don't force the same version that is already recommended by a BOM.
 - `checkNoUnusedPin` - Ensures all versions in your versions.props correspond to an actual gradle dependency.
 
 Run `./gradlew checkVersionsProps --fix` to solve the problems flagged by the above tasks.
 
-<small>_† `checkBomConflict` only exists if `nebula.dependency-recommender` wasn't disabled; please see below_</small> 
+### Turning it off
 
-### Configuration
-
-You can disable `nebula.dependency-recommender` by setting the following project property in `gradle.properties`:
+When using the `com.palantir.baseline` plugin, you can disable just `com.palantir.baseline-versions` without having to stop applying the main plugin. To do this, set the following project property in `gradle.properties`:
 ```diff
-+com.palantir.baseline-versions.disable-nebula
++com.palantir.baseline-versions.disable
 ```
 
-This is a temporary solution, intended to facilitate a move towards managing versions using [gradle constraints](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:dependency_constraints), which are safer.
-
-In that mode, `versions.props` is still considered the source for your versions, and consequently the plugin still offers some of the linting tasks, but you are responsible for configuring version constraints based on the contents of `versions.props` (via some other plugin).
+This is intended to facilitate a move towards managing versions using [gradle constraints](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:dependency_constraints), which are safer.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Run `./gradlew checkVersionsProps --fix` to solve the problems flagged by the ab
 
 When using the `com.palantir.baseline` plugin, you can disable just `com.palantir.baseline-versions` without having to stop applying the main plugin. To do this, set the following project property in `gradle.properties`:
 ```diff
-+com.palantir.baseline-versions.disable
++com.palantir.baseline-versions.disable = true
 ```
 
 This is intended to facilitate a move towards managing versions using [gradle constraints](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:dependency_constraints), which are safer.

--- a/README.md
+++ b/README.md
@@ -229,10 +229,23 @@ dependencyRecommendations {
 Adds the following tasks:
 
 - `checkVersionsProps` - A catch-all task to lint your versions.props file.
-- `checkBomConflict` - Ensures your versions.props pins don't force the same version that is already recommended by a BOM.
+- `checkBomConflict`<sup>†</sup> - Ensures your versions.props pins don't force the same version that is already recommended by a BOM.
 - `checkNoUnusedPin` - Ensures all versions in your versions.props correspond to an actual gradle dependency.
 
 Run `./gradlew checkVersionsProps --fix` to solve the problems flagged by the above tasks.
+
+<small>_† `checkBomConflict` only exists if `nebula.dependency-recommender` wasn't disabled; please see below_</small> 
+
+### Configuration
+
+You can disable `nebula.dependency-recommender` by setting the following project property in `gradle.properties`:
+```diff
++com.palantir.baseline-versions.disable-nebula
+```
+
+This is a temporary solution, intended to facilitate a move towards managing versions using [gradle constraints](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:dependency_constraints), which are safer.
+
+In that mode, `versions.props` is still considered the source for your versions, and consequently the plugin still offers some of the linting tasks, but you are responsible for configuring version constraints based on the contents of `versions.props` (via some other plugin).
 
 ### Troubleshooting
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
@@ -22,6 +22,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
 
 class BaselineVersionsIntegrationTest extends AbstractPluginTest {
 
@@ -250,14 +251,21 @@ class BaselineVersionsIntegrationTest extends AbstractPluginTest {
         file('versions.props').text.trim() == "org.slf4j:* = 1.7.20"
     }
 
-    def 'Unused version should fail'() {
+    @Unroll
+    def 'Unused version should fail when core bom support = #coreBomSupport'() {
         when:
         setupVersionsProps("notused:atall = 42.42")
         buildFile << standardBuildFile(projectDir)
+        if (coreBomSupport) {
+            file('gradle.properties') << 'systemProp.nebula.features.coreBomSupport = true'
+        }
 
         then:
         buildAndFailWith("There are unused pins in your versions.props")
         buildWithFixWorks()
+
+        where:
+        coreBomSupport << [false, true]
     }
 
     def 'recommending bom version shouldn\'t fail even if bom recommends itself'() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
@@ -22,7 +22,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.Unroll
 
 class BaselineVersionsIntegrationTest extends AbstractPluginTest {
 
@@ -251,21 +250,14 @@ class BaselineVersionsIntegrationTest extends AbstractPluginTest {
         file('versions.props').text.trim() == "org.slf4j:* = 1.7.20"
     }
 
-    @Unroll
-    def 'Unused version should fail when core bom support = #coreBomSupport'() {
+    def 'Unused version should fail'() {
         when:
         setupVersionsProps("notused:atall = 42.42")
         buildFile << standardBuildFile(projectDir)
-        if (coreBomSupport) {
-            file('gradle.properties') << 'systemProp.nebula.features.coreBomSupport = true'
-        }
 
         then:
         buildAndFailWith("There are unused pins in your versions.props")
         buildWithFixWorks()
-
-        where:
-        coreBomSupport << [false, true]
     }
 
     def 'recommending bom version shouldn\'t fail even if bom recommends itself'() {


### PR DESCRIPTION
## Before this PR

After #465, if `coreBomSupport` was turned on (`nebula.dependency-recommender` feature). then `BaselineVersions` would only apply dependency-recommender and do nothing else.

## After this PR

Always configure `checkVersionsProps` and `checkNoUnusedPin` regardless of whether nebula is being configured or not.

It's now possible to completely turn off (not applying) nebula.dependency-recommender by defining the project property:
```
com.palantir.baseline-versions.disable
```

e.g. 
```
./gradlew -Pcom.palantir.baseline-versions.disable
```
