### PR TITLE
Allow method references in Optional orElse

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocation.java
@@ -45,13 +45,9 @@ public final class OptionalOrElseMethodInvocation extends BugChecker implements 
             .onExactClass("java.util.Optional")
             .named("orElse");
 
-    private static final Matcher<ExpressionTree> METHOD_OR_CONSTRUCTOR = Matchers.anyOf(
-            MethodMatchers.anyMethod(),
-            MethodMatchers.constructor());
-
     private static final Matcher<ExpressionTree> METHOD_INVOCATIONS = Matchers.anyOf(
-            METHOD_OR_CONSTRUCTOR,
-            Matchers.contains(ExpressionTree.class, METHOD_OR_CONSTRUCTOR));
+            MethodInvocationMatcher.INSTANCE,
+            Matchers.contains(ExpressionTree.class, MethodInvocationMatcher.INSTANCE));
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
@@ -74,4 +70,21 @@ public final class OptionalOrElseMethodInvocation extends BugChecker implements 
                 .build();
     }
 
+    private enum MethodInvocationMatcher implements Matcher<ExpressionTree> {
+
+        INSTANCE;
+
+        @Override
+        public boolean matches(ExpressionTree tree, VisitorState state) {
+            switch (tree.getKind()) {
+                case NEW_CLASS:
+                case METHOD_INVOCATION:
+                    return true;
+                default:
+                    break;
+            }
+
+            return false;
+        }
+    }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocation.java
@@ -29,6 +29,7 @@ import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree.Kind;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -76,15 +77,9 @@ public final class OptionalOrElseMethodInvocation extends BugChecker implements 
 
         @Override
         public boolean matches(ExpressionTree tree, VisitorState state) {
-            switch (tree.getKind()) {
-                case NEW_CLASS:
-                case METHOD_INVOCATION:
-                    return true;
-                default:
-                    break;
-            }
-
-            return false;
+            Kind kind = tree.getKind();
+            return kind == Kind.NEW_CLASS
+                    || kind == Kind.METHOD_INVOCATION;
         }
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocationTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocationTests.java
@@ -129,6 +129,21 @@ public final class OptionalOrElseMethodInvocationTests {
     }
 
     @Test
+    public void testMethodReference() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.Optional;",
+                        "import java.util.function.Supplier;",
+                        "class Test {",
+                        "  String f() { return \"hello\"; }",
+                        "  private final Optional<Supplier<String>> optionalSupplier = Optional.of(() -> \"hello\");",
+                        "  private final Supplier<String> supplier = optionalSupplier.orElse(this::f);",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testOrElseGet() {
         compilationHelper
                 .addSourceLines(

--- a/changelog/@unreleased/pr-709.v2.yml
+++ b/changelog/@unreleased/pr-709.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: OptionalOrElseMethodInvocation now allows method references in orElse.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/709


### PR DESCRIPTION
## Before this PR
Using a method reference in an `Optional.orElse(...)` call resulted in a false positive.

## After this PR
Using a method reference in an `Optional.orElse(...)` call is allowed.

The `MethodMatchers` matchers only look at symbols and check whether a given symbol refers to a method. This means they are unable to distinguish between a method invocation and a method reference.

