### PR TITLE
Support Java12 by suppressing one error-prone check

### DIFF
--- a/changelog/@unreleased/pr-681.v2.yml
+++ b/changelog/@unreleased/pr-681.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Projects can now compile using Java12, because the one errorprone check
+    that breaks (Finally) is now disabled when you use this toolchain. It remains
+    enabled when compiling against earlier JDKs.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/681

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -87,6 +87,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
             });
 
             project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
+                JavaVersion jdkVersion = JavaVersion.toVersion(javaCompile.getToolChain().getVersion());
+
                 ((ExtensionAware) javaCompile.getOptions()).getExtensions()
                         .configure(ErrorProneOptions.class, errorProneOptions -> {
                             errorProneOptions.setEnabled(true);
@@ -94,6 +96,12 @@ public final class BaselineErrorProne implements Plugin<Project> {
                             errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
                             errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
                             errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
+
+                            if (jdkVersion.isJava12Compatible()) {
+                                // Errorprone isn't officially compatible with Java12, but in practise everything
+                                // works apart from this one check: https://github.com/google/error-prone/issues/1106
+                                errorProneOptions.check("Finally", CheckSeverity.OFF);
+                            }
 
                             if (javaCompile.equals(compileRefaster)) {
                                 // Don't apply refaster to itself...

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -97,7 +97,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                             errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
                             errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
 
-                            if (jdkVersion.isJava12Compatible()) {
+                            if (jdkVersion.compareTo(JavaVersion.toVersion("12.0.1")) >= 0) {
                                 // Errorprone isn't officially compatible with Java12, but in practise everything
                                 // works apart from this one check: https://github.com/google/error-prone/issues/1106
                                 errorProneOptions.check("Finally", CheckSeverity.OFF);


### PR DESCRIPTION
## Before this PR

Internally, we just build against Java11 and Java8 for legacy projects.  Java12 GA'd [19th March 2019](https://openjdk.java.net/projects/jdk/12/) and it comes with the long-awaited [Shenandoah GC](https://openjdk.java.net/jeps/189), however, if you try to build against Java12 today errorprone [breaks](https://circleci.com/gh/palantir/tracing-java/843?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link):

```
An unhandled exception was thrown by the Error Prone static analysis plugin.
ERROR: An unhandled exception was thrown by the Error Prone static analysis plugin.
                    break;
                    ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.3.3
     BugPattern: Finally
     Stack Trace:
     java.lang.NoSuchFieldError: label
  	at com.google.errorprone.bugpatterns.Finally$FinallyJumpMatcher.<init>(Finally.java:171)
```

This is a [known issue](https://github.com/google/error-prone/issues/1106) with errorprone, and there's a two line fix that just hasn't been merged.

## After this PR
==COMMIT_MSG==
Projects can now compile using Java12, because the one errorprone check that breaks (Finally) is now disabled when you use this toolchain. It remains enabled when compiling against earlier JDKs.
==COMMIT_MSG==

Here's a green build showing this is sufficient: https://github.com/palantir/tracing-java/pull/135

https://errorprone.info/bugpattern/Finally

## Possible downsides?

- any project that _only_ compiles against Java12 is at risk of writing silly bugs that the Finally static analysis would have caught.  In practise, I think this is a minor risk because we expect projects to build against multiple JDKs (e.g. 8 and 12), or at least use a different JDK locally!

