### PR TITLE
Disallow dangling parenthesis

### DIFF
--- a/changelog/@unreleased/pr-687.v2.yml
+++ b/changelog/@unreleased/pr-687.v2.yml
@@ -1,25 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    Disallow dangling parenthesis
-
-    ## Before this PR
-    Generally our style has always been to disallow dangling parenthesis, but nothing applies this rule.
-
-    The aim of this PR, and any style PR, is to increase consistency of coding style and reduce time spent in CR commenting with stylistic nit picks.
-
-    ```java
-    Preconditions.checkArgument(
-        myExpression,
-        "My expression isn't as true as it should be"
-    );
-    ```
-
-    ## After this PR
-    ```java
-    Preconditions.checkArgument(
-        myExpression,
-        "My expression isn't as true as it should be");
-    ```
+    Spotless check for disallowing dangling parenthesis.
   links:
   - https://github.com/palantir/gradle-baseline/pull/687

--- a/changelog/@unreleased/pr-687.v2.yml
+++ b/changelog/@unreleased/pr-687.v2.yml
@@ -1,0 +1,25 @@
+type: improvement
+improvement:
+  description: |-
+    Disallow dangling parenthesis
+
+    ## Before this PR
+    Generally our style has always been to disallow dangling parenthesis, but nothing applies this rule.
+
+    The aim of this PR, and any style PR, is to increase consistency of coding style and reduce time spent in CR commenting with stylistic nit picks.
+
+    ```java
+    Preconditions.checkArgument(
+        myExpression,
+        "My expression isn't as true as it should be"
+    );
+    ```
+
+    ## After this PR
+    ```java
+    Preconditions.checkArgument(
+        myExpression,
+        "My expression isn't as true as it should be");
+    ```
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/687

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -50,6 +50,9 @@ class BaselineFormat extends AbstractBaselinePlugin {
 
                 // No empty lines at start of blocks
                 java.replaceRegex("Block starts with blank lines", "\\) \\{\n+", ") {\n");
+
+                // No dangling parentheses - closing paren must be on the same line as the expression
+                java.replaceRegex("Dangling closing parenthesis", "(\n\\s+)+\\)", ")");
             });
 
             // necessary because SpotlessPlugin creates tasks in an afterEvaluate block

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -38,6 +38,8 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
     package test;
     public class Test { void test() {
         int x = 1;
+        System.out.println(
+            "Hello");
     } }
     '''.stripIndent()
 
@@ -48,6 +50,9 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
     
     
         int x = 1;
+        System.out.println(
+            "Hello"
+        );
     } }
     '''.stripIndent()
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -40,6 +40,9 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
         int x = 1;
         System.out.println(
             "Hello");
+        Optional.of("hello").orElseGet(() -> {
+            return "Hello World";
+        });
     } }
     '''.stripIndent()
 
@@ -53,6 +56,9 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
         System.out.println(
             "Hello"
         );
+        Optional.of("hello").orElseGet(() -> { 
+            return "Hello World";
+        });
     } }
     '''.stripIndent()
 


### PR DESCRIPTION
## Before this PR
Generally our style has always been to disallow dangling parenthesis, but nothing applies this rule.

The aim of this PR, and any style PR, is to increase consistency of coding style and reduce time spent in CR commenting with stylistic nit picks.

```java
Preconditions.checkArgument(
    myExpression,
    "My expression isn't as true as it should be"
);
```

## After this PR
```java
Preconditions.checkArgument(
    myExpression,
    "My expression isn't as true as it should be");
```
