### PR TITLE
Correctly configure Junit5 for non-default test sets

### DIFF
--- a/changelog/@unreleased/pr-701.v2.yml
+++ b/changelog/@unreleased/pr-701.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Determine whether to use junitPlatform on a per source set basis
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/701

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -51,7 +51,6 @@ public final class BaselineTesting implements Plugin<Project> {
                         .getSourceSets()
                         .matching(ss -> hasCompileDependenciesMatching(proj, ss, this::isJunitJupiter))
                         .forEach(ss -> {
-                            log.info("Detected 'org:junit.jupiter:junit-jupiter', enabling useJUnitPlatform()");
                             String testTaskName = ss.getTaskName(null, "test");
                             Test testTask = (Test) proj.getTasks().findByName(testTaskName);
                             if (testTask == null) {
@@ -63,6 +62,8 @@ public final class BaselineTesting implements Plugin<Project> {
                                     return;
                                 }
                             }
+                            log.info("Detected 'org:junit.jupiter:junit-jupiter', enabling useJUnitPlatform() on {}",
+                                    testTask.getName());
                             enableJunit5ForTestTask(testTask);
                         });
             });

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -102,6 +102,6 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         then:
         BuildResult result = with('integrationTest', '--write-locks').build()
         result.task(':integrationTest').outcome == TaskOutcome.SUCCESS
-        new File(projectDir, "build/reports/tests/test/classes/test.TestClass5.html").exists()
+        new File(projectDir, "build/reports/tests/integrationTest/classes/test.TestClass5.html").exists()
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package com.palantir.baseline
 
-
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
@@ -77,6 +76,32 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         BuildResult result = with('test', '--write-locks').build()
         result.task(':test').outcome == TaskOutcome.SUCCESS
         new File(projectDir, "build/reports/tests/test/classes/test.TestClass4.html").exists()
+        new File(projectDir, "build/reports/tests/test/classes/test.TestClass5.html").exists()
+    }
+
+    def 'runs integration tests with junit5'() {
+        when:
+        buildFile << '''
+        plugins {
+            id 'org.unbroken-dome.test-sets' version '2.1.1'
+        }
+        '''.stripIndent()
+        buildFile << standardBuildFile
+        buildFile << '''
+
+        testSets {
+            integrationTest
+        }
+        
+        dependencies {
+            integrationTestImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
+        }
+        '''.stripIndent()
+        file('src/integrationTest/java/test/TestClass5.java') << junit5Test
+
+        then:
+        BuildResult result = with('integrationTest', '--write-locks').build()
+        result.task(':integrationTest').outcome == TaskOutcome.SUCCESS
         new File(projectDir, "build/reports/tests/test/classes/test.TestClass5.html").exists()
     }
 }


### PR DESCRIPTION
## Before this PR
We would only configure tests to use junitPlatform if they had a `junit-jupiter` dependency to their test runtime classpath. This was confusing since projects which only had integration/ETE tests would have to add an unecessary dependency

## After this PR
==COMMIT_MSG==
Determine whether to use junitPlatform on a per source set basis
==COMMIT_MSG==

## Possible downsides?
N/A

