### PR TITLE
Autofix orElseGet

### DIFF
--- a/changelog/@unreleased/pr-690.v2.yml
+++ b/changelog/@unreleased/pr-690.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Auto-fix OptionalOrElseMethodInvocation using `-PerrorProneApply`.
   links:
   - https://github.com/palantir/gradle-baseline/pull/690

--- a/changelog/@unreleased/pr-690.v2.yml
+++ b/changelog/@unreleased/pr-690.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Auto-fix OptionalOrElseMethodInvocation using `-PerrorProneApply`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/690

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -29,6 +29,7 @@ public class BaselineErrorProneExtension {
             "PreferListsPartition",
             "PreferSafeLoggableExceptions",
             "PreferSafeLoggingPreconditions",
+            "OptionalOrElseMethodInvocation",
 
             // Built-in checks
             "ArrayEquals",

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -115,6 +115,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                         "-XepPatchChecks:refaster:" + refasterRulesFile.get().getAbsolutePath(),
                                         "-XepPatchLocation:IN_PLACE"));
                             } else if (project.hasProperty(PROP_ERROR_PRONE_APPLY)) {
+                                javaCompile.getOptions().setWarnings(false);
                                 // TODO(gatesn): Is there a way to discover error-prone checks?
                                 // Maybe service-load from a ClassLoader configured with annotation processor path?
                                 // https://github.com/google/error-prone/pull/947

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -44,12 +44,14 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
 
     def invalidJavaFile = '''
         package test;
+        import java.util.Optional;
         public class Test {
             void test() {
                 int[] a = {1, 2, 3};
                 int[] b = {1, 2, 3};
                 if (a.equals(b)) {
                   System.out.println("arrays are equal!");
+                  Optional.of("hello").orElse(System.getProperty("world"));
                 }
             }
         }
@@ -114,12 +116,14 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         package test;
         
         import java.util.Arrays;
+        import java.util.Optional;
         public class Test {
             void test() {
                 int[] a = {1, 2, 3};
                 int[] b = {1, 2, 3};
                 if (Arrays.equals(a, b)) {
                   System.out.println("arrays are equal!");
+                  Optional.of("hello").orElseGet(() -> System.getProperty("world"));
                 }
             }
         }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -114,7 +114,6 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
         file('src/main/java/test/Test.java').text == '''
         package test;
-        
         import java.util.Arrays;
         import java.util.Optional;
         public class Test {


### PR DESCRIPTION
## Before this PR
OptionalOrElseMethodInvocation is not auto-fixed by `-PerrorProneApply`.

## After this PR
It does.

Will follow-up with a PR to auto-detect all baseline checks.