### PR TITLE
[improvement] Error-prone check to help prevent logging AuthHeader and BearerToken

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -6,6 +6,7 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
     compile 'com.google.errorprone:error_prone_core'
 
+    testCompile 'com.palantir.tokens:auth-tokens'
     testCompile 'com.fasterxml.jackson.core:jackson-annotations'
     testCompile 'com.google.errorprone:error_prone_test_helpers'
     testCompile 'com.palantir.safe-logging:preconditions'

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreventTokenLogging.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreventTokenLogging.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "PreventTokenLogging",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.ERROR,
+        summary = "Authentication token information should never be logged as it poses a security risk. Prevents "
+                + "AuthHeader and BearerToken information from being passed to common logging calls.")
+public class PreventTokenLogging extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final Matcher<ExpressionTree> METHOD_MATCHER =
+            Matchers.anyOf(
+                    MethodMatchers.instanceMethod()
+                            .onExactClass("org.slf4j.Logger")
+                            .withNameMatching(Pattern.compile("trace|debug|info|warn|error")),
+                    MethodMatchers.staticMethod()
+                            .onClass("com.palantir.logsafe.SafeArg")
+                            .named("of"),
+                    MethodMatchers.staticMethod()
+                            .onClass("com.palantir.logsafe.UnsafeArg")
+                            .named("of"));
+
+    private static final Matcher<Tree> AUTH_MATCHER =
+            Matchers.anyOf(
+                    Matchers.isSubtypeOf("com.palantir.tokens.auth.AuthHeader"),
+                    Matchers.isSubtypeOf("com.palantir.tokens.auth.BearerToken"));
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (METHOD_MATCHER.matches(tree, state)) {
+            List<? extends ExpressionTree> args = tree.getArguments();
+            if (args.size() < 2) {
+                return Description.NO_MATCH;
+            }
+
+            for (Tree arg : args.subList(1, args.size())) {
+                if (AUTH_MATCHER.matches(arg, state)) {
+                    return buildDescription(arg)
+                            .setMessage("Authentication information is not allowed to be logged.")
+                            .build();
+                }
+            }
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreventTokenLogging.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreventTokenLogging.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
         severity = BugPattern.SeverityLevel.ERROR,
         summary = "Authentication token information should never be logged as it poses a security risk. Prevents "
                 + "AuthHeader and BearerToken information from being passed to common logging calls.")
-public class PreventTokenLogging extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+public final class PreventTokenLogging extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
     private static final Matcher<ExpressionTree> METHOD_MATCHER =
             Matchers.anyOf(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
@@ -234,7 +234,7 @@ public class PreventTokenLoggingTests {
         passLogSafe("UnsafeArg.of(name, value);");
     }
 
-    private void passSlf4j(String precondition) {
+    private void passSlf4j(String statement) {
         compilationHelper.addSourceLines(
                 "Test.java",
                 "import org.slf4j.Logger;",
@@ -244,13 +244,13 @@ public class PreventTokenLoggingTests {
                 "class Test {",
                 "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
                 "  void f(AuthHeader authHeader, BearerToken bearerToken, String message, Object arg1, Object arg2) {",
-                "    " + precondition,
+                "    " + statement,
                 "  }",
                 "}")
                 .doTest();
     }
 
-    private void failSlf4j(String precondition) {
+    private void failSlf4j(String statement) {
         compilationHelper.addSourceLines(
                 "Test.java",
                 "import org.slf4j.Logger;",
@@ -261,13 +261,13 @@ public class PreventTokenLoggingTests {
                 "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
                 "  void f(AuthHeader authHeader, BearerToken bearerToken, String message, Object arg1, Object arg2) {",
                 "    // BUG: Diagnostic contains: not allowed to be logged",
-                "    " + precondition,
+                "    " + statement,
                 "  }",
                 "}")
                 .doTest();
     }
 
-    private void passLogSafe(String precondition) {
+    private void passLogSafe(String statement) {
         compilationHelper.addSourceLines(
                 "Test.java",
                 "import com.palantir.logsafe.SafeArg;",
@@ -276,13 +276,13 @@ public class PreventTokenLoggingTests {
                 "import com.palantir.tokens.auth.BearerToken;",
                 "class Test {",
                 "  void f(AuthHeader authHeader, BearerToken bearerToken, String name, Object value) {",
-                "    " + precondition,
+                "    " + statement,
                 "  }",
                 "}")
                 .doTest();
     }
 
-    private void failLogSafe(String precondition) {
+    private void failLogSafe(String statement) {
         compilationHelper.addSourceLines(
                 "Test.java",
                 "import com.palantir.logsafe.SafeArg;",
@@ -292,7 +292,7 @@ public class PreventTokenLoggingTests {
                 "class Test {",
                 "  void f(AuthHeader authHeader, BearerToken bearerToken, String name, Object value) {",
                 "    // BUG: Diagnostic contains: not allowed to be logged",
-                "    " + precondition,
+                "    " + statement,
                 "  }",
                 "}")
                 .doTest();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
@@ -1,0 +1,300 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PreventTokenLoggingTests {
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(PreventTokenLogging.class, getClass());
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderTrace() {
+        failSlf4j("log.trace(message, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderTraceMultipleArgs() {
+        failSlf4j("log.trace(message, arg1, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderDebug() {
+        failSlf4j("log.debug(message, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderDebugMultipleArgs() {
+        failSlf4j("log.debug(message, arg1, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderInfo() {
+        failSlf4j("log.info(message, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderInfoMultipleArgs() {
+        failSlf4j("log.info(message, arg1, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderWarn() {
+        failSlf4j("log.warn(message, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderWarnMultipleArgs() {
+        failSlf4j("log.warn(message, arg1, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderError() {
+        failSlf4j("log.error(message, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jAuthHeaderErrorMultipleArgs() {
+        failSlf4j("log.error(message, arg1, authHeader);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenTrace() {
+        failSlf4j("log.trace(message, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenTraceMultipleArgs() {
+        failSlf4j("log.trace(message, arg1, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenDebug() {
+        failSlf4j("log.debug(message, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenDebugMultipleArgs() {
+        failSlf4j("log.debug(message, arg1, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenInfo() {
+        failSlf4j("log.info(message, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenInfoMultipleArgs() {
+        failSlf4j("log.info(message, arg1, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenWarn() {
+        failSlf4j("log.warn(message, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenWarnMultipleArgs() {
+        failSlf4j("log.warn(message, arg1, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenError() {
+        failSlf4j("log.error(message, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jBearerTokenErrorMultipleArgs() {
+        failSlf4j("log.error(message, arg1, bearerToken);");
+    }
+
+    @Test
+    public void testSlf4jTrace() {
+        passSlf4j("log.trace(message, arg1);");
+    }
+
+    @Test
+    public void testSlf4jTraceMultipleArgs() {
+        passSlf4j("log.trace(message, arg1, arg2);");
+    }
+
+    @Test
+    public void testSlf4jTraceNoArgs() {
+        passSlf4j("log.trace(message);");
+    }
+
+    @Test
+    public void testSlf4jDebug() {
+        passSlf4j("log.debug(message, arg1);");
+    }
+
+    @Test
+    public void testSlf4jDebugMultipleArgs() {
+        passSlf4j("log.debug(message, arg1, arg2);");
+    }
+
+    @Test
+    public void testSlf4jDebugNoArgs() {
+        passSlf4j("log.debug(message);");
+    }
+
+    @Test
+    public void testSlf4jInfo() {
+        passSlf4j("log.info(message, arg1);");
+    }
+
+    @Test
+    public void testSlf4jInfoMultipleArgs() {
+        passSlf4j("log.info(message, arg1, arg2);");
+    }
+
+    @Test
+    public void testSlf4jInfoNoArgs() {
+        passSlf4j("log.info(message);");
+    }
+
+    @Test
+    public void testSlf4jWarn() {
+        passSlf4j("log.warn(message, arg1);");
+    }
+
+    @Test
+    public void testSlf4jWarnMultipleArgs() {
+        passSlf4j("log.warn(message, arg1, arg2);");
+    }
+
+    @Test
+    public void testSlf4jWarnNoArgs() {
+        passSlf4j("log.warn(message);");
+    }
+
+    @Test
+    public void testSlf4jError() {
+        passSlf4j("log.error(message, arg1);");
+    }
+
+    @Test
+    public void testSlf4jErrorMultipleArgs() {
+        passSlf4j("log.error(message, arg1, arg2);");
+    }
+
+    @Test
+    public void testSlf4jErrorNoArgs() {
+        passSlf4j("log.error(message);");
+    }
+
+    @Test
+    public void testSafeArgAuthHeader() {
+        failLogSafe("SafeArg.of(name, authHeader);");
+    }
+
+    @Test
+    public void testUnsafeArgAuthHeader() {
+        failLogSafe("UnsafeArg.of(name, bearerToken);");
+    }
+
+    @Test
+    public void testSafeArgBearerToken() {
+        failLogSafe("SafeArg.of(name, authHeader);");
+    }
+
+    @Test
+    public void testUnsafeArgBearerToken() {
+        failLogSafe("UnsafeArg.of(name, bearerToken);");
+    }
+
+    @Test
+    public void testSafeArg() {
+        passLogSafe("SafeArg.of(name, value);");
+    }
+
+    @Test
+    public void testUnsafeArg() {
+        passLogSafe("UnsafeArg.of(name, value);");
+    }
+
+    private void passSlf4j(String precondition) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import org.slf4j.Logger;",
+                "import org.slf4j.LoggerFactory;",
+                "import com.palantir.tokens.auth.AuthHeader;",
+                "import com.palantir.tokens.auth.BearerToken;",
+                "class Test {",
+                "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                "  void f(AuthHeader authHeader, BearerToken bearerToken, String message, Object arg1, Object arg2) {",
+                "    " + precondition,
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    private void failSlf4j(String precondition) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import org.slf4j.Logger;",
+                "import org.slf4j.LoggerFactory;",
+                "import com.palantir.tokens.auth.AuthHeader;",
+                "import com.palantir.tokens.auth.BearerToken;",
+                "class Test {",
+                "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                "  void f(AuthHeader authHeader, BearerToken bearerToken, String message, Object arg1, Object arg2) {",
+                "    // BUG: Diagnostic contains: not allowed to be logged",
+                "    " + precondition,
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    private void passLogSafe(String precondition) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import com.palantir.logsafe.SafeArg;",
+                "import com.palantir.logsafe.UnsafeArg;",
+                "import com.palantir.tokens.auth.AuthHeader;",
+                "import com.palantir.tokens.auth.BearerToken;",
+                "class Test {",
+                "  void f(AuthHeader authHeader, BearerToken bearerToken, String name, Object value) {",
+                "    " + precondition,
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    private void failLogSafe(String precondition) {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import com.palantir.logsafe.SafeArg;",
+                "import com.palantir.logsafe.UnsafeArg;",
+                "import com.palantir.tokens.auth.AuthHeader;",
+                "import com.palantir.tokens.auth.BearerToken;",
+                "class Test {",
+                "  void f(AuthHeader authHeader, BearerToken bearerToken, String name, Object value) {",
+                "    // BUG: Diagnostic contains: not allowed to be logged",
+                "    " + precondition,
+                "  }",
+                "}")
+                .doTest();
+    }
+}

--- a/versions.props
+++ b/versions.props
@@ -24,6 +24,7 @@ org.hamcrest:hamcrest-core = 2.1
 org.junit.jupiter:* = 5.4.1
 org.mockito:mockito-core = 2.28.2
 com.fasterxml.jackson.*:* = 2.9.9
+com.palantir.tokens:auth-tokens = 3.5.2
 
 # dependency-upgrader:OFF
 # Updating to 0.8 would raise our minimum compatible version to 5.2


### PR DESCRIPTION
## Before this PR
Authentication information contained in AuthHeader and BearerToken could be accidentally logged resulting in a potential security risk.

## After this PR
A new error-prone check will now flag logging of AuthHeader and BearerToken objects via the use of slf4j and Safe/Unsafe args as compile-time errors when enabled.
