### PR TITLE
[improvement] Support auto-applying error-prone suggested fixes

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -23,11 +23,15 @@ import org.gradle.api.provider.ListProperty;
 public class BaselineErrorProneExtension {
 
     private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
+            // Baseline checks
             "PreferBuiltInConcurrentKeySet",
             "PreferCollectionTransform",
             "PreferListsPartition",
             "PreferSafeLoggableExceptions",
-            "PreferSafeLoggingPreconditions");
+            "PreferSafeLoggingPreconditions",
+
+            // Built-in checks
+            "MissingOverride");
 
     private final ListProperty<String> patchChecks;
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -31,6 +31,7 @@ public class BaselineErrorProneExtension {
             "PreferSafeLoggingPreconditions",
 
             // Built-in checks
+            "ArrayEquals",
             "MissingOverride");
 
     private final ListProperty<String> patchChecks;

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.extensions;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Project;
+import org.gradle.api.provider.ListProperty;
+
+public class BaselineErrorProneExtension {
+
+    private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
+            "PreferBuiltInConcurrentKeySet",
+            "PreferCollectionTransform",
+            "PreferListsPartition",
+            "PreferSafeLoggableExceptions",
+            "PreferSafeLoggingPreconditions");
+
+    private final ListProperty<String> patchChecks;
+
+    public BaselineErrorProneExtension(Project project) {
+        patchChecks = project.getObjects().listProperty(String.class);
+        patchChecks.set(DEFAULT_PATCH_CHECKS);
+    }
+
+    public final ListProperty<String> getPatchChecks() {
+        return patchChecks;
+    }
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -65,7 +65,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                             errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
                             errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
 
-                            if (project.getProperties().containsKey(PROP_ERROR_PRONE_APPLY)) {
+                            if (project.hasProperty(PROP_ERROR_PRONE_APPLY)) {
                                 // TODO(gatesn): Is there a way to discover error-prone checks?
                                 // Maybe service-load from a ClassLoader configured with annotation processor path?
                                 // https://github.com/google/error-prone/pull/947

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -40,9 +40,9 @@ import org.gradle.api.tasks.testing.Test;
 public final class BaselineErrorProne implements Plugin<Project> {
 
     public static final String EXTENSION_NAME = "baselineErrorProne";
-    public static final String PROP_ERROR_PRONE_APPLY = "errorProneApply";
 
     private static final String ERROR_PRONE_JAVAC_VERSION = "9+181-r4173-1";
+    private static final String PROP_ERROR_PRONE_APPLY = "errorProneApply";
 
     @Override
     public void apply(Project project) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -40,9 +40,9 @@ import org.gradle.api.tasks.testing.Test;
 public final class BaselineErrorProne implements Plugin<Project> {
 
     public static final String EXTENSION_NAME = "baselineErrorProne";
+    public static final String PROP_ERROR_PRONE_APPLY = "errorProneApply";
 
     private static final String ERROR_PRONE_JAVAC_VERSION = "9+181-r4173-1";
-    private static final String PROP_ERROR_PRONE_APPLY = "errorProneApply";
 
     @Override
     public void apply(Project project) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -16,8 +16,10 @@
 
 package com.palantir.baseline.plugins;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.palantir.baseline.extensions.BaselineErrorProneExtension;
 import java.io.File;
 import java.util.AbstractList;
 import java.util.List;
@@ -29,19 +31,28 @@ import net.ltgt.gradle.errorprone.ErrorPronePlugin;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.tasks.Exec;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
 
 public final class BaselineErrorProne implements Plugin<Project> {
 
+    public static final String EXTENSION_NAME = "baselineErrorProne";
+
     private static final String ERROR_PRONE_JAVAC_VERSION = "9+181-r4173-1";
+    private static final String APPLY_TASK_NAME = "compileApply";
+    private static final String APPLY_TASK_GROUP = "Verification";
+    private static final String APPLY_TASK_DESCRIPTION = "Applies error prone suggested fixes in-place.";
 
     @Override
     public void apply(Project project) {
         project.getPluginManager().withPlugin("java", plugin -> {
+            BaselineErrorProneExtension errorProneExtension = project.getExtensions()
+                    .create(EXTENSION_NAME, BaselineErrorProneExtension.class, project);
             project.getPluginManager().apply(ErrorPronePlugin.class);
             String version = Optional.ofNullable(getClass().getPackage().getImplementationVersion())
                     .orElse("latest.release");
@@ -91,6 +102,48 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                             .setBootClasspath(new LazyConfigurationList(errorProneFiles)));
                         });
             }
+
+            // Create compile*Apply tasks that apply the errorprone-generated patch files
+            Task applyTask = project.getTasks().create(APPLY_TASK_NAME);
+            List<JavaCompile> compileTasks = ImmutableList.copyOf(
+                    project.getTasks().withType(JavaCompile.class).iterator());
+            compileTasks.forEach(javaCompile -> {
+                File patchFile = project.getBuildDir().toPath()
+                        .resolve("errorprone")
+                        .resolve(javaCompile.getName())
+                        .resolve("error-prone.patch")
+                        .toFile();
+                javaCompile.getOutputs().file(patchFile);
+
+                // TODO(gatesn): How can we flag this on/off? It appears to come with a hefty perf hit
+                ((ExtensionAware) javaCompile.getOptions()).getExtensions()
+                        .configure(ErrorProneOptions.class, errorProneOptions -> {
+                            // TODO(gatesn): Is there a way to discover error-prone checks?
+                            // Maybe service-load from a ClassLoader configured with annotation processor path?
+                            // https://github.com/google/error-prone/pull/947
+                            errorProneOptions.getErrorproneArgumentProviders().add(() -> ImmutableList.of(
+                                    "-XepPatchChecks:" + Joiner.on(',')
+                                            .join(errorProneExtension.getPatchChecks().get()),
+                                    "-XepPatchLocation:" + patchFile.getParentFile().getAbsolutePath()));
+                        });
+
+                project.getTasks().create(javaCompile.getName() + "Apply", Exec.class, task -> {
+                    task.setGroup(APPLY_TASK_GROUP);
+                    task.setDescription(APPLY_TASK_DESCRIPTION);
+
+                    task.setExecutable("patch");
+                    task.args("-p3", "-u");
+                    //task.args("-d", patchFile.getParentFile().getAbsoluteFile());
+                    task.args("-i", patchFile.getAbsolutePath());
+
+                    task.getInputs().file(patchFile);
+                    task.getOutputs().files(javaCompile.getSource());
+                    task.dependsOn(javaCompile);
+
+                    applyTask.dependsOn(task);
+                });
+            });
+
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -65,7 +65,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                             errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
                             errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
 
-                            Optional.ofNullable(project.getProperties().get(PROP_ERROR_PRONE_APPLY)).ifPresent(x -> {
+                            if (project.getProperties().containsKey(PROP_ERROR_PRONE_APPLY)) {
                                 // TODO(gatesn): Is there a way to discover error-prone checks?
                                 // Maybe service-load from a ClassLoader configured with annotation processor path?
                                 // https://github.com/google/error-prone/pull/947
@@ -73,7 +73,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                         "-XepPatchChecks:" + Joiner.on(',')
                                                 .join(errorProneExtension.getPatchChecks().get()),
                                         "-XepPatchLocation:IN_PLACE"));
-                            });
+                            }
                         });
             });
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package com.palantir.baseline
 
-import com.palantir.baseline.plugins.BaselineErrorProne
+
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
@@ -42,7 +42,7 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         public class Test { void test() {} }
         '''.stripIndent()
 
-    def inValidJavaFile = '''
+    def invalidJavaFile = '''
         package test;
         public class Test {
             void test() {
@@ -84,7 +84,7 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
     def 'compileJava fails when error-prone finds errors'() {
         when:
         buildFile << standardBuildFile
-        file('src/main/java/test/Test.java') << inValidJavaFile
+        file('src/main/java/test/Test.java') << invalidJavaFile
 
         then:
         BuildResult result = with('compileJava').buildAndFail()
@@ -105,7 +105,7 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
     def 'compileJava applies patches when error-prone finds errors'() {
         when:
         buildFile << standardBuildFile
-        file('src/main/java/test/Test.java') << inValidJavaFile
+        file('src/main/java/test/Test.java') << invalidJavaFile
 
         then:
         BuildResult result = with('compileJava', '-PerrorProneApply').build()

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -108,7 +108,7 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         file('src/main/java/test/Test.java') << inValidJavaFile
 
         then:
-        BuildResult result = with('compileJava', "-P${BaselineErrorProne.PROP_ERROR_PRONE_APPLY}=true").build()
+        BuildResult result = with('compileJava', "-P${BaselineErrorProne.PROP_ERROR_PRONE_APPLY}").build()
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
         file('src/main/java/test/Test.java').text == '''
         package test;

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -108,7 +108,7 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         file('src/main/java/test/Test.java') << inValidJavaFile
 
         then:
-        BuildResult result = with('compileJava', "-P${BaselineErrorProne.PROP_ERROR_PRONE_APPLY}").build()
+        BuildResult result = with('compileJava', '-PerrorProneApply').build()
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
         file('src/main/java/test/Test.java').text == '''
         package test;


### PR DESCRIPTION
## Before this PR
Error-prone compiler emits suggested fixes as log lines.

## After this PR
Setting `-PerrorProneApply=true` will configure `CompileJava` to apply error-prone suggested fixes to the source.
