### PR TITLE
[improvement] Spotless to remove blank lines at start of methods

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -47,6 +47,9 @@ class BaselineFormat extends AbstractBaselinePlugin {
                 java.trimTrailingWhitespace();
                 java.indentWithSpaces(4);
                 java.endWithNewline();
+
+                // No empty lines at start of blocks
+                java.replaceRegex("Block starts with blank lines", "\\) \\{\n+", ") {\n");
             });
 
             // necessary because SpotlessPlugin creates tasks in an afterEvaluate block

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -36,8 +36,18 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
 
     def validJavaFile = '''
     package test;
-    import com.java.tests;
-    public class Test { void test() {} }
+    public class Test { void test() {
+        int x = 1;
+    } }
+    '''.stripIndent()
+
+    def invalidJavaFile = '''
+    package test;
+    public class Test { void test() {
+    
+    
+        int x = 1;
+    } }
     '''.stripIndent()
 
     def 'can apply plugin'() {
@@ -59,16 +69,13 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
     def 'format task fixes styles'() {
         when:
         buildFile << standardBuildFile
-        file('src/main/java/test/Test.java') << validJavaFile
+        file('src/main/java/test/Test.java') << invalidJavaFile
 
         then:
         BuildResult result = with('format').build();
         result.task(":format").outcome == TaskOutcome.SUCCESS
         result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
-        file('src/main/java/test/Test.java').text == '''
-            package test;
-            public class Test { void test() {} }
-        '''.stripIndent()
+        file('src/main/java/test/Test.java').text == validJavaFile
     }
 
     def 'format task works on new source sets'() {
@@ -77,16 +84,13 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
         buildFile << '''
             sourceSets { foo }
         '''.stripIndent()
-        file('src/foo/java/test/Test.java') << validJavaFile
+        file('src/foo/java/test/Test.java') << invalidJavaFile
 
         then:
         BuildResult result = with('format').build()
         result.task(":format").outcome == TaskOutcome.SUCCESS
         result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
-        file('src/foo/java/test/Test.java').text == '''
-            package test;
-            public class Test { void test() {} }
-        '''.stripIndent()
+        file('src/foo/java/test/Test.java').text == validJavaFile
     }
 
     def 'format task works on other language java sources'() {
@@ -96,16 +100,13 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
             apply plugin: 'groovy'
             sourceSets { foo }
         '''.stripIndent()
-        file('src/foo/groovy/test/Test.java') << validJavaFile
+        file('src/foo/groovy/test/Test.java') << invalidJavaFile
 
         then:
         BuildResult result = with('format').build()
         result.task(":format").outcome == TaskOutcome.SUCCESS
         result.task(":spotlessApply").outcome == TaskOutcome.SUCCESS
-        file('src/foo/groovy/test/Test.java').text == '''
-            package test;
-            public class Test { void test() {} }
-        '''.stripIndent()
+        file('src/foo/groovy/test/Test.java').text == validJavaFile
     }
 
     def 'format ignores generated files'() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -43,6 +43,7 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
 
     def invalidJavaFile = '''
     package test;
+    import com.java.unused;
     public class Test { void test() {
     
     


### PR DESCRIPTION
## Before this PR
Methods starting with blank lines are annoying

## After this PR
Methods cannot start with blank lines
