### PR TITLE
[fix] class uniqueness rule must have a config

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/rules/BaselineClassUniquenessRule.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/rules/BaselineClassUniquenessRule.java
@@ -29,7 +29,7 @@ import org.gradle.api.Rule;
 import org.gradle.api.artifacts.Configuration;
 
 public final class BaselineClassUniquenessRule implements Rule {
-    private static final Pattern TASK_NAME_PATTERN = Pattern.compile("^check(.*)ClassUniqueness$");
+    private static final Pattern TASK_NAME_PATTERN = Pattern.compile("^check(.+)ClassUniqueness$");
     private final Project project;
 
     public BaselineClassUniquenessRule(Project project) {


### PR DESCRIPTION
## Before this PR
The rule would match against `checkClassUniqueness`, which would fail since upper-casing an empty string ends up in an index out of bounds exception.

## After this PR
Doesn't match against `checkClassUniqueness` since it now requires at least 1 character in the regex.