### PR TITLE
[fix] Fix refaster compilation to support version recommendations

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -62,11 +62,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
                     .orElse("latest.release");
 
             Configuration refasterConfiguration = project.getConfigurations().create(REFASTER_CONFIGURATION);
-            Configuration refasterSources = project.getConfigurations()
-                    .create("refasterSources", configuration -> {
-                        configuration.extendsFrom(refasterConfiguration);
-                        configuration.setTransitive(false);
-                    });
             Configuration refasterCompilerConfiguration = project.getConfigurations()
                     .create("refasterCompiler", configuration -> configuration.extendsFrom(refasterConfiguration));
 
@@ -85,8 +80,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
                     .map(RegularFile::getAsFile);
 
             Task compileRefaster = project.getTasks().create("compileRefaster", RefasterCompileTask.class, task -> {
-                task.setSource(refasterSources);
-                task.getRefasterSources().from(refasterSources);
+                task.setSource(refasterConfiguration);
+                task.getRefasterSources().set(refasterConfiguration);
                 task.setClasspath(refasterCompilerConfiguration);
                 task.getRefasterRulesFile().set(refasterRulesFile);
             });


### PR DESCRIPTION
## Before this PR
Version recommendations (e.g. from BOMs) weren't applied to the refasterSources configuration since it was non-transitive.

## After this PR
We use a transitive configuration and filter in the compilation task down to first-level module dependencies.