### PR TITLE
[fix] Prevent null from flagging as authentication information in PreventTokenLogging check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreventTokenLogging.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreventTokenLogging.java
@@ -55,7 +55,7 @@ public final class PreventTokenLogging extends BugChecker implements BugChecker.
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (METHOD_MATCHER.matches(tree, state)) {
             for (Tree arg : tree.getArguments()) {
-                if (AUTH_MATCHER.matches(arg, state)) {
+                if (AUTH_MATCHER.matches(arg, state) && arg.getKind() != Tree.Kind.NULL_LITERAL) {
                     return buildDescription(arg)
                             .setMessage("Authentication information is not allowed to be logged.")
                             .build();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreventTokenLogging.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreventTokenLogging.java
@@ -46,16 +46,19 @@ public final class PreventTokenLogging extends BugChecker implements BugChecker.
                             .onClassAny("com.palantir.logsafe.SafeArg", "com.palantir.logsafe.UnsafeArg")
                             .named("of"));
 
-    private static final Matcher<Tree> AUTH_MATCHER =
-            Matchers.anyOf(
-                    Matchers.isSubtypeOf("com.palantir.tokens.auth.AuthHeader"),
-                    Matchers.isSubtypeOf("com.palantir.tokens.auth.BearerToken"));
+    private static final Matcher<ExpressionTree> AUTH_MATCHER =
+            Matchers.allOf(
+                    Matchers.anyOf(
+                            Matchers.isSubtypeOf("com.palantir.tokens.auth.AuthHeader"),
+                            Matchers.isSubtypeOf("com.palantir.tokens.auth.BearerToken")),
+                    Matchers.not(
+                            Matchers.kindIs(Tree.Kind.NULL_LITERAL)));
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (METHOD_MATCHER.matches(tree, state)) {
-            for (Tree arg : tree.getArguments()) {
-                if (AUTH_MATCHER.matches(arg, state) && arg.getKind() != Tree.Kind.NULL_LITERAL) {
+            for (ExpressionTree arg : tree.getArguments()) {
+                if (AUTH_MATCHER.matches(arg, state)) {
                     return buildDescription(arg)
                             .setMessage("Authentication information is not allowed to be logged.")
                             .build();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
@@ -145,6 +145,16 @@ public class PreventTokenLoggingTests {
     }
 
     @Test
+    public void testSlf4jTraceNullMessageNoArgs() {
+        passSlf4j("log.trace(null);");
+    }
+
+    @Test
+    public void testSlf4jTraceNullArg() {
+        passSlf4j("log.trace(message, arg1, null);");
+    }
+
+    @Test
     public void testSlf4jDebug() {
         passSlf4j("log.debug(message, arg1);");
     }
@@ -157,6 +167,16 @@ public class PreventTokenLoggingTests {
     @Test
     public void testSlf4jDebugNoArgs() {
         passSlf4j("log.debug(message);");
+    }
+
+    @Test
+    public void testSlf4jDebugNullMessageNoArgs() {
+        passSlf4j("log.debug(null);");
+    }
+
+    @Test
+    public void testSlf4jDebugNullArg() {
+        passSlf4j("log.debug(message, arg1, null);");
     }
 
     @Test
@@ -175,6 +195,16 @@ public class PreventTokenLoggingTests {
     }
 
     @Test
+    public void testSlf4jInfoNullMessageNoArgs() {
+        passSlf4j("log.info(null);");
+    }
+
+    @Test
+    public void testSlf4jInfoNullArg() {
+        passSlf4j("log.info(message, arg1, null);");
+    }
+
+    @Test
     public void testSlf4jWarn() {
         passSlf4j("log.warn(message, arg1);");
     }
@@ -190,6 +220,16 @@ public class PreventTokenLoggingTests {
     }
 
     @Test
+    public void testSlf4jWarnNullMessageNoArgs() {
+        passSlf4j("log.warn(null);");
+    }
+
+    @Test
+    public void testSlf4jWarnNullArg() {
+        passSlf4j("log.warn(message, arg1, null);");
+    }
+
+    @Test
     public void testSlf4jError() {
         passSlf4j("log.error(message, arg1);");
     }
@@ -202,6 +242,16 @@ public class PreventTokenLoggingTests {
     @Test
     public void testSlf4jErrorNoArgs() {
         passSlf4j("log.error(message);");
+    }
+
+    @Test
+    public void testSlf4jErrorNullMessageNoArgs() {
+        passSlf4j("log.error(null);");
+    }
+
+    @Test
+    public void testSlf4jErrorNullArg() {
+        passSlf4j("log.error(message, arg1, null);");
     }
 
     @Test
@@ -230,8 +280,28 @@ public class PreventTokenLoggingTests {
     }
 
     @Test
+    public void testSafeArgNullName() {
+        passLogSafe("SafeArg.of(null, value);");
+    }
+
+    @Test
+    public void testSafeArgNullValue() {
+        passLogSafe("SafeArg.of(name, null);");
+    }
+
+    @Test
     public void testUnsafeArg() {
         passLogSafe("UnsafeArg.of(name, value);");
+    }
+
+    @Test
+    public void testUnsafeArgNullName() {
+        passLogSafe("UnsafeArg.of(null, value);");
+    }
+
+    @Test
+    public void testUnsafeArgNullValue() {
+        passLogSafe("UnsafeArg.of(name, null);");
     }
 
     private void passSlf4j(String statement) {

--- a/changelog/@unreleased/pr-674.v2.yml
+++ b/changelog/@unreleased/pr-674.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The PreventTokenLogging error-prone check will now correctly handle
+    null use in SLF4J and Safe/Unsafe Arg functions.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/674


### PR DESCRIPTION
## Before this PR
Passing null into SLF4J and Safe/Unsafe Arg functions would incorrectly trigger false positives in the PreventTokenLogging error-prone check.

## After this PR
The PreventTokenLogging error-prone check will now correctly handle null use in SLF4J and Safe/Unsafe Arg functions.
