### PR TITLE
[fix] enable com.palantir.baseline-reproducibility by default (and fix logging)

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -44,11 +44,9 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineErrorProne.class);
             proj.getPluginManager().apply(BaselineVersions.class);
             proj.getPluginManager().apply(BaselineFormat.class);
+            proj.getPluginManager().apply(BaselineReproducibility.class);
             // TODO(dfox): enable this when it has been validated on a few real projects
             // proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);
-
-            // TODO(dfox): enable this when we've verified there are no unintended side-effects
-            // proj.getPluginManager().apply(BaselineReproducibility.class);
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
@@ -32,9 +32,9 @@ public final class BaselineReproducibility implements Plugin<Project> {
             t.setDuplicatesStrategy(DuplicatesStrategy.WARN);
         });
 
-        project.getPluginManager().withPlugin("nebula.info", p -> {
-            project.getLogger().warn("Please remove the 'nebula.info' plugin from '{}' as it breaks "
-                    + "reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF", p);
+        project.getPluginManager().withPlugin("nebula.info", plugin -> {
+            project.getLogger().warn("Please remove the 'nebula.info' plugin from {} as it breaks "
+                    + "reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF", project);
         });
     }
 }


### PR DESCRIPTION
## Before this PR

You had to explicitly opt-in to get this plugin. Also our logging was kinda borked:

```

> Configure project :log-receiver
Please remove the 'nebula.info' plugin from 'org.gradle.api.internal.plugins.DefaultAppliedPlugin@63f5d60' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF

> Configure project :log-receiver-api
Please remove the 'nebula.info' plugin from 'org.gradle.api.internal.plugins.DefaultAppliedPlugin@21c97961' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF
Please remove the 'nebula.info' plugin from 'org.gradle.api.internal.plugins.DefaultAppliedPlugin@2af840ec' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF
Please remove the 'nebula.info' plugin from 'org.gradle.api.internal.plugins.DefaultAppliedPlugin@7b343e79' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF
Please remove the 'nebula.info' plugin from 'org.gradle.api.internal.plugins.DefaultAppliedPlugin@6348089f' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF
```

## After this PR

Everyone will get the plugin

```
./gradlew tasks

> Configure project :log-receiver
Please remove the 'nebula.info' plugin from 'project ':log-receiver'' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF

> Configure project :log-receiver-api
Please remove the 'nebula.info' plugin from project ':log-receiver-api:log-receiver-api-jersey' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF
Please remove the 'nebula.info' plugin from project ':log-receiver-api:log-receiver-api-objects' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF
Please remove the 'nebula.info' plugin from project ':log-receiver-api:log-receiver-api-retrofit' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF
Please remove the 'nebula.info' plugin from project ':log-receiver-api:log-receiver-api-undertow' as it breaks reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF
```