### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - checkout
       - restore_cache: { key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
       - restore_cache: { key: 'gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --no-daemon --parallel --stacktrace  --continue --max-workers=8 --profile build
+      - run: ./gradlew --no-daemon --parallel --stacktrace  --continue --max-workers=8 --profile build --scan
       - save_cache:
           key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
           paths: [ ~/.gradle/wrapper ]
@@ -30,9 +30,9 @@ jobs:
           command: |
             # publishing snapshots to bintray does not work, so we only publish from tag builds (not develop)
             if [[ "${CIRCLE_TAG}" =~ [0-9]+(\.[0-9]+)+(-[a-zA-Z]+[0-9]*)* ]]; then
-              ./gradlew --no-daemon --parallel --stacktrace  --continue --max-workers=8 --profile publish
+              ./gradlew --no-daemon --parallel --stacktrace  --continue --max-workers=8 --profile publish --scan
             else
-              ./gradlew --no-daemon --parallel --stacktrace  --continue --max-workers=8 --profile publishToMavenLocal
+              ./gradlew --no-daemon --parallel --stacktrace  --continue --max-workers=8 --profile publishToMavenLocal --scan
               mkdir -p $CIRCLE_ARTIFACTS/poms
               find . -name 'pom-default.xml' -exec cp --parents {} $CIRCLE_ARTIFACTS/poms \;
             fi
@@ -51,7 +51,7 @@ jobs:
       - checkout
       - restore_cache: { key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
       - restore_cache: { key: 'gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --no-daemon --parallel --stacktrace  --continue --profile build
+      - run: ./gradlew --no-daemon --parallel --stacktrace  --continue --profile build --scan
       - save_cache:
           key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
           paths: [ ~/.gradle/wrapper ]

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,15 @@ buildscript {
 }
 
 plugins {
+    id 'com.gradle.build-scan' version '2.2.1'
     id 'com.palantir.git-version' version '0.11.0'
     id 'org.inferred.processors' version '2.1.0'
 }
 
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    apply from: 'gradle/build-scans.gradle'
+}
 apply plugin: 'com.palantir.baseline'
 
 allprojects {

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -1,0 +1,33 @@
+def acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/palntir/gradle-scans-license-agree.txt")
+def env = System.getenv()
+boolean isCI = env.CI || env.TRAVIS
+boolean hasAccepted = isCI || env.PALANTIR_GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.PALANTIR_GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+
+buildScan {
+    if (hasAccepted) {
+        termsOfServiceAgree = 'yes'
+    } else if (!hasRefused) {
+        gradle.buildFinished {
+            println """
+This build uses Gradle Build Scans to gather statistics, share information about 
+failures, environmental issues, dependencies resolved during the build and more.
+Build scans will be published after each build, if you accept the terms of 
+service, and in particular the privacy policy.
+
+Please read 
+   
+    https://gradle.com/terms-of-service 
+    https://gradle.com/legal/privacy
+
+and then:
+
+  - set the `PALANTIR_GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
+
+And we'll not bother you again. Note that build scans are only made public if 
+you share the URL at the end of the build.
+"""
+        }
+    }
+}


### PR DESCRIPTION
## Before this PR
No insight into build performance.

## After this PR
Configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.

Sample scan at: https://gradle.com/s/hlv3zm5qtkdhg

Note that this scan has detected 162 deprecations.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
