### PR TITLE
[fix] Add Javac Settings to uncheck "Use compiler from module target JDK when possible"

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -51,6 +51,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
                     addCheckstyle(node)
                     addGit(node)
                     addInspectionProjectProfile(node)
+                    addJavacSettings(node)
                 }
 
                 ideaRootModel.workspace.iws.withXml { provider ->
@@ -190,6 +191,14 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 </profile>
                 <option name="PROJECT_PROFILE" value="Default" />
                 <option name="USE_PROJECT_PROFILE" value="true" />
+            </component>
+            """.stripIndent()))
+    }
+
+    private void addJavacSettings(node) {
+        node.append(new XmlParser().parseText("""
+            <component name="JavacSettings">
+                <option name="PREFER_TARGET_JDK_COMPILER" value="false" />
             </component>
             """.stripIndent()))
     }


### PR DESCRIPTION
Fixes #618

## Before this PR
"Use compiler from module target JDK when possible" is checked by default, which prevents compilation of projects in IntelliJ with an SDK11 and source compatibility 8.

## After this PR
"Use compiler from module target JDK when possible" is unchecked and compilation works