### PR TITLE
add refaster rule to migrate away from orElse(supplier.get())

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/OptionalOrElseSupplier.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/OptionalOrElseSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class OptionalOrElseSupplier<T> {
+    @BeforeTemplate
+    final T eagerOrElse(Optional<T> optional, Supplier<T> supplier) {
+        return optional.orElse(supplier.get());
+    }
+
+    @AfterTemplate
+    final T lazyOrElse(Optional<T> optional, Supplier<T> supplier) {
+        return optional.orElseGet(supplier);
+    }
+}

--- a/changelog/@unreleased/pr-679.v2.yml
+++ b/changelog/@unreleased/pr-679.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add refaster rule to migrate away from optional.orElse(supplier.get())
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/679


### PR DESCRIPTION
## Before this PR
In support of bringing back #655.

## After this PR
==COMMIT_MSG==
Add refaster rule to migrate away from optional.orElse(supplier.get())
==COMMIT_MSG==

## Possible downsides?
Unfortunately, this rule only seems to match cases where the parameter is explicitly a supplier and ignores cases such as a field access on an immutable.

@gatesn for SA