### PR TITLE
[fix] Fix cleanup of old idea project files

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -64,7 +64,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
         Action<Task> cleanup = new Action<Task>() {
             void execute(Task t) {
                 project.delete(project.fileTree(
-                        dir: project.getProjectDir(), include: '*.ipr', exclude: "${project.name}.ipr"));
+                        dir: project.getProjectDir(), include: '*.ipr', exclude: "${project.name}.ipr"))
                 project.delete(project.fileTree(
                         dir: project.getProjectDir(), include: '*.iml', exclude: "${project.name}.iml"))
                 project.delete(project.fileTree(
@@ -72,7 +72,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             }
         }
 
-        project.getTasks().findByName("idea").doLast(cleanup);
+        project.getTasks().findByName("idea").doLast(cleanup)
     }
 
     /**


### PR DESCRIPTION
## Before this PR

Regression introduced in #550 means that `.iml` files might be removed if the idea extension were configured in such a way as for them to differ from the project name.
Even if not explicitly configured, if a subproject had the same name as the root project, the IDEA plugin would give it a name like `${project.name}-${project.name}.iml` as mentioned in https://github.com/palantir/gradle-baseline/pull/555#issuecomment-467851332, which differs from the name the cleanup task was instructed to exclude.

## After this PR

Decide based on the outputs of the actual tasks creating these ipr / iws / iml files what the name that they would use is, and exclude just that name, rather than assuming it's going to be e.g. `${project.name}.iml`.

Fixes #557.