### PR TITLE
[fix] Exact dependency only for jar deps

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -98,6 +98,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         public void populateIndexes(Set<ResolvedDependency> declaredDependencies) {
             Set<ResolvedArtifact> allArtifacts = declaredDependencies.stream()
                     .flatMap(dependency -> dependency.getAllModuleArtifacts().stream())
+                    .filter(resolvedArtifact -> resolvedArtifact.getExtension().equals("jar"))
                     .collect(Collectors.toSet());
 
             allArtifacts.forEach(artifact -> {


### PR DESCRIPTION
## Before this PR
We had a dependency `<group>:<artifact>@pom` that caused the exact dependencies plugin to fail.

`Cannot accept visitor on URL: ...`

## After this PR
Only jars are visited
