### PR TITLE
Checkstyle now accepts the output of the eclipse formatter

### DIFF
--- a/changelog/@unreleased/pr-715.v2.yml
+++ b/changelog/@unreleased/pr-715.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Checkstyle now tolerates empty lambda bodies (e.g. `() -> {}`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/715

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -422,6 +422,7 @@
             <property name="allowEmptyMethods" value="true"/>
             <property name="allowEmptyTypes" value="true"/>
             <property name="allowEmptyLoops" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
             <property name="ignoreEnhancedForColon" value="false"/>
             <message key="ws.notFollowed" value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
             <message key="ws.notPreceded" value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>


### PR DESCRIPTION
## Before this PR

I just released 1.7.0 and tried out `./gradlew format` on an internal project. Unfortunately, since we're still in the hybrid world where we have both checkstyle _and_ spotless autoformatting, checkstyle currently doesn't accept the format that spotless produced!

## After this PR
==COMMIT_MSG==
Checkstyle now tolerates empty lambda bodies (e.g. `() -> {}`
==COMMIT_MSG==

## Possible downsides?
