### PR TITLE
Disallow javafx imports with checkstyle

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -127,6 +127,10 @@
             <property name="illegalPkgs" value="junit.framework"/>
             <message key="import.illegal" value="Use JUnit 4-style (org.junit.*) test classes and assertions instead of JUnit 3 (junit.framework.*)."/>
         </module>
+        <module name="IllegalImport"> <!-- Some OpenJDK builds do not include javafx -->
+            <property name="illegalPkgs" value="javafx"/>
+            <message key="import.illegal" value="Must not import javafx classes."/>
+        </module>
         <module name="IllegalImport"> <!-- Java Coding Guidelines: Import the canonical package -->
             <property name="illegalPkgs" value="org.elasticsearch.common.base, com.clearspring.analytics.util, org.spark_project.guava"/>
             <message key="import.illegal" value="Must not import repackaged classes."/>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -127,7 +127,7 @@
             <property name="illegalPkgs" value="junit.framework"/>
             <message key="import.illegal" value="Use JUnit 4-style (org.junit.*) test classes and assertions instead of JUnit 3 (junit.framework.*)."/>
         </module>
-        <module name="IllegalImport"> <!-- Some OpenJDK builds do not include javafx; only relevant for pre-Java 11 b/c javafx is gone completely in Java 11 -->
+        <module name="IllegalImport"> <!-- Only relevant for pre-Java 11 because javafx is gone completely in Java 11 -->
             <property name="id" value="BanJavafx"/>
             <property name="illegalPkgs" value="javafx"/>
             <message key="import.illegal" value="Must not import javafx classes because some OpenJDK builds do not include javafx."/>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -127,7 +127,8 @@
             <property name="illegalPkgs" value="junit.framework"/>
             <message key="import.illegal" value="Use JUnit 4-style (org.junit.*) test classes and assertions instead of JUnit 3 (junit.framework.*)."/>
         </module>
-        <module name="IllegalImport"> <!-- Some OpenJDK builds do not include javafx -->
+        <module name="IllegalImport"> <!-- Some OpenJDK builds do not include javafx; only relevant for pre-Java 11 b/c javafx is gone completely in Java 11 -->
+            <property name="id" value="BanJavafx"/>
             <property name="illegalPkgs" value="javafx"/>
             <message key="import.illegal" value="Must not import javafx classes."/>
         </module>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -130,7 +130,7 @@
         <module name="IllegalImport"> <!-- Some OpenJDK builds do not include javafx; only relevant for pre-Java 11 b/c javafx is gone completely in Java 11 -->
             <property name="id" value="BanJavafx"/>
             <property name="illegalPkgs" value="javafx"/>
-            <message key="import.illegal" value="Must not import javafx classes because some OpenJDK builds do not include it."/>
+            <message key="import.illegal" value="Must not import javafx classes because some OpenJDK builds do not include javafx."/>
         </module>
         <module name="IllegalImport"> <!-- Java Coding Guidelines: Import the canonical package -->
             <property name="illegalPkgs" value="org.elasticsearch.common.base, com.clearspring.analytics.util, org.spark_project.guava"/>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -130,7 +130,7 @@
         <module name="IllegalImport"> <!-- Some OpenJDK builds do not include javafx; only relevant for pre-Java 11 b/c javafx is gone completely in Java 11 -->
             <property name="id" value="BanJavafx"/>
             <property name="illegalPkgs" value="javafx"/>
-            <message key="import.illegal" value="Must not import javafx classes."/>
+            <message key="import.illegal" value="Must not import javafx classes because some OpenJDK builds do not include it."/>
         </module>
         <module name="IllegalImport"> <!-- Java Coding Guidelines: Import the canonical package -->
             <property name="illegalPkgs" value="org.elasticsearch.common.base, com.clearspring.analytics.util, org.spark_project.guava"/>


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Checkstyle allows javafx imports. javafx comes with Oracle JVMs, but is not included in some others we use internally. My team's internal project has a checkstyle customization that does this (we got broken by a javafx `Pair` import) but we'd like to be able to switch to the standard checkstyle and avoid another service hitting the same issue.

## After this PR
Disallow javafx imports. There's usually a non-javafx alternative.

CC @schlosna 
