### PR TITLE
[fix] Correct prioritisation of versions.props to match nebula logic

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -16,10 +16,13 @@
 
 package com.palantir.baseline.plugins.versions;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Comparator;
 import java.util.Set;
 import java.util.stream.Collectors;
 import netflix.nebula.dependency.recommender.DependencyRecommendationsPlugin;
@@ -161,5 +164,27 @@ public final class BaselineVersions implements Plugin<Project> {
                     }
                 })
                 .collect(Collectors.toSet());
+    }
+
+    /**
+     * Compares {@code versions.props} matchers by weight. Higher weight means the matcher is more specific.
+     * For example,
+     * <pre>
+     *     com.google.guava:guava
+     * </pre>
+     * is more specific than
+     * <pre>
+     *     com.google.guava:*
+     * </pre>
+     */
+    static final Comparator<String> VERSIONS_PROPS_ENTRY_SPECIFIC_COMPARATOR =
+            Comparator.comparing(BaselineVersions::versionsPropsMatcherWeight);
+
+    /**
+     * The weight of a matcher in {@code versions.props} according to the disambiguation logic defined in
+     * {@code nebula.dependency-recommender}.
+     */
+    private static int versionsPropsMatcherWeight(String propertiesLine) {
+        return Streams.stream(Splitter.on("*").split(propertiesLine)).mapToInt(String::length).sum();
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -16,9 +16,8 @@
 
 package com.palantir.baseline.plugins.versions;
 
-import com.google.common.base.Splitter;
+import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -187,7 +186,7 @@ public final class BaselineVersions implements Plugin<Project> {
      *
      * This matches the logic in {@link FuzzyVersionResolver}.
      */
-    private static int versionsPropsMatcherWeight(String propertiesLine) {
-        return Streams.stream(Splitter.on("*").split(propertiesLine)).mapToInt(String::length).sum();
+    private static int versionsPropsMatcherWeight(String matcher) {
+        return CharMatcher.isNot('*').countIn(matcher);
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import netflix.nebula.dependency.recommender.DependencyRecommendationsPlugin;
 import netflix.nebula.dependency.recommender.RecommendationStrategies;
+import netflix.nebula.dependency.recommender.provider.FuzzyVersionResolver;
 import netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -183,6 +184,8 @@ public final class BaselineVersions implements Plugin<Project> {
     /**
      * The weight of a matcher in {@code versions.props} according to the disambiguation logic defined in
      * {@code nebula.dependency-recommender}.
+     *
+     * This matches the logic in {@link FuzzyVersionResolver}.
      */
     private static int versionsPropsMatcherWeight(String propertiesLine) {
         return Streams.stream(Splitter.on("*").split(propertiesLine)).mapToInt(String::length).sum();

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 import netflix.nebula.dependency.recommender.DependencyRecommendationsPlugin;
 import netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer;
@@ -121,11 +122,11 @@ public class CheckBomConflictTask extends DefaultTask {
                             .filter(artifactName -> !recommendationConflicts.contains(artifactName))
                             .map(artifactName -> Pair.of(artifactName, propName));
                 })
+                // Resolve conflicts by choosing the more specific entry
                 .collect(Collectors.toMap(
                         Pair::getLeft,
                         Pair::getRight,
-                        // Resolve conflicts by choosing the latest matching entry, because that's how nebula works.
-                        (propName1, propName2) -> propName2));
+                        BinaryOperator.maxBy(BaselineVersions.VERSIONS_PROPS_ENTRY_SPECIFIC_COMPARATOR)));
 
         Set<String> versionPropsVindicatedLines = ImmutableSet.copyOf(resolvedConflicts.values());
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
@@ -93,13 +93,13 @@ public class CheckNoUnusedPinTask extends DefaultTask {
                 .map(Pair::getLeft)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        // Remove the force that each artifact uses. This will be the last matching force, if any.
+        // Remove the force that each artifact uses. This will be the most specific force.
         artifacts.forEach(artifact -> {
             Optional<String> matching = versionsPropToPredicate
                     .stream()
                     .filter(pair -> pair.getRight().test(artifact))
                     .map(Entry::getKey)
-                    .reduce((first, second) -> second);
+                    .max(BaselineVersions.VERSIONS_PROPS_ENTRY_SPECIFIC_COMPARATOR);
             matching.ifPresent(unusedForces::remove);
         });
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
@@ -232,7 +232,7 @@ class BaselineVersionsIntegrationTest extends AbstractPluginTest {
         buildSucceed()
     }
 
-    def 'Last matching version should win'() {
+    def 'Most specific matching version should win'() {
         when:
         setupVersionsProps("""
             org.slf4j:slf4j-api = 1.7.25
@@ -245,9 +245,9 @@ class BaselineVersionsIntegrationTest extends AbstractPluginTest {
         }""".stripIndent()
 
         then:
-        buildAndFailWith('There are unused pins in your versions.props: \n[org.slf4j:slf4j-api]')
+        buildAndFailWith('There are unused pins in your versions.props: \n[org.slf4j:*]')
         buildWithFixWorks()
-        file('versions.props').text.trim() == "org.slf4j:* = 1.7.20"
+        file('versions.props').text.trim() == "org.slf4j:slf4j-api = 1.7.25"
     }
 
     def 'Unused version should fail'() {


### PR DESCRIPTION
## Before this PR

`versions.props` property names (matchers) were incorrectly being prioritised when deciding which `versions.props` line is most specific and matches a given dependency.

The current logic assumes that the last line to match a dependency wins.

## After this PR

Implemented the logic that `nebula.dependency-recommender` [actually uses](https://github.com/nebula-plugins/nebula-dependency-recommender-plugin/blob/dae66d3f5f9fb3b656ddf5348cd0527e000b4340/src/main/groovy/netflix/nebula/dependency/recommender/provider/FuzzyVersionResolver.java#L77), which is to weigh the matchers by "number of characters which are not globs, i.e. `*`".
The most specific matcher is the one with the highest weight.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
