### PR TITLE
[fix] Special case for proj-proj.ipr files

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -63,22 +63,21 @@ class BaselineIdea extends AbstractBaselinePlugin {
         // confuse users, so we proactively clean them up. Intentionally using an Action<Task> to allow up-to-dateness.
         Action<Task> cleanup = new Action<Task>() {
             void execute(Task t) {
-                project.delete(project.fileTree(
-                        dir: project.getProjectDir(),
-                        include: '*.ipr',
-                        exclude: "(${project.rootProject.name}-)?${project.name}.ipr"));
-                project.delete(project.fileTree(
-                        dir: project.getProjectDir(),
-                        include: '*.iml',
-                        exclude: "(${project.rootProject.name}-)?${project.name}.iml"))
-                project.delete(project.fileTree(
-                        dir: project.getProjectDir(),
-                        include: '*.iws',
-                        exclude: "(${project.rootProject.name}-)?${project.name}.iws"))
+                deleteRedundantIdeaFilesWithExtension(project, ".ipr")
+                deleteRedundantIdeaFilesWithExtension(project, ".iml")
+                deleteRedundantIdeaFilesWithExtension(project, ".iws")
             }
         }
 
         project.getTasks().findByName("idea").doLast(cleanup);
+    }
+
+    private static void deleteRedundantIdeaFilesWithExtension(Project project, String extension) {
+        Arrays.stream(project.getProjectDir().listFiles())
+                .filter({ it.isFile() && it.toString().endsWith(extension)})
+                .filter({ it.toPath().getFileName().toString() != project.name + extension})
+                .filter({ it.toPath().getFileName().toString() != project.rootProject.name + "-" + project.name + extension})
+                .forEach({ it.delete()})
     }
 
     /**

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -64,11 +64,17 @@ class BaselineIdea extends AbstractBaselinePlugin {
         Action<Task> cleanup = new Action<Task>() {
             void execute(Task t) {
                 project.delete(project.fileTree(
-                        dir: project.getProjectDir(), include: '*.ipr', exclude: "${project.name}.ipr"));
+                        dir: project.getProjectDir(),
+                        include: '*.ipr',
+                        exclude: "(${project.rootProject.name}-)?${project.name}.ipr"));
                 project.delete(project.fileTree(
-                        dir: project.getProjectDir(), include: '*.iml', exclude: "${project.name}.iml"))
+                        dir: project.getProjectDir(),
+                        include: '*.iml',
+                        exclude: "(${project.rootProject.name}-)?${project.name}.iml"))
                 project.delete(project.fileTree(
-                        dir: project.getProjectDir(), include: '*.iws', exclude: "${project.name}.iws"))
+                        dir: project.getProjectDir(),
+                        include: '*.iws',
+                        exclude: "(${project.rootProject.name}-)?${project.name}.iws"))
             }
         }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -241,6 +241,7 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         when:
         buildFile << standardBuildFile
         File real = new File(projectDir, projectDir.name + ".ipr")
+        File funky = new File(projectDir, rootProject.name + "-" + projectDir.name + ".ipr")
         File iws = createFile('foo.ipr')
         File iml = createFile('foo.iml')
         File ipr = createFile('foo.iws')
@@ -248,10 +249,12 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         then:
         !real.exists()
         iws.exists() && iml.exists() && ipr.exists()
+        funky.exists()
 
         with('idea').build()
 
         real.exists()
         !iws.exists() && !iml.exists() && !ipr.exists()
+        funky.exists() // when a subproject & rootproject have the same name, the idea plugin creates 'foo-foo.ipr'
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -241,7 +241,8 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         when:
         buildFile << standardBuildFile
         File real = new File(projectDir, projectDir.name + ".ipr")
-        File funky = new File(projectDir, rootProject.name + "-" + projectDir.name + ".ipr")
+        // rootProject 'foobar' defined in resources/com.palantir.baseline/settings.gradle
+        File funky = createFile("foobar-" + projectDir.name + ".ipr")
         File iws = createFile('foo.ipr')
         File iml = createFile('foo.iml')
         File ipr = createFile('foo.iws')
@@ -251,7 +252,8 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         iws.exists() && iml.exists() && ipr.exists()
         funky.exists()
 
-        with('idea').build()
+        BuildResult r = with('idea', '-i').build()
+        println r.output
 
         real.exists()
         !iws.exists() && !iml.exists() && !ipr.exists()


### PR DESCRIPTION
## Before this PR

baseline-idea 0.51.0 broke workflows for any repo where the rootproject has the same name as a subproject.

## After this PR

Sensible behaviour is restored - files of pattern `name-name.ipr` are no longer deleted.

fixes https://github.com/palantir/gradle-baseline/issues/557

cc @gregakinman @ellisjoe 