### PR TITLE
[improvement] make CheckClassUniquenessTask cacheable

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessTask.java
@@ -28,10 +28,12 @@ import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+@CacheableTask
 public class CheckClassUniquenessTask extends DefaultTask {
 
     private Configuration configuration;


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
The task CheckClassUniqueness was not cacheable, even if it had inputs and outputs defined.

You could set it manually in your own project by adding the following, but this PR turns it on by default:

```gradle
tasks.checkClassUniqueness.outputs.cacheIf { true }
```

## After this PR
The task is now cacheable.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->