### PR TITLE
[improvement] Sensible defaults for test tasks (HeapDumpOnOutOfMemory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Baseline is a family of Gradle plugins for configuring Java projects with sensi
 | `com.palantir.baseline-reproducibility`       | Sensible defaults to ensure Jar, Tar and Zip tasks can be reproduced
 | `com.palantir.baseline-exact-dependencies`    | Ensures projects explicitly declare all the dependencies they rely on, no more and no less
 | `com.palantir.baseline-release-compatibility` | Ensures projects targetting older JREs only compile against classes and methods available in those JREs.
+| `com.palantir.baseline-testing`               | Configures test tasks to dump heap dumps (hprof files) for convenient debugging
 
 See also the [Baseline Java Style Guide and Best Practises](./docs).
 
@@ -338,3 +339,15 @@ checkImplicitDependencies {
 This plugin adds the `--release <number>` flag to JavaCompile tasks (when the compiler [supports it](https://openjdk.java.net/jeps/247)), so that published jars will only use methods available in the target JRE.  Relying on `sourceCompatibility = 1.8` and `targetCompatibility = 1.8` is insufficient because you run the risk of using method that have been added in newer JREs, e.g. `Optional#isEmpty`.
 
 This plugin may become redundant if this functionality is implemented upstream [in Gradle](https://github.com/gradle/gradle/issues/2510).
+
+## com.palantir.baseline-testing
+
+Equivalent to:
+
+```gradle
+tasks.withType(Test) {
+    jvmArgs '-XX:+HeapDumpOnOutOfMemoryError', '-XX:+CrashOnOutOfMemoryError'
+}
+```
+
+This ensures that if one of your tests fails with an OutOfMemoryError (OOM), you'll get a large hprof file in the relevant subdirectory which can be analyzed with Eclipse Memory Analyzer Tool, Yourkit profiler, jvisualvm etc.

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -47,6 +47,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineReproducibility.class);
             proj.getPluginManager().apply(BaselineExactDependencies.class);
             proj.getPluginManager().apply(BaselineReleaseCompatibility.class);
+            proj.getPluginManager().apply(BaselineTesting.class);
 
             // TODO(dfox): enable this when it has been validated on a few real projects
             // proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.testing.Test;
+
+public final class BaselineTesting implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getTasks().withType(Test.class).all(task -> {
+            task.jvmArgs("-XX:+HeapDumpOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError");
+        });
+    }
+}


### PR DESCRIPTION
## Before this PR

Earlier today, I was a bit flummoxed by some tests OOMing.  Adding these lines dumped out a nice helpful hprof file, which was very informative.

cc @carterkozak 

## After this PR
Every project should just have these defaults set.

## Possible downsides
- Maybe some versions of Java won't support these flags???
- zero tests, so regressions possible