### PR TITLE
Allow collection constants in orElse

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocationTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocationTests.java
@@ -33,7 +33,7 @@ public final class OptionalOrElseMethodInvocationTests {
                 new OptionalOrElseMethodInvocation(), getClass());
     }
 
-    private void test(String expr) {
+    private void testPositive(String expr) {
         compilationHelper
                 .addSourceLines(
                         "Test.java",
@@ -47,12 +47,28 @@ public final class OptionalOrElseMethodInvocationTests {
                 .doTest();
     }
 
+    private void testNegative(String expr) {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.collect.*;",
+                        "import java.util.Collections;",
+                        "import java.util.Optional;",
+                        "class Test {",
+                        "  String f() { return \"hello\"; }",
+                        "  void test() {",
+                        "    Optional.empty().orElse(" + expr + ");",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
     @Test
     public void testNonCompileTimeConstantExpression() {
-        test("f()");
-        test("s + s");
-        test("\"world\" + s");
-        test("\"world\".substring(1)");
+        testPositive("f()");
+        testPositive("s + s");
+        testPositive("\"world\" + s");
+        testPositive("\"world\".substring(1)");
     }
 
     @Test
@@ -76,7 +92,7 @@ public final class OptionalOrElseMethodInvocationTests {
     }
 
     @Test
-    public void negative() {
+    public void testCompileTimeConstantExpression() {
         compilationHelper
                 .addSourceLines(
                         "Test.java",
@@ -95,4 +111,33 @@ public final class OptionalOrElseMethodInvocationTests {
                 .doTest();
     }
 
+    @Test
+    public void testConstantEmptyCollection() {
+        testNegative("Collections.emptyEnumeration()");
+        testNegative("Collections.emptyIterator()");
+        testNegative("Collections.emptyList()");
+        testNegative("Collections.emptyListIterator()");
+        testNegative("Collections.emptyMap()");
+        testNegative("Collections.emptyNavigableMap()");
+        testNegative("Collections.emptyNavigableSet()");
+        testNegative("Collections.emptySet()");
+        testNegative("Collections.emptySortedMap()");
+        testNegative("Collections.emptySortedSet()");
+        testNegative("ImmutableSet.of()");
+        testNegative("ImmutableBiMap.of()");
+        testNegative("ImmutableClassToInstanceMap.of()");
+        testNegative("ImmutableList.of()");
+        testNegative("ImmutableListMultimap.of()");
+        testNegative("ImmutableMap.of()");
+        testNegative("ImmutableMultimap.of()");
+        testNegative("ImmutableMultiset.of()");
+        testNegative("ImmutableRangeMap.of()");
+        testNegative("ImmutableRangeSet.of()");
+        testNegative("ImmutableSet.of()");
+        testNegative("ImmutableSetMultimap.of()");
+        testNegative("ImmutableSortedMap.of()");
+        testNegative("ImmutableSortedMultiset.of()");
+        testNegative("ImmutableSortedSet.of()");
+        testNegative("ImmutableTable.of()");
+    }
 }

--- a/changelog/@unreleased/pr-691.v2.yml
+++ b/changelog/@unreleased/pr-691.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Known constant collection values can now be used in optional.orElse(value).
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/691


### PR DESCRIPTION
## Before this PR
Using known constant collection values in `orElse` is forbidden. The current check requires changing this to use `orElseGet` which is less performant and a bit more confusing.

## After this PR
Using known constant collection values is allowed in `orElse`.

