### PR TITLE
[feature] New 'com.palantir.baseline-reproducibility' plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _Baseline is a family of Gradle plugins for configuring Java projects with sensi
 | `com.palantir.baseline-circleci`         | [CircleCI](https://circleci.com/) integration using `$CIRCLE_ARTIFACTS` and `$CIRCLE_TEST_REPORTS` dirs
 | `com.palantir.baseline-versions`         | Source dependency versions from a `versions.props` file using [nebula dependency recommender](https://github.com/nebula-plugins/nebula-dependency-recommender-plugin)
 | `com.palantir.baseline-config`           | Config files for the above plugins
+| `com.palantir.baseline-reproducibility`  | Sensible defaults to ensure Jar, Tar and Zip tasks can be reproduced
 
 See also the [Baseline Java Style Guide and Best Practises](./docs).
 
@@ -289,3 +290,18 @@ spotless {
     }
 }
 ```
+
+## com.palantir.baseline-reproducibility
+
+This plugin is a shorthand for the following snippet, which opts-in to reproducible behaviour for all Gradle's Jar, Tar and Zip tasks. (Surprisingly, these tasks are not reproducible by default).
+
+```gradle
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+```
+
+It also warns if it detects usage of the [`nebula.info`](https://github.com/nebula-plugins/gradle-info-plugin) plugin which is known to violate the reproducibility of Jars by adding a 'Build-Date' entry to the MANIFEST.MF, which will be different on every run of `./gradlew jar`.
+
+_Complete byte-for-byte reproducibility is desirable because it enables the [Gradle build cache](https://docs.gradle.org/4.10/userguide/build_cache.html) to be much more effective._

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -46,6 +46,9 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineFormat.class);
             // TODO(dfox): enable this when it has been validated on a few real projects
             // proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);
+
+            // TODO(dfox): enable this when we've verified there are no unintended side-effects
+            // proj.getPluginManager().apply(BaselineReproducibility.class);
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.file.DuplicatesStrategy;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+
+/** Sensible defaults so that all Jar, Tar, Zip tasks can be deterministically reproduced. */
+public final class BaselineReproducibility implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getTasks().withType(AbstractArchiveTask.class).configureEach(t -> {
+            t.setPreserveFileTimestamps(false);
+            t.setReproducibleFileOrder(true);
+            t.setDuplicatesStrategy(DuplicatesStrategy.WARN);
+        });
+
+        project.getPluginManager().withPlugin("nebula.info", p -> {
+            project.getLogger().warn("Project '{}' applies the 'nebula.info' plugin "
+                    + "which breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF", p);
+        });
+    }
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
@@ -33,8 +33,8 @@ public final class BaselineReproducibility implements Plugin<Project> {
         });
 
         project.getPluginManager().withPlugin("nebula.info", p -> {
-            project.getLogger().warn("Project '{}' applies the 'nebula.info' plugin "
-                    + "which breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF", p);
+            project.getLogger().warn("Please remove the 'nebula.info' plugin from '{}' as it breaks "
+                    + "reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF", p);
         });
     }
 }

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-reproducibility.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-reproducibility.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineReproducibility


### PR DESCRIPTION
## Before this PR

I discovered that in most of our projects, running `./gradlew jar` twice on a completely clean checkout results in jars with different hashes. This defeats any kind of fancy gradle caching we might want to enable in the future.

## After this PR

Projects can `apply plugin: 'com.palantir.baseline-reproducibility'` to opt-in to more sensible behaviour.