### PR TITLE
Do not overwrite junit5 test config

### DIFF
--- a/changelog/@unreleased/pr-712.v2.yml
+++ b/changelog/@unreleased/pr-712.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Do not overwrite user provided test configure when using junit5
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/712

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -25,6 +25,8 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.TestFrameworkOptions;
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +88,10 @@ public final class BaselineTesting implements Plugin<Project> {
     }
 
     private void enableJunit5ForTestTask(Test task) {
-        task.useJUnitPlatform();
+        TestFrameworkOptions options = task.getOptions();
+        if (!(options instanceof JUnitPlatformOptions)) {
+            task.useJUnitPlatform();
+        }
 
         task.systemProperty("junit.platform.output.capture.stdout", "true");
         task.systemProperty("junit.platform.output.capture.stderr", "true");


### PR DESCRIPTION
## Before this PR
Baseline would overwrite any options that a user provided to the junit5 test framework

## After this PR
==COMMIT_MSG==
Do not overwrite user provided test configure when using junit5
==COMMIT_MSG==

## Possible downsides?
N/A

