### PR TITLE
[fix] Remove stale references to no longer existing puppycrawl checkstyle DTDs

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle-suppressions.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
-
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <!-- IMPORTANT ECLIPSE NOTE: If you change this file, you must restart Eclipse
  for your changes to take effect in its Checkstyle integration. -->

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Palantir Baseline Checkstyle configuration.

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/checkstyle.xml
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <property name="charset" value="UTF-8"/>


### PR DESCRIPTION
2 days ago creator of checkstyle stopped hosting the dtd schemas. This doesn't seem to fail gradle but have seen other checkstyle plugins fail hard if they can't find the DTD. This pr moves references to the official checkstyle.org dtds