### PR TITLE
[fix] Avoid lambda to allow build caching of checkstyle results

### DIFF
--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/XmlReportFailuresSupplier.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/XmlReportFailuresSupplier.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
+import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.reporting.ReportContainer;
 import org.gradle.api.reporting.Reporting;
@@ -32,7 +33,12 @@ public final class XmlReportFailuresSupplier implements FailuresSupplier {
     public static <T extends Task & Reporting<? extends ReportContainer<SingleFileReport>>>
             XmlReportFailuresSupplier create(final T task, final ReportHandler<T> reportHandler) {
             // Ensure any necessary output is enabled
-        task.doFirst(ignored -> reportHandler.configureTask(task));
+        task.doFirst(new Action<Task>() {
+            @Override
+            public void execute(Task ignored) {
+                reportHandler.configureTask(task);
+            }
+        });
         return new XmlReportFailuresSupplier(task, reportHandler);
     }
 


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
Caching checkstyle results isn't possible due to same issue as in https://github.com/palantir/gradle-conjure/pull/116

I can share an internal build scan pointing to this as the culprit.

## After this PR
Caching checkstyleMain results should be possible.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
