### PR TITLE
[RFC] Fail for unused dependencies

### DIFF
--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compile 'com.netflix.nebula:nebula-dependency-recommender'
     compile 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin'
     compile 'net.ltgt.gradle:gradle-errorprone-plugin'
+    compile 'org.apache.maven.shared:maven-dependency-analyzer'
     compile 'org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11'
 
     testCompile gradleTestKit()
@@ -60,6 +61,10 @@ pluginBundle {
         baselineConfigPlugin {
             id = 'com.palantir.baseline-config'
             displayName = 'Palantir Baseline Configuration Plugin'
+        }
+        baselineDependenciesPlugin {
+            id = 'com.palantir.baseline-dependencies'
+            displayName = 'Palantir Baseline Dependency Analysis Plugin'
         }
         baselineEclipsePlugin {
             id = 'com.palantir.baseline-eclipse'

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineDependencies.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import com.palantir.baseline.tasks.CheckUnusedDependenciesTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+
+public final class BaselineDependencies implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().withPlugin("java", plugin -> {
+            project.getTasks().create("checkUnusedDependencies", CheckUnusedDependenciesTask.class, task -> {
+                task.dependsOn(JavaPlugin.CLASSES_TASK_NAME);
+
+                SourceSetContainer sourceSets = (SourceSetContainer) project.getProperties().get("sourceSets");
+                SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                task.setClasses(mainSourceSet.getOutput().getClassesDirs());
+
+                task.dependenciesConfiguration(project.getConfigurations()
+                        .findByName("compile"));
+                task.dependenciesConfiguration(project.getConfigurations()
+                        .findByName("compileOnly"));
+                task.dependenciesConfiguration(project.getConfigurations()
+                        .findByName("provided"));
+            });
+        });
+    }
+
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -1,0 +1,185 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.tasks;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.maven.shared.dependency.analyzer.ClassAnalyzer;
+import org.apache.maven.shared.dependency.analyzer.DefaultClassAnalyzer;
+import org.apache.maven.shared.dependency.analyzer.DependencyAnalyzer;
+import org.apache.maven.shared.dependency.analyzer.asm.ASMDependencyAnalyzer;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.TaskAction;
+
+@SuppressWarnings("DesignForExtension")
+public class CheckUnusedDependenciesTask extends DefaultTask {
+
+    private static final ClassAnalyzer classAnalayzer = new DefaultClassAnalyzer();
+    private static final DependencyAnalyzer dependencyAnalyzer = new ASMDependencyAnalyzer();
+
+    private List<Configuration> dependenciesConfigurations = new ArrayList<>();
+    private FileCollection classes;
+
+    private Map<String, ResolvedArtifact> classToDependency = new HashMap<>();
+    private Map<ResolvedArtifact, Set<String>> classesFromArtifact = new HashMap<>();
+    private Map<ResolvedArtifact, ResolvedDependency> artifactsFromDependency = new HashMap<>();
+
+    public CheckUnusedDependenciesTask() {
+        setGroup("Verification");
+    }
+
+    @TaskAction
+    public void checkUnusedDependencies() {
+        Set<ResolvedDependency> declaredDependencies = getDependenciesConfigurations().stream()
+                .map(Configuration::getResolvedConfiguration)
+                .flatMap(resolved -> resolved.getFirstLevelModuleDependencies().stream())
+                .collect(Collectors.toSet());
+
+        // All artifacts
+        Set<ResolvedArtifact> allArtifacts = declaredDependencies.stream()
+                .flatMap(dependency -> dependency.getAllModuleArtifacts().stream())
+                .collect(Collectors.toSet());
+
+        // Construct caches of classes in each dependency
+        allArtifacts.forEach(artifact -> {
+            try {
+                // Construct class/artifact maps
+                Set<String> classesInArtifact = classAnalayzer.analyze(artifact.getFile().toURI().toURL());
+                classesFromArtifact.put(artifact, classesInArtifact);
+                classesInArtifact.forEach(clazz -> {
+                    if (classToDependency.put(clazz, artifact) != null) {
+                        getLogger().info("Found duplicate class " + clazz);
+                    }
+                });
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Declared artifacts
+        Set<ResolvedArtifact> declaredArtifacts = declaredDependencies.stream()
+                .flatMap(dependency -> {
+                    Set<ResolvedArtifact> artifacts = dependency.getModuleArtifacts();
+                    artifacts.forEach(artifact -> artifactsFromDependency.put(artifact, dependency));
+                    return artifacts.stream();
+                })
+                .collect(Collectors.toSet());
+
+        // Go through classes dirs to find which classes are referenced
+        Set<String> referencedClasses = Streams.stream(getClasses().iterator())
+                .flatMap(file -> {
+                    try {
+                        return dependencyAnalyzer.analyze(file.toURI().toURL()).stream();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toSet());
+
+        // Gather the set of expected dependencies based on referenced classes
+        Set<ResolvedArtifact> expectedArtifacts = referencedClasses.stream()
+                .map(clazz -> {
+                    ResolvedArtifact maybeArtifact = classToDependency.get(clazz);
+                    if (maybeArtifact == null) {
+                        getLogger().debug("Failed to locate artifact for {}", clazz);
+                    }
+                    return maybeArtifact;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        List<ResolvedArtifact> usedButUndeclared = Sets.difference(expectedArtifacts, declaredArtifacts).stream()
+                .sorted(Comparator.comparing(artifact -> artifact.getId().getDisplayName()))
+                .collect(Collectors.toList());
+
+        List<ResolvedArtifact> declaredButUnused = Sets.difference(declaredArtifacts, expectedArtifacts).stream()
+                .sorted(Comparator.comparing(artifact -> artifact.getId().getDisplayName()))
+                .collect(Collectors.toList());
+
+        if (!usedButUndeclared.isEmpty()) {
+            getLogger().warn(
+                    "Used but undeclared dependencies:\n{}",
+                    Joiner.on("\t\n").join(usedButUndeclared));
+        }
+
+        if (!declaredButUnused.isEmpty()) {
+            StringBuilder sb = new StringBuilder("Declared but unused dependencies:\n");
+            for (ResolvedArtifact resolvedArtifact : declaredButUnused) {
+                sb.append('\t').append(resolvedArtifact).append('\n');
+
+                // Find the original first-level dependency corresponding to this artifact
+                ResolvedDependency dependency = artifactsFromDependency.get(resolvedArtifact);
+
+                // Suggest fixes by looking at all transitive classes, filtering the ones we have declarations on,
+                // and mapping the remaining ones back to the jars they came from.
+                Set<ResolvedArtifact> didYouMean = dependency.getAllModuleArtifacts().stream()
+                        .flatMap(artifact -> classesFromArtifact.get(artifact).stream())
+                        .filter(referencedClasses::contains)
+                        .map(clazz -> classToDependency.get(clazz))
+                        .filter(Objects::nonNull)
+                        .filter(artifact -> !declaredArtifacts.contains(artifact))
+                        .collect(Collectors.toSet());
+
+                if (!didYouMean.isEmpty()) {
+                    sb.append("\t\tDid you mean:\n");
+                    didYouMean.forEach(transitive -> sb.append("\t\t\t").append(transitive).append('\n'));
+                }
+            }
+            throw new GradleException(sb.toString());
+        }
+    }
+
+    @Input
+    public List<Configuration> getDependenciesConfigurations() {
+        return dependenciesConfigurations.stream().filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    public void setDependenciesConfigurations(List<Configuration> dependenciesConfigurations) {
+        this.dependenciesConfigurations = new ArrayList<>(dependenciesConfigurations);
+    }
+
+    public void dependenciesConfiguration(Configuration dependenciesConfiguration) {
+        this.dependenciesConfigurations.add(dependenciesConfiguration);
+    }
+
+    @InputFiles
+    public FileCollection getClasses() {
+        return classes;
+    }
+
+    public void setClasses(Object newClasses) {
+        this.classes = getProject().files(newClasses);
+    }
+
+}

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-dependencies.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-dependencies.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineDependencies

--- a/versions.props
+++ b/versions.props
@@ -7,6 +7,7 @@ com.netflix.nebula:nebula-dependency-recommender = 7.4.0
 com.palantir.configurationresolver:gradle-configuration-resolver-plugin = 0.3.0
 com.palantir.safe-logging:* = 1.8.1
 net.ltgt.gradle:gradle-errorprone-plugin = 0.7
+org.apache.maven.shared:maven-dependency-analyzer = 1.11.1
 org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11 = 1.0.1
 org.inferred:freebuilder = 1.14.6
 org.slf4j:slf4j-api = 1.7.25


### PR DESCRIPTION
Currently the task will:
* Fail if there are any jars referenced as a first-level dependency from which the `main` source set doesn't reference any classes.
* Suggest an alternative transitive dependency that contains one or more referenced classes.

This means if A -> B -> C, and a project takes a dependency on A but only uses classes from C, then the task will fail and recommend instead taking a dependency on C.

I wonder if a better/safer place to start would be to just throw for any dependency of which no classes are referenced from it or any of its transitives. i.e. a project takes a dependency on A -> B -> C, but no classes are referenced from any of A, B or C.