### PR TITLE
Ensure format executes after compile

### DIFF
--- a/changelog/@unreleased/pr-688.v2.yml
+++ b/changelog/@unreleased/pr-688.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Ensure that format tasks execute after compilation
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/688

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -21,6 +21,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.compile.JavaCompile;
 
 class BaselineFormat extends AbstractBaselinePlugin {
 
@@ -54,7 +55,11 @@ class BaselineFormat extends AbstractBaselinePlugin {
 
             // necessary because SpotlessPlugin creates tasks in an afterEvaluate block
             Task formatTask = project.task("format");
-            project.afterEvaluate(p -> formatTask.dependsOn(project.getTasks().getByName("spotlessApply")));
+            project.afterEvaluate(p -> {
+                Task spotlessApply = project.getTasks().getByName("spotlessApply");
+                formatTask.dependsOn(spotlessApply);
+                project.getTasks().withType(JavaCompile.class).configureEach(spotlessApply::mustRunAfter);
+            });
         });
     }
 }


### PR DESCRIPTION
## Before this PR
We would fail to correctly format code when applying errorProne/refaster fixes since there was no explicit ordering between formatting and compiling.

We encountered this issue as part of the excavator to upgrade baseline

## After this PR
==COMMIT_MSG==
Ensure that format tasks execute after compilation
==COMMIT_MSG==

## Possible downsides?
N/A

