### PR TITLE
Don't cache when applying errorprone / refaster rules

### DIFF
--- a/changelog/@unreleased/pr-696.v2.yml
+++ b/changelog/@unreleased/pr-696.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: No longer cache javaCompile tasks when applying errorprone or refaster
+    checks.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/696

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -114,7 +114,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 errorProneOptions.getErrorproneArgumentProviders().add(() -> ImmutableList.of(
                                         "-XepPatchChecks:refaster:" + refasterRulesFile.get().getAbsolutePath(),
                                         "-XepPatchLocation:IN_PLACE"));
-                                // We no longer compile classes, so don't attempt to cache the declared output dirs
+                                // Don't attempt to cache since it won't capture the source files that might be modified
                                 javaCompile.getOutputs().cacheIf(t -> false);
                             } else if (project.hasProperty(PROP_ERROR_PRONE_APPLY)) {
                                 javaCompile.getOptions().setWarnings(false);
@@ -125,7 +125,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                         "-XepPatchChecks:" + Joiner.on(',')
                                                 .join(errorProneExtension.getPatchChecks().get()),
                                         "-XepPatchLocation:IN_PLACE"));
-                                // We no longer compile classes, so don't attempt to cache the declared output dirs
+                                // Don't attempt to cache since it won't capture the source files that might be modified
                                 javaCompile.getOutputs().cacheIf(t -> false);
                             }
                         });

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -114,6 +114,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 errorProneOptions.getErrorproneArgumentProviders().add(() -> ImmutableList.of(
                                         "-XepPatchChecks:refaster:" + refasterRulesFile.get().getAbsolutePath(),
                                         "-XepPatchLocation:IN_PLACE"));
+                                // We no longer compile classes, so don't attempt to cache the declared output dirs
+                                javaCompile.getOutputs().cacheIf(t -> false);
                             } else if (project.hasProperty(PROP_ERROR_PRONE_APPLY)) {
                                 javaCompile.getOptions().setWarnings(false);
                                 // TODO(gatesn): Is there a way to discover error-prone checks?
@@ -123,6 +125,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                         "-XepPatchChecks:" + Joiner.on(',')
                                                 .join(errorProneExtension.getPatchChecks().get()),
                                         "-XepPatchLocation:IN_PLACE"));
+                                // We no longer compile classes, so don't attempt to cache the declared output dirs
+                                javaCompile.getOutputs().cacheIf(t -> false);
                             }
                         });
             });


### PR DESCRIPTION
## Before this PR

We might accidentally cache javaCompile invocations that actually have a hidden output - the rewritten source files. This hidden output is not tracked by gradle, so if such attempts are cached, future invocations would stop rewriting the source files.

## After this PR
==COMMIT_MSG==
No longer cache javaCompile tasks when applying errorprone or refaster checks.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

