### PR TITLE
[improvement] Prevent commit of ShutdownStrategy.SKIP

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -381,6 +381,10 @@
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>
             <property name="message" value="Test setup/teardown methods are called before(), beforeClass(), after(), afterClass(), but not setUp, teardown, etc."/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="ShutdownStrategy\.SKIP"/>
+            <property name="message" value="Do not commit docker-compose-rule's ShutdownStrategy.SKIP to avoid leaking resources during CI."/>
+        </module>
         <module name="RightCurly"> <!-- Java Style Guide: Nonempty blocks: K & R style -->
             <property name="option" value="same"/>
             <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>


### PR DESCRIPTION
Per https://github.com/palantir/docker-compose-rule/blob/a2adeae9ac12b7fc4c9f7a8d1bacaa7db97a430a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ShutdownStrategy.java#L56, we do not want to commit docker-compose-rule's ShutdownStrategy.SKIP to avoid leaking resources during CI.