### PR TITLE
Improve error prone bug catcher performance

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArg.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArg.java
@@ -25,7 +25,6 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -44,17 +43,13 @@ public final class DangerousThrowableMessageSafeArg extends BugChecker
 
     private static final long serialVersionUID = 1L;
 
-    private static final Matcher<ExpressionTree> SAFEARG_FACTORY_METHOD =
-            Matchers.anyOf(
-                    MethodMatchers.staticMethod()
-                            .onClass("com.palantir.logsafe.SafeArg")
-                            .named("of"));
+    private static final Matcher<ExpressionTree> SAFEARG_FACTORY_METHOD = MethodMatchers.staticMethod()
+            .onClass("com.palantir.logsafe.SafeArg")
+            .named("of");
 
-    private static final Matcher<ExpressionTree> THROWABLE_MESSAGE_METHOD =
-            Matchers.anyOf(
-                    MethodMatchers.instanceMethod()
-                            .onDescendantOf(Throwable.class.getName())
-                            .named("getMessage"));
+    private static final Matcher<ExpressionTree> THROWABLE_MESSAGE_METHOD = MethodMatchers.instanceMethod()
+            .onDescendantOf(Throwable.class.getName())
+            .named("getMessage");
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GuavaPreconditionsMessageFormat.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GuavaPreconditionsMessageFormat.java
@@ -24,7 +24,6 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -40,11 +39,9 @@ public final class GuavaPreconditionsMessageFormat extends PreconditionsMessageF
 
     private static final long serialVersionUID = 1L;
 
-    private static final Matcher<ExpressionTree> GUAVA_PRECONDITIONS_METHODS =
-            Matchers.anyOf(
-                    MethodMatchers.staticMethod()
-                            .onClassAny("com.google.common.base.Preconditions")
-                            .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull")));
+    private static final Matcher<ExpressionTree> GUAVA_PRECONDITIONS_METHODS = MethodMatchers.staticMethod()
+            .onClassAny("com.google.common.base.Preconditions")
+            .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull"));
 
     public GuavaPreconditionsMessageFormat() {
         super(GUAVA_PRECONDITIONS_METHODS);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessage.java
@@ -25,7 +25,6 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -43,11 +42,9 @@ public final class LogSafePreconditionsConstantMessage
 
     private static final long serialVersionUID = 1L;
 
-    private static final Matcher<ExpressionTree> PRECONDITIONS_METHOD =
-            Matchers.anyOf(
-                    MethodMatchers.staticMethod()
-                            .onClass("com.palantir.logsafe.Preconditions")
-                            .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull")));
+    private static final Matcher<ExpressionTree> PRECONDITIONS_METHOD =  MethodMatchers.staticMethod()
+            .onClass("com.palantir.logsafe.Preconditions")
+            .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull"));
 
     private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
             new CompileTimeConstantExpressionMatcher();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsMessageFormat.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsMessageFormat.java
@@ -25,7 +25,6 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -43,11 +42,9 @@ public final class LogSafePreconditionsMessageFormat extends PreconditionsMessag
 
     private static final long serialVersionUID = 1L;
 
-    private static final Matcher<ExpressionTree> LOGSAFE_PRECONDITIONS_METHOD =
-            Matchers.anyOf(
-                    MethodMatchers.staticMethod()
-                            .onClassAny("com.palantir.logsafe.Preconditions")
-                            .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull")));
+    private static final Matcher<ExpressionTree> LOGSAFE_PRECONDITIONS_METHOD = MethodMatchers.staticMethod()
+            .onClassAny("com.palantir.logsafe.Preconditions")
+            .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull"));
 
     public LogSafePreconditionsMessageFormat() {
         super(LOGSAFE_PRECONDITIONS_METHOD);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
@@ -25,7 +25,6 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -43,10 +42,9 @@ public final class PreconditionsConstantMessage extends BugChecker implements Bu
     private static final long serialVersionUID = 1L;
 
     private static final Matcher<ExpressionTree> PRECONDITIONS_METHOD =
-            Matchers.anyOf(
-                    MethodMatchers.staticMethod()
-                            .onClass("com.google.common.base.Preconditions")
-                            .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull")));
+            MethodMatchers.staticMethod()
+                    .onClass("com.google.common.base.Preconditions")
+                    .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull"));
 
     private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
             new CompileTimeConstantExpressionMatcher();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -72,10 +72,6 @@ public final class PreferSafeLoggingPreconditions extends BugChecker implements 
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (TestCheckUtils.isTestCode(state)) {
-            return Description.NO_MATCH;
-        }
-
         if (!METHOD_MATCHER.matches(tree, state)) {
             return Description.NO_MATCH;
         }
@@ -94,6 +90,10 @@ public final class PreferSafeLoggingPreconditions extends BugChecker implements 
             if (!isStringType || !compileTimeConstExpressionMatcher.matches(messageArg, state)) {
                 return Description.NO_MATCH;
             }
+        }
+
+        if (TestCheckUtils.isTestCode(state)) {
+            return Description.NO_MATCH;
         }
 
         SuggestedFix.Builder fix = SuggestedFix.builder();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessage.java
@@ -26,7 +26,6 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
@@ -46,11 +45,9 @@ public final class Slf4jConstantLogMessage extends BugChecker implements MethodI
 
     private static final long serialVersionUID = 1L;
 
-    private static final Matcher<ExpressionTree> LOG_METHOD =
-            Matchers.anyOf(
-                    MethodMatchers.instanceMethod()
-                            .onDescendantOf("org.slf4j.Logger")
-                            .withNameMatching(Pattern.compile("trace|debug|info|warn|error")));
+    private static final Matcher<ExpressionTree> LOG_METHOD = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.slf4j.Logger")
+            .withNameMatching(Pattern.compile("trace|debug|info|warn|error"));
 
     private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
             new CompileTimeConstantExpressionMatcher();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -26,7 +26,6 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
@@ -46,11 +45,9 @@ public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocati
 
     private static final long serialVersionUID = 1L;
 
-    private static final Matcher<ExpressionTree> LOG_METHOD =
-            Matchers.anyOf(
-                    MethodMatchers.instanceMethod()
-                            .onDescendantOf("org.slf4j.Logger")
-                            .withNameMatching(Pattern.compile("trace|debug|info|warn|error")));
+    private static final Matcher<ExpressionTree> LOG_METHOD = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.slf4j.Logger")
+            .withNameMatching(Pattern.compile("trace|debug|info|warn|error"));
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {


### PR DESCRIPTION
Updated checks to perform easier validation first, deferring more
involved checks (e.g. isTestCode) until we have validated that
the check is likely to be relevant.