### PR TITLE
[improvement] ./gradlew idea deletes redundant ipr files

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -59,15 +59,16 @@ class BaselineIdea extends AbstractBaselinePlugin {
             moveProjectReferencesToEnd(ideaModuleModel);
         }
 
-        // leftover ipr files from a different rootProject.name are confusing - let's proactively
-        // clean them up. Intentionally using an Action<Task> to allow up-to-dateness
+        // If someone renames a project, leftover {ipr,iml,ipr} files may still exist on disk and
+        // confuse users, so we proactively clean them up. Intentionally using an Action<Task> to allow up-to-dateness.
         Action<Task> cleanup = new Action<Task>() {
             void execute(Task t) {
                 project.delete(project.fileTree(
-                        dir: project.getProjectDir(),
-                        include: '*.ipr',
-                        exclude: "${rootProject.name}.ipr"
-                ))
+                        dir: project.getProjectDir(), include: '*.ipr', exclude: "${project.name}.ipr"));
+                project.delete(project.fileTree(
+                        dir: project.getProjectDir(), include: '*.iml', exclude: "${project.name}.iml"))
+                project.delete(project.fileTree(
+                        dir: project.getProjectDir(), include: '*.iws', exclude: "${project.name}.iws"))
             }
         }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -236,4 +236,22 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         BuildResult result = with('--stacktrace', '--info', 'idea').build()
         assert result.tasks(TaskOutcome.SUCCESS).collect { it.path }.contains(':idea')
     }
+
+    def 'deletes redundant iml,ipr,iws files'() {
+        when:
+        buildFile << standardBuildFile
+        File real = new File(projectDir, projectDir.name + ".ipr")
+        File iws = createFile('foo.ipr')
+        File iml = createFile('foo.iml')
+        File ipr = createFile('foo.iws')
+
+        then:
+        !real.exists()
+        iws.exists() && iml.exists() && ipr.exists()
+
+        with('idea').build()
+
+        real.exists()
+        !iws.exists() && !iml.exists() && !ipr.exists()
+    }
 }


### PR DESCRIPTION
fixes https://github.com/palantir/gradle-baseline/issues/538

## Before this PR

While adopting gradle-consistent-versions (which sometimes requires renaming the root project), people have been confused by leftover *.ipr files.

## After this PR

Running ./gradlew idea will result in exactly on ipr file.