### PR TITLE
[improvement] errorprone 2.3.2 -> 2.3.3

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchBlockLogException.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchBlockLogException.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -36,7 +35,6 @@ import java.util.regex.Pattern;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "CatchBlockLogException",
-        category = Category.ONE_OFF,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousJsonTypeInfoUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousJsonTypeInfoUsage.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -33,7 +32,6 @@ import com.sun.source.tree.ExpressionTree;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "DangerousJsonTypeInfoUsage",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         summary = "Disallow usage of Jackson's JsonTypeInfo.Id.CLASS annotation for security reasons, "
                 + "cf. https://github.com/FasterXML/jackson-databind/issues/1599")

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousParallelStreamUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousParallelStreamUsage.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -31,7 +30,6 @@ import com.sun.source.tree.MethodInvocationTree;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "DangerousParallelStreamUsage",
-        category = Category.JDK,
         severity = SeverityLevel.WARNING,
         summary = "Discourage usage of .parallel() in Java streams.")
 public final class DangerousParallelStreamUsage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThreadPoolExecutorUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThreadPoolExecutorUsage.java
@@ -6,7 +6,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -20,7 +19,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "DangerousThreadPoolExecutorUsage",
-        category = Category.JDK,
         severity = SeverityLevel.ERROR,
         summary = "Disallow direct ThreadPoolExecutor usages.")
 public final class DangerousThreadPoolExecutorUsage extends BugChecker implements BugChecker.NewClassTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArg.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArg.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -33,7 +32,6 @@ import java.util.List;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "DangerousThrowableMessageSafeArg",
-        category = Category.ONE_OFF,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GuavaPreconditionsMessageFormat.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GuavaPreconditionsMessageFormat.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -32,7 +31,6 @@ import java.util.regex.Pattern;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "GuavaPreconditionsMessageFormat",
-        category = Category.GUAVA,
         severity = SeverityLevel.ERROR,
         summary = "Guava Preconditions.checkX() methods must use print-f style formatting.")
 public final class GuavaPreconditionsMessageFormat extends PreconditionsMessageFormat {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsConstantMessage.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -34,7 +33,6 @@ import java.util.regex.Pattern;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "LogSafePreconditionsConstantMessage",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         summary = "Allow only constant messages to logsafe Preconditions.checkX() methods")
 public final class LogSafePreconditionsConstantMessage

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsMessageFormat.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsMessageFormat.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -33,7 +32,6 @@ import java.util.regex.Pattern;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "LogSafePreconditionsMessageFormat",
-        category = Category.ONE_OFF,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsConstantMessage.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -34,7 +33,6 @@ import java.util.regex.Pattern;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "PreconditionsConstantMessage",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         summary = "Allow only constant messages to Preconditions.checkX() methods")
 public final class PreconditionsConstantMessage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
         name = "PreferSafeLoggableExceptions",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        category = BugPattern.Category.ONE_OFF,
         severity = BugPattern.SeverityLevel.SUGGESTION,
         summary = "Throw SafeLoggable exceptions to ensure the exception message will not be redacted")
 public final class PreferSafeLoggableExceptions extends BugChecker implements BugChecker.NewClassTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -40,7 +40,6 @@ import java.util.regex.Pattern;
         name = "PreferSafeLoggingPreconditions",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        category = BugPattern.Category.ONE_OFF,
         severity = BugPattern.SeverityLevel.SUGGESTION,
         summary = "Precondition and similar checks with a constant message and no parameters should use equivalent "
                 + "checks from com.palantir.logsafe.Preconditions for standardization as functionality is the same.")

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ShutdownHook.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ShutdownHook.java
@@ -31,7 +31,6 @@ import java.util.regex.Pattern;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "ShutdownHook",
-        category = BugPattern.Category.ONE_OFF,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = BugPattern.SeverityLevel.ERROR,

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessage.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -36,7 +35,6 @@ import java.util.regex.Pattern;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "Slf4jConstantLogMessage",
-        category = Category.ONE_OFF,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -19,7 +19,6 @@ package com.palantir.baseline.errorprone;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -36,7 +35,6 @@ import java.util.regex.Pattern;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "Slf4jLogsafeArgs",
-        category = Category.ONE_OFF,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.WARNING,

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCase.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCase.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -31,7 +30,6 @@ import java.util.Objects;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "SwitchStatementDefaultCase",
-        category = Category.ONE_OFF,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = LinkType.CUSTOM,
         severity = SeverityLevel.SUGGESTION,

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ValidateConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ValidateConstantMessage.java
@@ -19,7 +19,6 @@ package com.palantir.baseline.errorprone;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -35,7 +34,6 @@ import java.util.List;
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "ValidateConstantMessage",
-        category = Category.ONE_OFF, // or APACHE
         severity = SeverityLevel.ERROR,
         summary = "Allow only constant messages to Validate.X() methods")
 public final class ValidateConstantMessage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {

--- a/versions.props
+++ b/versions.props
@@ -1,7 +1,7 @@
 com.google.auto.service:auto-service = 1.0-rc4
-com.google.errorprone:error_prone_annotations = 2.3.2
-com.google.errorprone:error_prone_core = 2.3.2
-com.google.errorprone:error_prone_test_helpers = 2.3.2
+com.google.errorprone:error_prone_annotations = 2.3.3
+com.google.errorprone:error_prone_core = 2.3.3
+com.google.errorprone:error_prone_test_helpers = 2.3.3
 com.google.guava:guava = 23.6.1-jre
 com.netflix.nebula:nebula-dependency-recommender = 7.5.0
 com.palantir.configurationresolver:gradle-configuration-resolver-plugin = 0.3.0


### PR DESCRIPTION
error-prone usually brings some welcome new static analysis.

Looks like we just needed to delete our Category annotations: https://github.com/google/error-prone/commit/1f2fed928c87a548588278fe4333688e40b31ffe

I'd prefer not to start using the new tags just yet so that anyone who happens to be forcing 2.3.2 somehow keeps working