### PR TITLE
[improvement] Enforce guava and objects calls with no parameters and constant strings use logsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferSafeLoggingPreconditions`: Users should use the safe-logging versions of Precondition checks for standardization when there is equivalent functionality
     ```diff
     -com.google.common.base.Preconditions.checkNotNull(variable, "message");
-    -com.palantir.logsafe.Preconditions.checkNotNull(variable, "message"); // equivalent functionality is available in the safe-logging variant
+    +com.palantir.logsafe.Preconditions.checkNotNull(variable, "message"); // equivalent functionality is available in the safe-logging variant
     ```
 - `ShutdownHook`: Applications should not use `Runtime#addShutdownHook`.
 - `SwitchStatementDefaultCase`: Switch statements should avoid using default cases. Default cases prevent the [MissingCasesInEnumSwitch](http://errorprone.info/bugpattern/MissingCasesInEnumSwitch.html) check from detecting when an enum value is not explicitly handled. This check is important to help avoid incorrect behavior when new enum values are introduced.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
     -throw new RuntimeException("explanation", e); // this message will be redacted when logs are collected
     +throw new SafeRuntimeException("explanation", e); // this message will be preserved (allowing easier debugging)
     ```
+- `PreferSafeLoggingPreconditions`: Users should use the safe-logging versions of Precondition checks for standardization when there is equivalent functionality
+    ```diff
+    -com.google.common.base.Preconditions.checkNotNull(variable, "message");
+    -com.palantir.logsafe.Preconditions.checkNotNull(variable, "message"); // equivalent functionality is available in the safe-logging variant
+    ```
 - `ShutdownHook`: Applications should not use `Runtime#addShutdownHook`.
 - `SwitchStatementDefaultCase`: Switch statements should avoid using default cases. Default cases prevent the [MissingCasesInEnumSwitch](http://errorprone.info/bugpattern/MissingCasesInEnumSwitch.html) check from detecting when an enum value is not explicitly handled. This check is important to help avoid incorrect behavior when new enum values are introduced.
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -1,0 +1,105 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "PreferSafeLoggingPreconditions",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        category = BugPattern.Category.ONE_OFF,
+        severity = BugPattern.SeverityLevel.SUGGESTION,
+        summary = "Precondition and similar checks with a constant message and no parameters should use equivalent "
+                + "checks from com.palantir.logsafe.Preconditions for standardization as functionality is the same.")
+public final class PreferSafeLoggingPreconditions extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
+            new CompileTimeConstantExpressionMatcher();
+
+    private static final String LOGSAFE_NAME = "com.palantir.logsafe.Preconditions";
+    private static final Matcher<ExpressionTree> PRECONDITIONS_MATCHER = MethodMatchers.staticMethod()
+            .onClass("com.google.common.base.Preconditions")
+            .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull"));
+    private static final Matcher<ExpressionTree> OBJECTS_MATCHER = MethodMatchers.staticMethod()
+            .onClass("java.util.Objects")
+            .withNameMatching(Pattern.compile("requireNonNull"));
+
+    private static final String DESCRIPTION_MESSAGE =
+            "The call can be replaced with an equivalent one from com.palantir.logsafe.Preconditions for "
+                    + "standardization as the functionality is the same.";
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (TestCheckUtils.isTestCode(state)) {
+            return Description.NO_MATCH;
+        }
+
+        boolean matchPreconditions = PRECONDITIONS_MATCHER.matches(tree, state);
+        boolean matchObjects = OBJECTS_MATCHER.matches(tree, state);
+
+        if (!matchPreconditions && !matchObjects) {
+            return Description.NO_MATCH;
+        }
+
+        List<? extends ExpressionTree> args = tree.getArguments();
+        if (args.size() > 2) {
+            return Description.NO_MATCH;
+        }
+
+        if (args.size() == 2) {
+            ExpressionTree messageArg = args.get(1);
+            boolean isStringType = ASTHelpers.isSameType(
+                    ASTHelpers.getType(messageArg),
+                    state.getTypeFromString("java.lang.String"),
+                    state);
+            if (!isStringType || !compileTimeConstExpressionMatcher.matches(messageArg, state)) {
+                return Description.NO_MATCH;
+            }
+        }
+
+        Description.Builder description = buildDescription(tree).setMessage(DESCRIPTION_MESSAGE);
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        String qualifiedClassName = SuggestedFixes.qualifyType(state, fix, LOGSAFE_NAME);
+        if (matchPreconditions) {
+            String replacement = String.format("%s.%s", qualifiedClassName, ASTHelpers.getSymbol(tree).name);
+            fix.replace(tree.getMethodSelect(), replacement);
+            return description.addFix(fix.build()).build();
+        } else {
+            String replacement = String.format("%s.%s", qualifiedClassName, "checkNotNull");
+            fix.replace(tree.getMethodSelect(), replacement);
+            return description.addFix(fix.build()).build();
+        }
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -57,7 +57,7 @@ public final class PreferSafeLoggingPreconditions extends BugChecker implements 
                             .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull")),
                     MethodMatchers.staticMethod()
                             .onClass("java.util.Objects")
-                            .withNameMatching(Pattern.compile("requireNonNull")));
+                            .named("requireNonNull"));
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
@@ -99,6 +99,7 @@ public final class PreferSafeLoggingPreconditions extends BugChecker implements 
 
     private static String getLogSafeMethodName(MethodSymbol methodSymbol) {
         String name = methodSymbol.name.toString();
+        // Check to handle the java.util.Objects.requireNonNull case
         if (name.equals("requireNonNull")) {
             return "checkNotNull";
         }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.common.collect.Streams;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.matchers.JUnitMatchers;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ClassTree;
+
+final class TestCheckUtils {
+
+    private TestCheckUtils() {
+        // utility class
+    }
+
+    static boolean isTestCode(VisitorState state) {
+        return Streams.stream(state.getPath().iterator())
+                .filter(ancestor -> ancestor instanceof ClassTree)
+                .anyMatch(ancestor -> Matchers
+                        .anyOf(JUnitMatchers.hasJUnit4TestCases, hasJUnit5TestCases)
+                        .matches((ClassTree) ancestor, state));
+    }
+
+    private static final Matcher<ClassTree> hasJUnit5TestCases =
+            Matchers.hasMethod(Matchers.hasAnnotationOnAnyOverriddenMethod("org.junit.jupiter.api.Test"));
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditionsTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditionsTests.java
@@ -1,0 +1,246 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class PreferSafeLoggingPreconditionsTests {
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(PreferSafeLoggingPreconditions.class, getClass());
+    }
+
+    @Test
+    public void testObjectsRequireNonNull() {
+        failObjects("Objects.requireNonNull(param);");
+    }
+
+    @Test
+    public void testObjectsRequireNonNullConstantString() {
+        failObjects("Objects.requireNonNull(param, \"constant\");");
+    }
+
+    @Test
+    public void testObjectsRequireNonNullNonConstantString() {
+        passObjects("Objects.requireNonNull(param, String.format(\"constant %s\", param));");
+    }
+
+    @Test
+    public void testObjectsRequireNonNullStringSupplier() {
+        passObjects("Objects.requireNonNull(param, () -> \"test\");");
+    }
+
+    @Test
+    public void testPreconditionsCheckArgumentNoParams() {
+        failGuava("Preconditions.checkArgument(param != \"string\");");
+    }
+
+    @Test
+    public void testPreconditionsCheckArgumentConstantStringNoParams() {
+        failGuava("Preconditions.checkArgument(param != \"string\", \"constant\");");
+    }
+
+    @Test
+    public void testPreconditionsCheckArgumentNonConstantStringNoParams() {
+        passGuava("Preconditions.checkArgument(param != \"string\", String.format(\"constant %s\", param));");
+    }
+
+    @Test
+    public void testPreconditionsCheckArgumentParams() {
+        passGuava("Preconditions.checkArgument(param != \"string\", \"message %s\", \"a\");");
+    }
+
+    @Test
+    public void testPreconditionsCheckStateNoParams() {
+        failGuava("Preconditions.checkState(param != \"string\");");
+    }
+
+    @Test
+    public void testPreconditionsCheckStateConstantStringNoParams() {
+        failGuava("Preconditions.checkState(param != \"string\", \"constant\");");
+    }
+
+    @Test
+    public void testPreconditionsCheckStateNonConstantStringNoParams() {
+        passGuava("Preconditions.checkState(param != \"string\", String.format(\"constant %s\", param));");
+    }
+
+    @Test
+    public void testPreconditionsCheckStateParams() {
+        passGuava("Preconditions.checkState(param != \"string\", \"message %s\", \"a\");");
+    }
+
+    @Test
+    public void testPreconditionsCheckNotNullNoParams() {
+        // CHECKSTYLE:OFF
+        failGuava("Preconditions.checkNotNull(param);");
+        // CHECKSTYLE:ON
+    }
+
+    @Test
+    public void testPreconditionsCheckNotNullConstantStringNoParams() {
+        failGuava("Preconditions.checkNotNull(param, \"constant\");");
+    }
+
+    @Test
+    public void testPreconditionsCheckNotNullNonConstantStringNoParams() {
+        passGuava("Preconditions.checkNotNull(param, String.format(\"constant %s\", param));");
+    }
+
+    @Test
+    public void testPreconditionsCheckNotNullParams() {
+        passGuava("Preconditions.checkNotNull(param, \"message %s\", \"a\");");
+    }
+
+    @Test
+    public void testPreconditionsAutoFixShortNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "import com.google.common.base.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    Preconditions.checkState(param != \"string\", \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.google.common.base.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testPreconditionsAutoFixFullNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "class Test {",
+                "  void f(String param) {",
+                "    com.google.common.base.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    com.google.common.base.Preconditions.checkState(param != \"string\", \"constant\");",
+                "    com.google.common.base.Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    Preconditions.checkState(param != \"string\", \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testObjectsAutoFixShortNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "import java.util.Objects;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Objects.requireNonNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "import java.util.Objects;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testObjectsAutoFixFullNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "class Test {",
+                "  void f(String param) {",
+                "    java.util.Objects.requireNonNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    private void passObjects(String precondition) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import java.util.Objects;",
+                "class Test {",
+                "  void f(String param) {",
+                "    " + precondition,
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    private void passGuava(String precondition) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import com.google.common.base.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    " + precondition,
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    private void failObjects(String precondition) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import java.util.Objects;",
+                "class Test {",
+                "  void f(String param) {",
+                "    // BUG: Diagnostic contains: call can be replaced",
+                "    " + precondition,
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    private void failGuava(String precondition) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import com.google.common.base.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    // BUG: Diagnostic contains: call can be replaced",
+                "    " + precondition,
+                "  }",
+                "}")
+                .doTest();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditionsTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditionsTests.java
@@ -157,6 +157,64 @@ public final class PreferSafeLoggingPreconditionsTests {
     }
 
     @Test
+    public void testMixedGuavaPreconditionsFullNamesAndLogSafeShortNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    com.google.common.base.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    com.google.common.base.Preconditions.checkState(param != \"string\", \"constant\");",
+                "    com.google.common.base.Preconditions.checkNotNull(param, \"constant\");",
+                "    Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    Preconditions.checkState(param != \"string\", \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    Preconditions.checkState(param != \"string\", \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "    Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    Preconditions.checkState(param != \"string\", \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testMixedGuavaPreconditionsShortNamesAndLogSafeFullNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "import com.google.common.base.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    Preconditions.checkState(param != \"string\", \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.google.common.base.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
     public void testObjectsAutoFixShortNames() {
         BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
                 "Test.java",
@@ -189,6 +247,100 @@ public final class PreferSafeLoggingPreconditionsTests {
                 "import com.palantir.logsafe.Preconditions;",
                 "class Test {",
                 "  void f(String param) {",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testMixedObjectsFullNamesAndLogSafeShortNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    java.util.Objects.requireNonNull(param, \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testMixedObjectsShortNamesAndLogSafeFullNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "import java.util.Objects;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Objects.requireNonNull(param, \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "import java.util.Objects;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testMixedGuavaPreconditionsAndObjectsAutoFixShortNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "import com.google.common.base.Preconditions;",
+                "import java.util.Objects;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Objects.requireNonNull(param, \"constant\");",
+                "    Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    Preconditions.checkState(param != \"string\", \"constant\");",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.google.common.base.Preconditions;",
+                "import java.util.Objects;",
+                "class Test {",
+                "  void f(String param) {",
+                "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
+                "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testMixedGuavaPreconditionsAndObjectsAutoFixFullNames() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferSafeLoggingPreconditions(), getClass()).addInputLines(
+                "Test.java",
+                "class Test {",
+                "  void f(String param) {",
+                "    java.util.Objects.requireNonNull(param, \"constant\");",
+                "    com.google.common.base.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    com.google.common.base.Preconditions.checkState(param != \"string\", \"constant\");",
+                "    com.google.common.base.Preconditions.checkNotNull(param, \"constant\");",
+                "  }",
+                "}").addOutputLines(
+                "Test.java",
+                "import com.palantir.logsafe.Preconditions;",
+                "class Test {",
+                "  void f(String param) {",
+                "    Preconditions.checkNotNull(param, \"constant\");",
+                "    Preconditions.checkArgument(param != \"string\", \"constant\");",
+                "    Preconditions.checkState(param != \"string\", \"constant\");",
                 "    Preconditions.checkNotNull(param, \"constant\");",
                 "  }",
                 "}").doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -65,6 +65,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 .configure(ErrorProneOptions.class, errorProneOptions -> {
                                     errorProneOptions.check("Slf4jLogsafeArgs", CheckSeverity.OFF);
                                     errorProneOptions.check("PreferSafeLoggableExceptions", CheckSeverity.OFF);
+                                    errorProneOptions.check("PreferSafeLoggingPreconditions", CheckSeverity.OFF);
                                 }));
             });
 


### PR DESCRIPTION
## Before this PR
There is no standardization in the use of basic calls to verify conditions like guava's Preconditions.check* or Objects.requireNonNull.

## After this PR
Simple use cases of guava Preconditions.check* and Objects.requireNonNull are now required to be changed to use logsafe variants. This will help to standardize calls where it is clear there can be a direct one-for-one replacement made with logsafe calls.