### PR TITLE
[feature] Gradle task action errorprone check

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
     ```
 - `ShutdownHook`: Applications should not use `Runtime#addShutdownHook`.
 - `SwitchStatementDefaultCase`: Switch statements should avoid using default cases. Default cases prevent the [MissingCasesInEnumSwitch](http://errorprone.info/bugpattern/MissingCasesInEnumSwitch.html) check from detecting when an enum value is not explicitly handled. This check is important to help avoid incorrect behavior when new enum values are introduced.
-- `GradleCacheableTaskAction`: Gradle plugins should not call `Task.doFirst` or `Task.doLast` with a lambda, as that is not cacheable.
+- `GradleCacheableTaskAction`: Gradle plugins should not call `Task.doFirst` or `Task.doLast` with a lambda, as that is not cacheable. See [gradle/gradle#5510](https://github.com/gradle/gradle/issues/5510) for more details.
 
 ## com.palantir.baseline-checkstyle
 Checkstyle rules can be suppressed on a per-line or per-block basis. (It is good practice to first consider formatting

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
     ```
 - `ShutdownHook`: Applications should not use `Runtime#addShutdownHook`.
 - `SwitchStatementDefaultCase`: Switch statements should avoid using default cases. Default cases prevent the [MissingCasesInEnumSwitch](http://errorprone.info/bugpattern/MissingCasesInEnumSwitch.html) check from detecting when an enum value is not explicitly handled. This check is important to help avoid incorrect behavior when new enum values are introduced.
+- `GradleCacheableTaskAction`: Gradle plugins should not call `Task.doFirst` or `Task.doLast` with a lambda, as that is not cacheable.
 
 ## com.palantir.baseline-checkstyle
 Checkstyle rules can be suppressed on a per-line or per-block basis. (It is good practice to first consider formatting

--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testCompile 'org.apache.commons:commons-lang3'
     testCompile 'commons-lang:commons-lang'
     testCompile 'org.junit.jupiter:junit-jupiter-api'
+    testCompile gradleApi()
 
     annotationProcessor 'com.google.auto.service:auto-service'
     compileOnly 'com.google.auto.service:auto-service'

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.Iterables;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.ChildMultiMatcher.MatchType;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import java.util.regex.Pattern;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "GradleCacheableTaskAction",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.ERROR,
+        summary = "Forbid gradle actions (doFirst, doLast) to be implemented by lambdas.")
+public final class GradleCacheableTaskAction extends BugChecker implements MethodInvocationTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+    private static final Matcher<Tree> IS_ACTION = Matchers.isSubtypeOf("org.gradle.api.Action");
+
+    private static final Matcher<ExpressionTree> TASK_ACTION = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Task")
+            .withNameMatching(Pattern.compile("doFirst|doLast"));
+
+    private static final Matcher<ExpressionTree> IS_LAMBDA_EXPRESSION =
+            (expression, state) -> expression instanceof LambdaExpressionTree;
+
+    private static final Matcher<MethodInvocationTree> TASK_ACTION_WITH_LAMBDA = Matchers.allOf(
+            TASK_ACTION,
+            Matchers.hasArguments(MatchType.LAST, Matchers.allOf(IS_ACTION, IS_LAMBDA_EXPRESSION)));
+
+    @Override
+    public Description matchMethodInvocation(
+            MethodInvocationTree tree, VisitorState state) {
+        if (!TASK_ACTION_WITH_LAMBDA.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+        ExpressionTree lastArgument = Iterables.getLast(tree.getArguments());
+        return buildDescription(lastArgument)
+                .setMessage("Gradle task actions are not cacheable when implemented by lambdas")
+                .build();
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
@@ -17,22 +17,17 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
-import com.google.errorprone.matchers.ChildMultiMatcher.MatchType;
+import com.google.errorprone.bugpatterns.BugChecker.LambdaExpressionTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
-import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.tree.Tree.Kind;
 import java.util.regex.Pattern;
 
 @AutoService(BugChecker.class)
@@ -42,27 +37,24 @@ import java.util.regex.Pattern;
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,
         summary = "Forbid gradle actions (doFirst, doLast) to be implemented by lambdas.")
-public final class GradleCacheableTaskAction extends BugChecker implements MethodInvocationTreeMatcher {
+public final class GradleCacheableTaskAction extends BugChecker implements LambdaExpressionTreeMatcher {
 
     private static final long serialVersionUID = 1L;
-    private static final Matcher<Tree> IS_ACTION = Matchers.isSubtypeOf("org.gradle.api.Action");
+    private static final Matcher<ExpressionTree> IS_ACTION = Matchers.isSubtypeOf("org.gradle.api.Action");
 
     private static final Matcher<ExpressionTree> TASK_ACTION = MethodMatchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Task")
             .withNameMatching(Pattern.compile("doFirst|doLast"));
 
-    private static final Matcher<MethodInvocationTree> TASK_ACTION_WITH_LAMBDA = Matchers.allOf(
-            TASK_ACTION,
-            Matchers.hasArguments(MatchType.LAST, Matchers.allOf(IS_ACTION, Matchers.kindIs(Kind.LAMBDA_EXPRESSION))));
+    private static final Matcher<ExpressionTree> IS_TASK_ACTION =
+            Matchers.allOf(Matchers.parentNode(Matchers.methodInvocation(TASK_ACTION)), IS_ACTION);
 
     @Override
-    public Description matchMethodInvocation(
-            MethodInvocationTree tree, VisitorState state) {
-        if (!TASK_ACTION_WITH_LAMBDA.matches(tree, state)) {
+    public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
+        if (!IS_TASK_ACTION.matches(tree, state)) {
             return Description.NO_MATCH;
         }
-        LambdaExpressionTree lambdaArg = (LambdaExpressionTree) Iterables.getLast(tree.getArguments());
-        return buildDescription(lambdaArg)
+        return buildDescription(tree)
                 .setMessage("Gradle task actions are not cacheable when implemented by lambdas")
                 .build();
     }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,
-        summary = "Forbid gradle actions (doFirst, doLast) to be implemented by lambdas.")
+        summary = "Forbid gradle task actions (doFirst, doLast) to be implemented by lambdas.")
 public final class GradleCacheableTaskAction extends BugChecker implements LambdaExpressionTreeMatcher {
 
     private static final long serialVersionUID = 1L;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleCacheableTaskActionTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleCacheableTaskActionTest.java
@@ -33,7 +33,7 @@ public class GradleCacheableTaskActionTest {
     }
 
     @Test
-    public void testFailsOnDoFirstLambda() {
+    public void failsOnDoFirstLambda() {
         compilationHelper
                 .addSourceLines(
                         "Foo.java",
@@ -45,6 +45,27 @@ public class GradleCacheableTaskActionTest {
                         "    project.getTasks().register(\"foo\", task -> {",
                         "      // " + errorMsg,
                         "      task.doFirst(t -> System.out.println(\"im a lambda\"));",
+                        "    });",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void allowsDoFirstAnonymousClass() {
+        compilationHelper
+                .addSourceLines(
+                        "Foo.java",
+                        "import org.gradle.api.Task;",
+                        "import org.gradle.api.Action;",
+                        "import org.gradle.api.Project;",
+                        "import org.gradle.api.Plugin;",
+                        "class Foo implements Plugin<Project> {",
+                        "  public final void apply(Project project) {",
+                        "    project.getTasks().register(\"foo\", task -> {",
+                        "      task.doFirst(new Action<Task>() {",
+                        "          public void execute(Task task) {}",
+                        "      });",
                         "    });",
                         "  }",
                         "}")

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleCacheableTaskActionTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleCacheableTaskActionTest.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GradleCacheableTaskActionTest {
+
+    private static final String errorMsg = "BUG: Diagnostic contains: "
+            + "Gradle task actions are not cacheable when implemented by lambdas";
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(GradleCacheableTaskAction.class, getClass());
+    }
+
+    @Test
+    public void testFailsOnDoFirstLambda() {
+        compilationHelper
+                .addSourceLines(
+                        "Foo.java",
+                        "import org.gradle.api.Task;",
+                        "import org.gradle.api.Project;",
+                        "import org.gradle.api.Plugin;",
+                        "class Foo implements Plugin<Project> {",
+                        "  public final void apply(Project project) {",
+                        "    project.getTasks().register(\"foo\", task -> {",
+                        "      // " + errorMsg,
+                        "      task.doFirst(t -> System.out.println(\"im a lambda\"));",
+                        "    });",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+}


### PR DESCRIPTION
## Before this PR

Devs could accidentally pass a lambda to `Task.doFirst` or `Task.doLast` actions in gradle plugins. This makes the task non-cacheable, as pointed out in https://github.com/gradle/gradle/issues/5510.


## After this PR

==COMMIT_MSG=
Add an errorprone rule `GradleCacheableTaskAction` that prevents passing a lambda to `Task.doFirst` or `Task.doLast` when implementing gradle plugins.
==COMMIT_MSG==