### PR TITLE
[improvement] Prefer Lists or Collections2 transfrom over Iterables.transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ checks](https://errorprone.info):
 - `Slf4jConstantLogMessage`: Allow only compile-time constant slf4j log message strings.
 - `Slf4jLogsafeArgs`: Allow only com.palantir.logsafe.Arg types as parameter inputs to slf4j log messages. More information on
 Safe Logging can be found at [github.com/palantir/safe-logging](https://github.com/palantir/safe-logging).
+- `PreferCollectionTransform`: Prefer Guava's Lists.transform or Collections2.transform instead of Iterables.transform when first argument's declared type is a List or Collection type for performance reasons.
 - `PreferSafeLoggableExceptions`: Users should throw `SafeRuntimeException` instead of `RuntimeException` so that messages will not be needlessly redacted when logs are collected:
     ```diff
     -throw new RuntimeException("explanation", e); // this message will be redacted when logs are collected

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionTransform.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionTransform.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import java.util.List;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "PreferCollectionTransform",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.WARNING,
+        summary = "Prefer Guava's Lists.transform or Collections2.transform instead of Iterables.transform when "
+                + "first argument's declared type is a List or Collection type for performance reasons, "
+                + "cf. https://google.github.io/guava/releases/23.0/api/docs/com/google/common/collect/Iterables.html#transform-java.lang.Iterable-com.google.common.base.Function-")
+public final class PreferCollectionTransform extends BugChecker
+        implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Matcher<ExpressionTree> ITERABLES_TRANSFORM_MATCHER =
+            MethodMatchers.staticMethod()
+                    .onClass("com.google.common.collect.Iterables")
+                    .named("transform");
+
+    private static final Matcher<Tree> LIST_MATCHER = Matchers.isSubtypeOf("java.util.List");
+    private static final Matcher<Tree> COLLECTION_MATCHER = Matchers.isSubtypeOf("java.util.Collection");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (ITERABLES_TRANSFORM_MATCHER.matches(tree, state)) {
+            List<? extends ExpressionTree> args = tree.getArguments();
+            if (args.size() > 1 && COLLECTION_MATCHER.matches(args.get(0), state)) {
+                String qualifiedType;
+                String errorMessage;
+                SuggestedFix.Builder fix = SuggestedFix.builder();
+                if (LIST_MATCHER.matches(args.get(0), state)) {
+                    // Fail on any 'Iterables.transform(List, Function) invocation
+                    qualifiedType = SuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Lists");
+                    errorMessage = "Prefer Lists.transform";
+                } else {
+                    // Fail on any 'Iterables.transform(Collection, Function) invocation
+                    qualifiedType = SuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Collections2");
+                    errorMessage = "Prefer Collections2.transform";
+                }
+                String method = qualifiedType + ".transform";
+                return buildDescription(tree)
+                        .setMessage(errorMessage)
+                        .addFix(fix.replace(tree.getMethodSelect(), method).build())
+                        .build();
+            }
+        }
+
+        return Description.NO_MATCH;
+    }
+
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferCollectionTransformTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferCollectionTransformTests.java
@@ -1,0 +1,169 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+
+public final class PreferCollectionTransformTests {
+
+    @Test
+    public void should_not_use_Iterables_transform_for_List() {
+        CompilationTestHelper.newInstance(PreferCollectionTransform.class, getClass())
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.collect.Iterables;",
+                        "import java.util.List;",
+                        "class Test {",
+                        "  Iterable<?> f(List<?> list) {",
+                        "    // BUG: Diagnostic contains: Prefer Lists.transform",
+                        "    return Iterables.transform(list, x -> x);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void should_not_use_Iterables_transform_for_Collection() {
+        CompilationTestHelper.newInstance(PreferCollectionTransform.class, getClass())
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.collect.Iterables;",
+                        "import java.util.Collection;",
+                        "class Test {",
+                        "  Iterable<?> f(Collection<?> collection) {",
+                        "    // BUG: Diagnostic contains: Prefer Collections2.transform",
+                        "    return Iterables.transform(collection, x -> x);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void should_not_use_Iterables_transform_for_Set() {
+        CompilationTestHelper.newInstance(PreferCollectionTransform.class, getClass())
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.collect.Iterables;",
+                        "import java.util.Set;",
+                        "class Test {",
+                        "  Iterable<?> f(Set<?> set) {",
+                        "    // BUG: Diagnostic contains: Prefer Collections2.transform",
+                        "    return Iterables.transform(set, x -> x);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void may_use_Iterables_transform_for_Iterable() {
+        CompilationTestHelper.newInstance(PreferCollectionTransform.class, getClass())
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.collect.Iterables;",
+                        "class Test {",
+                        "  Iterable<?> f(Iterable<?> iterable) {",
+                        "    return Iterables.transform(iterable, x -> x);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void should_use_Lists_transform() {
+        CompilationTestHelper.newInstance(PreferCollectionTransform.class, getClass())
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.collect.Lists;",
+                        "import java.util.List;",
+                        "class Test {",
+                        "  Iterable<?> f(List<?> list) {",
+                        "    return Lists.transform(list, x -> x);",
+                        "  }",
+                        "}")
+                .expectNoDiagnostics()
+                .doTest();
+    }
+
+    @Test
+    public void should_use_Collections2_transform() {
+        CompilationTestHelper.newInstance(PreferCollectionTransform.class, getClass())
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.collect.Collections2;",
+                        "import java.util.Collection;",
+                        "class Test {",
+                        "  Iterable<?> f(Collection<?> collection) {",
+                        "    return Collections2.transform(collection, x -> x);",
+                        "  }",
+                        "}")
+                .expectNoDiagnostics()
+                .doTest();
+    }
+
+    @Test
+    public void auto_fix_Iterables_transform_List() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferCollectionTransform(), getClass())
+                .addInputLines(
+                        "Test.java",
+                        "import com.google.common.collect.Iterables;",
+                        "import java.util.List;",
+                        "class Test {",
+                        "  Iterable<?> f(List<?> list) {",
+                        "    return Iterables.transform(list, x -> x);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.google.common.collect.Iterables;",
+                        "import com.google.common.collect.Lists;",
+                        "import java.util.List;",
+                        "class Test {",
+                        "  Iterable<?> f(List<?> list) {",
+                        "    return Lists.transform(list, x -> x);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void auto_fix_Iterables_transform_Collection() {
+        BugCheckerRefactoringTestHelper.newInstance(new PreferCollectionTransform(), getClass())
+                .addInputLines(
+                        "Test.java",
+                        "import com.google.common.collect.Iterables;",
+                        "import java.util.Collection;",
+                        "class Test {",
+                        "  Iterable<?> f(Collection<?> collection) {",
+                        "    return Iterables.transform(collection, x -> x);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.google.common.collect.Collections2;",
+                        "import com.google.common.collect.Iterables;",
+                        "import java.util.Collection;",
+                        "class Test {",
+                        "  Iterable<?> f(Collection<?> collection) {",
+                        "    return Collections2.transform(collection, x -> x);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+}


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

When using Guava's lazy transforms such as `Iterables.transform` to avoid full copying of collection via Java Streams, one should generally prefer `Lists.transform` or `Collections2.transform` where possible as the resulting lazy collection provides `O(1)` `size()` and generally no allocation for `isEmpty()`.

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
No warnings when invoking `Iterables.transform(Iterable, Function)` with a first argument declared type of `List` or `Collection`.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
The user is warned that [one should prefer `Lists.transform(List, Function)` or `Collections2.transform(Collection, Function)` per Guava JavaDoc](https://google.github.io/guava/releases/23.0/api/docs/com/google/common/collect/Iterables.html#transform-java.lang.Iterable-com.google.common.base.Function-).

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
Similar to #622 