### PR TITLE
Fix incorrect argument selection in ValidateConstantMessage

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     testCompile 'com.palantir.safe-logging:safe-logging'
     testCompile 'org.slf4j:slf4j-api'
     testCompile 'org.apache.commons:commons-lang3'
+    testCompile 'commons-lang:commons-lang'
     testCompile 'org.junit.jupiter:junit-jupiter-api'
 
     annotationProcessor 'com.google.auto.service:auto-service'

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ValidateConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ValidateConstantMessage.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
@@ -30,7 +31,6 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import java.util.List;
-import java.util.Optional;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -49,20 +49,54 @@ public final class ValidateConstantMessage extends BugChecker implements BugChec
     private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
             new CompileTimeConstantExpressionMatcher();
 
+    private static final ImmutableMap<String, Integer> VALIDATE_METHODS_MESSAGE_ARGS =
+            ImmutableMap.<String, Integer>builder()
+                    .put("exclusiveBetween", 4)
+                    .put("finite", 2)
+                    .put("inclusiveBetween", 4)
+                    .put("isAssignableFrom", 3)
+                    .put("isInstanceOf", 3)
+                    .put("isTrue", 2)
+                    .put("matchesPattern", 3)
+                    .put("noNullElements", 2)
+                    .put("notBlank", 2)
+                    .put("notEmpty", 2)
+                    .put("notNaN", 2)
+                    .put("notNull", 2)
+                    .put("validIndex", 3)
+                    .put("validState", 2)
+                    .put("allElementsOfType", 3) // commons-lang 2.x only
+                    .build();
+
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (!VALIDATE_METHODS.matches(tree, state)) {
             return Description.NO_MATCH;
         }
 
+        String methodName = ASTHelpers.getSymbol(tree).name.toString();
+        if (!VALIDATE_METHODS_MESSAGE_ARGS.containsKey(methodName)) {
+            return Description.NO_MATCH;
+        }
+
+        int messageArgNumber = VALIDATE_METHODS_MESSAGE_ARGS.get(methodName);
         List<? extends ExpressionTree> args = tree.getArguments();
 
-        Optional<? extends ExpressionTree> messageArg = args.stream()
-                .filter(arg -> ASTHelpers.isSameType(ASTHelpers.getType(arg),
-                        state.getTypeFromString("java.lang.String"), state))
-                .reduce((one, two) -> two);
+        if (args.size() < messageArgNumber) {
+            return Description.NO_MATCH;
+        }
 
-        if (!messageArg.isPresent() || compileTimeConstExpressionMatcher.matches(messageArg.get(), state)) {
+        ExpressionTree messageArg = args.get(messageArgNumber - 1);
+        boolean isStringType = ASTHelpers.isSameType(
+                ASTHelpers.getType(messageArg),
+                state.getTypeFromString("java.lang.String"),
+                state);
+        boolean isConstantString = compileTimeConstExpressionMatcher.matches(messageArg, state);
+        if (!isStringType || isConstantString) {
+            return Description.NO_MATCH;
+        }
+
+        if (TestCheckUtils.isTestCode(state)) {
             return Description.NO_MATCH;
         }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ValidateConstantMessageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ValidateConstantMessageTests.java
@@ -29,7 +29,640 @@ public final class ValidateConstantMessageTests {
         compilationHelper = CompilationTestHelper.newInstance(ValidateConstantMessage.class, getClass());
     }
 
-    private void test(String call) throws Exception {
+    @Test
+    public void testValidateIsTrueNoMessage() {
+        testPassBoth("Validate.isTrue(param != \"string\");");
+    }
+
+    @Test
+    public void testValidateIsTrueConstantMessageNoArgs() {
+        testPassBoth("Validate.isTrue(param != \"string\", \"constant\");");
+    }
+
+    @Test
+    public void testValidateIsTrueConstantMessageArgs() {
+        testPassLang3Only("Validate.isTrue(param != \"string\", \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateIsTrueNonConstantMessageNoArgs() {
+        testFailBoth("Validate.isTrue(param != \"string\", \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateIsTrueNonConstantMessageArgs() {
+        testFailLang3Only("Validate.isTrue(param != \"string\", \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateIsTrueNonConstantMessageDouble() {
+        testFailBoth("Validate.isTrue(param != \"string\", \"constant\" + param, 0.0);");
+    }
+
+    @Test
+    public void testValidateIsTrueNonConstantMessageLong() {
+        testFailBoth("Validate.isTrue(param != \"string\", \"constant\" + param, 123L);");
+    }
+
+    @Test
+    public void testValidateNotNullNoMessage() {
+        // CHECKSTYLE:OFF
+        testPassBoth("Validate.notNull(param);");
+        // CHECKSTYLE:ON
+    }
+
+    @Test
+    public void testValidateNotNullConstantMessageNoArgs() {
+        testPassBoth("Validate.notNull(param, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNotNullConstantMessageArgs() {
+        testPassLang3Only("Validate.notNull(param, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotNullNonConstantMessageNoArgs() {
+        testFailBoth("Validate.notNull(param, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNotNullNonConstantMessageArgs() {
+        testFailLang3Only("Validate.notNull(param, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyNoMessageArray() {
+        testPassBoth("Validate.notEmpty(arrayArg);");
+    }
+
+    @Test
+    public void testValidateNotEmptyConstantMessageArrayNoArgs() {
+        testPassBoth("Validate.notEmpty(arrayArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyConstantMessageArrayArgs() {
+        testPassLang3Only("Validate.notEmpty(arrayArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyNonConstantMessageArrayNoArgs() {
+        testFailBoth("Validate.notEmpty(arrayArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNotEmptyNonConstantMessageArrayArgs() {
+        testFailLang3Only("Validate.notEmpty(arrayArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyNoMessageCollection() {
+        testPassBoth("Validate.notEmpty(collectionArg);");
+    }
+
+    @Test
+    public void testValidateNotEmptyConstantMessageCollectionNoArgs() {
+        testPassBoth("Validate.notEmpty(collectionArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyConstantMessageCollectionArgs() {
+        testPassLang3Only("Validate.notEmpty(collectionArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyNonConstantMessageCollectionNoArgs() {
+        testFailBoth("Validate.notEmpty(collectionArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNotEmptyNonConstantMessageCollectionArgs() {
+        testFailLang3Only("Validate.notEmpty(collectionArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyNoMessageMap() {
+        testPassBoth("Validate.notEmpty(mapArg);");
+    }
+
+    @Test
+    public void testValidateNotEmptyConstantMessageMapNoArgs() {
+        testPassBoth("Validate.notEmpty(mapArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyConstantMessageMapArgs() {
+        testPassLang3Only("Validate.notEmpty(mapArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyNonConstantMessageMapNoArgs() {
+        testFailBoth("Validate.notEmpty(mapArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNotEmptyNonConstantMessageMapArgs() {
+        testFailLang3Only("Validate.notEmpty(mapArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyNoMessageChars() {
+        testPassBoth("Validate.notEmpty(stringArg);");
+    }
+
+    @Test
+    public void testValidateNotEmptyConstantMessageCharsNoArgs() {
+        testPassBoth("Validate.notEmpty(stringArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyConstantMessageCharsArgs() {
+        testPassLang3Only("Validate.notEmpty(stringArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotEmptyNonConstantMessageCharsNoArgs() {
+        testFailBoth("Validate.notEmpty(stringArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNotEmptyNonConstantMessageCharsArgs() {
+        testFailLang3Only("Validate.notEmpty(stringArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotBlankNoMessage() {
+        testPassLang3Only("Validate.notBlank(stringArg);");
+    }
+
+    @Test
+    public void testValidateNotBlankConstantMessageNoArgs() {
+        testPassLang3Only("Validate.notBlank(stringArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNotBlankConstantMessageArgs() {
+        testPassLang3Only("Validate.notBlank(stringArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotBlankNonConstantMessageNoArgs() {
+        testFailLang3Only("Validate.notBlank(stringArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNotBlankNonConstantMessageArgs() {
+        testFailLang3Only("Validate.notBlank(stringArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateNoNullElementsNoMessageIterable() {
+        testPassLang3Only("Validate.noNullElements(iterableArg);");
+    }
+
+    @Test
+    public void testValidateNoNullElementsConstantMessageIterableNoArgs() {
+        testPassLang3Only("Validate.noNullElements(iterableArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNoNullElementsConstantMessageIterableArgs() {
+        testPassLang3Only("Validate.noNullElements(iterableArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNoNullElementsNonConstantMessageIterableNoArgs() {
+        testFailLang3Only("Validate.noNullElements(iterableArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNoNullElementsNonConstantMessageIterableArgs() {
+        testFailLang3Only("Validate.noNullElements(iterableArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateNoNullElementsNoMessageArray() {
+        testPassBoth("Validate.noNullElements(arrayArg);");
+    }
+
+    @Test
+    public void testValidateNoNullElementsConstantMessageArrayNoArgs() {
+        testPassBoth("Validate.noNullElements(arrayArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNoNullElementsConstantMessageArrayArgs() {
+        testPassLang3Only("Validate.noNullElements(arrayArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNoNullElementsNonConstantMessageArrayNoArgs() {
+        testFailBoth("Validate.noNullElements(arrayArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNoNullElementsNonConstantMessageArrayArgs() {
+        testFailLang3Only("Validate.noNullElements(arrayArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateValidIndexNoMessageArray() {
+        testPassLang3Only("Validate.validIndex(arrayArg, 1);");
+    }
+
+    @Test
+    public void testValidateValidIndexConstantMessageArrayNoArgs() {
+        testPassLang3Only("Validate.validIndex(arrayArg, 1, \"constant\");");
+    }
+
+    @Test
+    public void testValidateValidIndexConstantMessageArrayArgs() {
+        testPassLang3Only("Validate.validIndex(arrayArg, 1, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateValidIndexNonConstantMessageArrayNoArgs() {
+        testFailLang3Only("Validate.validIndex(arrayArg, 1, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateValidIndexNonConstantMessageArrayArgs() {
+        testFailLang3Only("Validate.validIndex(arrayArg, 1, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateValidIndexNoMessageCollection() {
+        testPassLang3Only("Validate.validIndex(collectionArg, 1);");
+    }
+
+    @Test
+    public void testValidateValidIndexConstantMessageCollectionNoArgs() {
+        testPassLang3Only("Validate.validIndex(collectionArg, 1, \"constant\");");
+    }
+
+    @Test
+    public void testValidateValidIndexConstantMessageCollectionArgs() {
+        testPassLang3Only("Validate.validIndex(collectionArg, 1, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateValidIndexNonConstantMessageCollectionNoArgs() {
+        testFailLang3Only("Validate.validIndex(collectionArg, 1, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateValidIndexNonConstantMessageCollectionArgs() {
+        testFailLang3Only("Validate.validIndex(collectionArg, 1, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateValidIndexNoMessageChars() {
+        testPassLang3Only("Validate.validIndex(stringArg, 1);");
+    }
+
+    @Test
+    public void testValidateValidIndexConstantMessageCharsNoArgs() {
+        testPassLang3Only("Validate.validIndex(stringArg, 1, \"constant\");");
+    }
+
+    @Test
+    public void testValidateValidIndexConstantMessageCharsArgs() {
+        testPassLang3Only("Validate.validIndex(stringArg, 1, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateValidIndexNonConstantMessageCharsNoArgs() {
+        testFailLang3Only("Validate.validIndex(stringArg, 1, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateValidIndexNonConstantMessageCharsArgs() {
+        testFailLang3Only("Validate.validIndex(stringArg, 1, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateValidStateNoMessage() {
+        testPassLang3Only("Validate.validState(bArg);");
+    }
+
+    @Test
+    public void testValidateValidStateConstantMessageNoArgs() {
+        testPassLang3Only("Validate.validState(bArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateValidStateConstantMessageArgs() {
+        testPassLang3Only("Validate.validState(bArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateValidStateNonConstantMessageNoArgs() {
+        testFailLang3Only("Validate.validState(bArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateValidStateNonConstantMessageArgs() {
+        testFailLang3Only("Validate.validState(bArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateMatchesPatternNoMessage() {
+        testPassLang3Only("Validate.matchesPattern(stringArg, \"[A-Z]+\");");
+    }
+
+    @Test
+    public void testValidateMatchesPatternConstantMessageNoArgs() {
+        testPassLang3Only("Validate.matchesPattern(stringArg, \"[A-Z]+\", \"constant\");");
+    }
+
+    @Test
+    public void testValidateMatchesPatternConstantMessageArgs() {
+        testPassLang3Only("Validate.matchesPattern(stringArg, \"[A-Z]+\", \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateMatchesPatternNonConstantMessageNoArgs() {
+        testFailLang3Only("Validate.matchesPattern(stringArg, \"[A-Z]+\", \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateMatchesPatternNonConstantMessageArgs() {
+        testFailLang3Only("Validate.matchesPattern(stringArg, \"[A-Z]+\", \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotNanNoMessage() {
+        testPassLang3Only("Validate.notNaN(dArg);");
+    }
+
+    @Test
+    public void testValidateNotNanConstantMessageNoArgs() {
+        testPassLang3Only("Validate.notNaN(dArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateNotNanConstantMessageArgs() {
+        testPassLang3Only("Validate.notNaN(dArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateNotNanNonConstantMessageNoArgs() {
+        testFailLang3Only("Validate.notNaN(dArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateNotNanNonConstantMessageArgs() {
+        testFailLang3Only("Validate.notNaN(dArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateFiniteNoMessage() {
+        testPassLang3Only("Validate.finite(dArg);");
+    }
+
+    @Test
+    public void testValidateFiniteConstantMessageNoArgs() {
+        testPassLang3Only("Validate.finite(dArg, \"constant\");");
+    }
+
+    @Test
+    public void testValidateFiniteConstantMessageArgs() {
+        testPassLang3Only("Validate.finite(dArg, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateFiniteNonConstantMessageNoArgs() {
+        testFailLang3Only("Validate.finite(dArg, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateFiniteNonConstantMessageArgs() {
+        testFailLang3Only("Validate.finite(dArg, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNoMessageLong() {
+        testPassLang3Only("Validate.inclusiveBetween(0L, 100L, 50L);");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenConstantMessageLongNoArgs() {
+        testPassLang3Only("Validate.inclusiveBetween(0L, 100L, 50L, \"constant\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenConstantMessageLongArgs() {
+        testPassLang3Only("Validate.inclusiveBetween(0L, 100L, 50L, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNonConstantMessageLongNoArgs() {
+        testFailLang3Only("Validate.inclusiveBetween(0L, 100L, 50L, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNonConstantMessageLongArgs() {
+        testFailLang3Only("Validate.inclusiveBetween(0L, 100L, 50L, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNoMessageDouble() {
+        testPassLang3Only("Validate.inclusiveBetween(0.0, 1.0, 0.5);");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenConstantMessageDoubleNoArgs() {
+        testPassLang3Only("Validate.inclusiveBetween(0.0, 1.0, 0.5, \"constant\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenConstantMessageDoubleArgs() {
+        testPassLang3Only("Validate.inclusiveBetween(0.0, 1.0, 0.5, \"constant\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNonConstantMessageDoubleNoArgs() {
+        testFailLang3Only("Validate.inclusiveBetween(0.0, 1.0, 0.5, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNonConstantMessageDoubleArgs() {
+        testFailLang3Only("Validate.inclusiveBetween(0.0, 1.0, 0.5, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNoMessageComparable() {
+        testPassLang3Only("Validate.inclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE);");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenConstantMessageComparableNoArgs() {
+        testPassLang3Only("Validate.inclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, \"constant\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenConstantMessageComparableArgs() {
+        testPassLang3Only("Validate.inclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, \"constant %s\", "
+                + "\"arg\");");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNonConstantMessageComparableNoArgs() {
+        testFailLang3Only("Validate.inclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "
+                + "\"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateInclusiveBetweenNonConstantMessageComparableArgs() {
+        testFailLang3Only("Validate.inclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "
+                + "\"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNoMessageLong() {
+        testPassLang3Only("Validate.exclusiveBetween(0L, 100L, 50L);");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenConstantMessageLongNoArgs() {
+        testPassLang3Only("Validate.exclusiveBetween(0L, 100L, 50L, \"constant\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenConstantMessageLongArgs() {
+        testPassLang3Only("Validate.exclusiveBetween(0L, 100L, 50L, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNonConstantMessageLongNoArgs() {
+        testFailLang3Only("Validate.exclusiveBetween(0L, 100L, 50L, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNonConstantMessageLongArgs() {
+        testFailLang3Only("Validate.exclusiveBetween(0L, 100L, 50L, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNoMessageDouble() {
+        testPassLang3Only("Validate.exclusiveBetween(0.0, 1.0, 0.5);");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenConstantMessageDoubleNoArgs() {
+        testPassLang3Only("Validate.exclusiveBetween(0.0, 1.0, 0.5, \"constant\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenConstantMessageDoubleArgs() {
+        testPassLang3Only("Validate.exclusiveBetween(0.0, 1.0, 0.5, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNonConstantMessageDoubleNoArgs() {
+        testFailLang3Only("Validate.exclusiveBetween(0.0, 1.0, 0.5, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNonConstantMessageDoubleArgs() {
+        testFailLang3Only("Validate.exclusiveBetween(0.0, 1.0, 0.5, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNoMessageComparable() {
+        testPassLang3Only("Validate.exclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE);");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenConstantMessageComparableNoArgs() {
+        testPassLang3Only("Validate.exclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, \"constant\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenConstantMessageComparableArgs() {
+        testPassLang3Only("Validate.exclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, \"constant %s\", "
+                + "\"arg\");");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNonConstantMessageComparableNoArgs() {
+        testFailLang3Only("Validate.exclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "
+                + "\"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateExclusiveBetweenNonConstantMessageComparableArgs() {
+        testFailLang3Only("Validate.exclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "
+                + "\"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateIsInstanceOfNoMessage() {
+        testPassLang3Only("Validate.isInstanceOf(BigDecimal.class, BigDecimal.ONE);");
+    }
+
+    @Test
+    public void testValidateIsInstanceOfConstantMessageNoArgs() {
+        testPassLang3Only("Validate.isInstanceOf(BigDecimal.class, BigDecimal.ONE, \"constant\");");
+    }
+
+    @Test
+    public void testValidateIsInstanceOfConstantMessageArgs() {
+        testPassLang3Only("Validate.isInstanceOf(BigDecimal.class, BigDecimal.ONE, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateIsInstanceOfNonConstantMessageNoArgs() {
+        testFailLang3Only("Validate.isInstanceOf(BigDecimal.class, BigDecimal.ONE, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateIsInstanceOfNonConstantMessageArgs() {
+        testFailLang3Only("Validate.isInstanceOf(BigDecimal.class, BigDecimal.ONE, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateIsAssignableFromNoMessage() {
+        testPassLang3Only("Validate.isAssignableFrom(Object.class, BigDecimal.class);");
+    }
+
+    @Test
+    public void testValidateIsAssignableFromConstantMessageNoArgs() {
+        testPassLang3Only("Validate.isAssignableFrom(Object.class, BigDecimal.class, \"constant\");");
+    }
+
+    @Test
+    public void testValidateIsAssignableFromConstantMessageArgs() {
+        testPassLang3Only("Validate.isAssignableFrom(Object.class, BigDecimal.class, \"constant %s\", \"arg\");");
+    }
+
+    @Test
+    public void testValidateIsAssignableFromNonConstantMessageNoArgs() {
+        testFailLang3Only("Validate.isAssignableFrom(Object.class, BigDecimal.class, \"constant\" + param);");
+    }
+
+    @Test
+    public void testValidateIsAssignableFromNonConstantMessageArgs() {
+        testFailLang3Only("Validate.isAssignableFrom(Object.class, BigDecimal.class, \"constant\" + param, \"arg\");");
+    }
+
+    @Test
+    public void testValidateAllElementsOfTypeNoMessage() {
+        testPassLang2Only("Validate.allElementsOfType(collectionArg, BigDecimal.class);");
+    }
+
+    @Test
+    public void testValidateAllElementsOfTypeConstantMessageNoArgs() {
+        testPassLang2Only("Validate.allElementsOfType(collectionArg, BigDecimal.class, \"constant\");");
+    }
+
+    @Test
+    public void testValidateAllElementsOfTypeNonConstantMessageNoArgs() {
+        testFailLang2Only("Validate.allElementsOfType(collectionArg, BigDecimal.class, \"constant\" + param);");
+    }
+
+    private void testFailLang3Only(String call) {
         compilationHelper
                 .addSourceLines(
                         "Test.java",
@@ -48,100 +681,96 @@ public final class ValidateConstantMessageTests {
                 .doTest();
     }
 
-    @Test
-    public void positive() throws Exception {
-        test("Validate.isTrue(param != \"string\", String.format(\"constant %s\", param));");
-
-        test("Validate.isTrue(param != \"string\", \"constant\" + param);");
-        test("Validate.isTrue(param != \"string\", \"constant\" + param, 0.0);");
-        test("Validate.isTrue(param != \"string\", \"constant\" + param, 123L);");
-
-        test("Validate.notNull(param, \"constant\" + param);");
-
-        test("Validate.notEmpty(collectionArg, \"constant\" + param);");
-        test("Validate.notEmpty(arrayArg, \"constant\" + param);");
-        test("Validate.notEmpty(mapArg, \"constant\" + param);");
-        test("Validate.notEmpty(stringArg, \"constant\" + param);");
-
-        test("Validate.notBlank(stringArg, \"constant\" + param);");
-
-        test("Validate.noNullElements(arrayArg, \"constant\" + param);");
-        test("Validate.noNullElements(iterableArg, \"constant\" + param);");
-
-        test("Validate.validIndex(arrayArg, 1, \"constant\" + param);");
-        test("Validate.validIndex(collectionArg, 1, \"constant\" + param);");
-        test("Validate.validIndex(stringArg, 1, \"constant\" + param);");
-
-        test("Validate.validState(bArg, \"constant\" + param);");
-
-        test("Validate.matchesPattern(stringArg, \"[A-Z]+\", \"constant\" + param);");
-
-        test("Validate.notNaN(dArg, \"constant\" + param);");
-        test("Validate.finite(dArg, \"constant\" + param);");
-
-        test("Validate.inclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "
-                + "\"constant\" + param);");
-        test("Validate.inclusiveBetween(0L, 100L, 50L, \"constant\" + param);");
-        test("Validate.inclusiveBetween(0.0, 1.0, 0.5, \"constant\" + param);");
-
-        test("Validate.exclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "
-                + "\"constant\" + param);");
-        test("Validate.exclusiveBetween(0L, 100L, 50L, \"constant\" + param);");
-        test("Validate.exclusiveBetween(0.0, 1.0, 0.5, \"constant\" + param);");
-
-        test("Validate.isInstanceOf(BigDecimal.class, BigDecimal.ONE, \"constant\" + param);");
-        test("Validate.isAssignableFrom(Object.class, BigDecimal.class, "
-                + "\"constant\" + param);");
-    }
-
-    @Test
-    public void negative() throws Exception {
+    private void testPassLang3Only(String call) {
         compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import org.apache.commons.lang3.Validate;",
                         "import java.math.BigDecimal;",
                         "import java.util.Collection;",
-                        "import java.util.Iterator;",
                         "import java.util.Map;",
                         "class Test {",
-                        "  private static final String compileTimeConstant = \"constant\";",
-                        "  void f(boolean bArg, int iArg, Object oArg, Integer[] arrayArg, "
-                            + "Collection<String> collectionArg, Map<String, String> mapArg, String stringArg, "
-                            + "Iterable<String> iterableArg, double dArg) {",
-                        "    Validate.isTrue(bArg, \"message %d\", 123L);",
-                        "    Validate.isTrue(bArg, \"message %f\", 0.0);",
-                        "    Validate.isTrue(bArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.notNull(oArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.notEmpty(arrayArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.notEmpty(collectionArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.notEmpty(mapArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.notEmpty(stringArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.notBlank(stringArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.noNullElements(arrayArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.noNullElements(iterableArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.validIndex(arrayArg, 1, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.validIndex(collectionArg, 1, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.validIndex(stringArg, 1, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.validState(bArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.matchesPattern(stringArg, \"[A-Z]+\", \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.notNaN(dArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.finite(dArg, \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.inclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE,"
-                                + " \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.inclusiveBetween(0L, 100L, 50L, \"message\");",
-                        "    Validate.inclusiveBetween(0.0, 1.0, 0.5, \"message\");",
-                        "    Validate.exclusiveBetween(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE,"
-                                + " \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.exclusiveBetween(0L, 100L, 50L, \"message\");",
-                        "    Validate.exclusiveBetween(0.0, 1.0, 0.5, \"message\");",
-                        "    Validate.isInstanceOf(BigDecimal.class, BigDecimal.ONE,"
-                                + " \"message %s %s\", \"msg\", \"msg\");",
-                        "    Validate.isAssignableFrom(Object.class, BigDecimal.class,"
-                                + " \"message %s %s\", \"msg\", \"msg\");",
+                        "  void f(String param, boolean bArg, int iArg, Object oArg, Integer[] arrayArg, "
+                                + "Collection<String> collectionArg, Map<String, String> mapArg, String stringArg, "
+                                + "Iterable<String> iterableArg, double dArg) {",
+                        "    " + call,
                         "  }",
                         "}")
                 .doTest();
     }
 
+    private void testFailLang2Only(String call) {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import org.apache.commons.lang.Validate;",
+                        "import java.math.BigDecimal;",
+                        "import java.util.Collection;",
+                        "import java.util.Map;",
+                        "class Test {",
+                        "  void f(String param, boolean bArg, int iArg, Object oArg, Integer[] arrayArg, "
+                                + "Collection<String> collectionArg, Map<String, String> mapArg, String stringArg, "
+                                + "Iterable<String> iterableArg, double dArg) {",
+                        "    // BUG: Diagnostic contains: non-constant message",
+                        "    " + call,
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    private void testPassLang2Only(String call) {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import org.apache.commons.lang.Validate;",
+                        "import java.math.BigDecimal;",
+                        "import java.util.Collection;",
+                        "import java.util.Map;",
+                        "class Test {",
+                        "  void f(String param, boolean bArg, int iArg, Object oArg, Integer[] arrayArg, "
+                                + "Collection<String> collectionArg, Map<String, String> mapArg, String stringArg, "
+                                + "Iterable<String> iterableArg, double dArg) {",
+                        "    " + call,
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    private void testFailBoth(String call) {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.math.BigDecimal;",
+                        "import java.util.Collection;",
+                        "import java.util.Map;",
+                        "class Test {",
+                        "  void f(String param, boolean bArg, int iArg, Object oArg, Integer[] arrayArg, "
+                                + "Collection<String> collectionArg, Map<String, String> mapArg, String stringArg, "
+                                + "Iterable<String> iterableArg, double dArg) {",
+                        "    // BUG: Diagnostic contains: non-constant message",
+                        "    org.apache.commons.lang." + call,
+                        "    // BUG: Diagnostic contains: non-constant message",
+                        "    org.apache.commons.lang3." + call,
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    private void testPassBoth(String call) {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.math.BigDecimal;",
+                        "import java.util.Collection;",
+                        "import java.util.Map;",
+                        "class Test {",
+                        "  void f(String param, boolean bArg, int iArg, Object oArg, Integer[] arrayArg, "
+                                + "Collection<String> collectionArg, Map<String, String> mapArg, String stringArg, "
+                                + "Iterable<String> iterableArg, double dArg) {",
+                        "    org.apache.commons.lang." + call,
+                        "    org.apache.commons.lang3." + call,
+                        "  }",
+                        "}")
+                .doTest();
+    }
 }

--- a/versions.props
+++ b/versions.props
@@ -18,6 +18,7 @@ junit:junit = 4.12
 net.lingala.zip4j:zip4j = 1.3.2
 com.github.stefanbirkner:system-rules = 1.19.0
 org.apache.commons:commons-lang3 = 3.8.1
+commons-lang:commons-lang = 2.6
 org.assertj:assertj-core = 3.12.0
 org.hamcrest:hamcrest-core = 2.1
 org.junit.jupiter:* = 5.4.0


### PR DESCRIPTION
## Before this PR
The ValidateConstantMessage check would flag on the last argument that is a string rather than on the message string. Additionally, the grouping of test cases under the single positive test does not correctly test cases after the first one.

## After this PR
The ValidateConstantMessage check now knows the argument index of all message argument in all calls so it can be correctly identified and checked. Test cases are now all completely separated in their own tests.
