### PR TITLE
Don't cache test tasks

### DIFF
--- a/changelog/@unreleased/pr-694.v2.yml
+++ b/changelog/@unreleased/pr-694.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    Don't cache test tasks in the build cache by default.
+    It's possible to restore caching by adding `com.palantir.baseline.restore-test-cache = true` to your `gradle.properties`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/694

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -30,8 +30,11 @@ public final class BaselineTesting implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getTasks().withType(Test.class).all(task -> {
+        project.getTasks().withType(Test.class).configureEach(task -> {
             task.jvmArgs("-XX:+HeapDumpOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError");
+
+            // Never cache test tasks, until we work out the correct inputs for ETE / integration tests
+            task.getOutputs().cacheIf(t -> false);
         });
 
         project.getPlugins().withType(JavaPlugin.class, p -> {
@@ -47,9 +50,6 @@ public final class BaselineTesting implements Plugin<Project> {
                         .findAny()
                         .ifPresent(ignored -> enableJUnit5ForAllTestTasks(project));
             });
-
-            // Never cache test tasks, until we work out the correct inputs for ETE / integration tests
-            project.getTasks().withType(Test.class).configureEach(test -> test.getOutputs().cacheIf(task -> false));
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -47,6 +47,9 @@ public final class BaselineTesting implements Plugin<Project> {
                         .findAny()
                         .ifPresent(ignored -> enableJUnit5ForAllTestTasks(project));
             });
+
+            // Never cache test tasks, until we work out the correct inputs for ETE / integration tests
+            project.getTasks().withType(Test.class).configureEach(test -> test.getOutputs().cacheIf(task -> false));
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -33,8 +33,10 @@ public final class BaselineTesting implements Plugin<Project> {
         project.getTasks().withType(Test.class).configureEach(task -> {
             task.jvmArgs("-XX:+HeapDumpOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError");
 
-            // Never cache test tasks, until we work out the correct inputs for ETE / integration tests
-            task.getOutputs().cacheIf(t -> false);
+            if (!Objects.equals("true", project.findProperty("com.palantir.baseline.restore-test-cache"))) {
+                // Never cache test tasks, until we work out the correct inputs for ETE / integration tests
+                task.getOutputs().cacheIf(t -> false);
+            }
         });
 
         project.getPlugins().withType(JavaPlugin.class, p -> {


### PR DESCRIPTION
## Before this PR

Enabling the gradle build cache could cause test tasks (particularly, integration and ete tests) to appear up to date and not run again, even though details about the other services being spun up in docker might have changed (such as their versions or configuration).

## After this PR
==COMMIT_MSG==
Don't cache test tasks in the build cache

This is to remediate the situation where the inputs of test tasks aren't properly configured. Specifically, the tasks might be relying on external files (such as `docker-compose.yml`) without gradle being aware of this, and so when only those files change, gradle doesn't know that the test tasks should be re-run and considers them up-to-date.
==COMMIT_MSG==

## Possible downsides?
All test tasks (`test`, `integrationTest` etc) now run unconditionally in CI.
