### PR TITLE
Promote safe logging checks from SUGGESTION -> WARNING

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
         name = "PreferSafeLoggableExceptions",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = BugPattern.SeverityLevel.WARNING,
         summary = "Throw SafeLoggable exceptions to ensure the exception message will not be redacted")
 public final class PreferSafeLoggableExceptions extends BugChecker implements BugChecker.NewClassTreeMatcher {
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
         name = "PreferSafeLoggingPreconditions",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = BugPattern.SeverityLevel.WARNING,
         summary = "Precondition and similar checks with a constant message and no parameters should use equivalent "
                 + "checks from com.palantir.logsafe.Preconditions for standardization as functionality is the same.")
 public final class PreferSafeLoggingPreconditions extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {

--- a/changelog/@unreleased/pr-697.v2.yml
+++ b/changelog/@unreleased/pr-697.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The severity of PreferSafeLoggableExceptions and PreferSafeLoggingPreconditions is now WARNING.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/704


### PR DESCRIPTION
## Before this PR
The severity of `PreferSafeLoggableExceptions` and `PreferSafeLoggingPreconditions` is `SUGGESTION`.

## After this PR
The severity of `PreferSafeLoggableExceptions` and `PreferSafeLoggingPreconditions` is `WARNING`.

Reasons:
  1. It seems like we wanted to change these at some point in the future:
    - https://github.com/palantir/gradle-baseline/pull/440#issue-225172777
    - https://github.com/palantir/gradle-baseline/pull/517#discussion_r249577418
  2. We provide a suggested fix for `PreferSafeLoggingPreconditions`.
  3. `WARNING` seems like a better _default_ severity. Downgrading the severity for either check is as easy as adding an [error-prone option](http://errorprone.info/docs/flags) like `-Xep:PreferSafeLoggableExceptions:SUGGESTION`.