### PR TITLE
Allow static import of spark sql functions

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -88,7 +88,8 @@
                 java.util.stream.Collectors.*,
                 com.palantir.logsafe.Preconditions.*,
                 com.google.common.base.Preconditions.*,
-                org.apache.commons.lang3.Validate.*"/>
+                org.apache.commons.lang3.Validate.*",
+                "org.apache.spark.sql.functions.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -88,8 +88,8 @@
                 java.util.stream.Collectors.*,
                 com.palantir.logsafe.Preconditions.*,
                 com.google.common.base.Preconditions.*,
-                org.apache.commons.lang3.Validate.*",
-                "org.apache.spark.sql.functions.*"/>
+                org.apache.commons.lang3.Validate.*,
+                org.apache.spark.sql.functions.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>


### PR DESCRIPTION
## Before this PR

If we static import spark sql functions such as `lit`, `sum` etc, checkstyle fails even though this is the recommended way to use them for code like this:

```
df.agg(sum("col1")).withColumn("idx", lit("5")))
```

## After this PR
==COMMIT_MSG==
Allows static importing spark sql functions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

