### PR TITLE
Remove custom idea JDK configuration

### DIFF
--- a/changelog/@unreleased/pr-718.v2.yml
+++ b/changelog/@unreleased/pr-718.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The `baseline-idea` plugin now generates configuration more closely aligned with Gradle defaults.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/718

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -61,7 +61,6 @@ class BaselineIdea extends AbstractBaselinePlugin {
             }
 
             // Configure Idea module
-            addJdkVersion(ideaModuleModel)
             markResourcesDirs(ideaModuleModel)
             moveProjectReferencesToEnd(ideaModuleModel)
         }
@@ -226,29 +225,6 @@ class BaselineIdea extends AbstractBaselinePlugin {
         }
 
         return base.appendNode(name, attributes + defaults)
-    }
-
-    /**
-     * Configures JDK and Java language level of the given IdeaModel according to the sourceCompatibility property.
-     */
-    private void addJdkVersion(IdeaModel ideaModel) {
-        def compileJavaTask = (JavaCompile) project.tasks.findByName('compileJava')
-        if (compileJavaTask) {
-            def javaVersion = compileJavaTask.sourceCompatibility
-            def jdkVersion = 'JDK_' + javaVersion.replaceAll('\\.', '_')
-            project.logger.debug("BaselineIdea: Configuring IDEA Module for Java version: " + javaVersion)
-
-            if (ideaModel.project != null) {
-                ideaModel.project.languageLevel = javaVersion
-            }
-
-            ideaModel.module.jdkName = javaVersion
-            ideaModel.module.iml.withXml {
-                it.asNode().component.find { it.@name == 'NewModuleRootManager' }.@LANGUAGE_LEVEL = jdkVersion
-            }
-        } else {
-            project.logger.debug("BaselineIdea: No Java version found in sourceCompatibility property.")
-        }
     }
 
     /**

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -70,36 +70,6 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         with('idea').build()
     }
 
-    def 'Modules for subprojects pick up the correct sourceCompatibility'() {
-        when:
-        buildFile << standardBuildFile
-        buildFile << '''
-            sourceCompatibility = 1.6
-        '''.stripIndent()
-        def subproject = multiProject.create(["subproject1", "subproject2"])
-        subproject["subproject1"].buildGradle << '''
-            apply plugin: 'java'
-            apply plugin: 'com.palantir.baseline-idea'
-            sourceCompatibility = 1.7
-        '''.stripIndent()
-        subproject["subproject2"].buildGradle << '''
-            apply plugin: 'java'
-            apply plugin: 'com.palantir.baseline-idea'
-            sourceCompatibility = 1.8
-        '''.stripIndent()
-
-        then:
-        with('idea').build()
-        def rootIml = Files.asCharSource(new File(projectDir, projectDir.name + ".iml"), Charsets.UTF_8).read()
-        rootIml ==~ /(?s).*orderEntry[^\\n]*jdkName="1.6".*/
-        def subproject1Iml = Files.asCharSource(new File(projectDir, "subproject1/subproject1.iml"),
-                Charsets.UTF_8).read()
-        subproject1Iml ==~ /(?s).*orderEntry[^\\n]*jdkName="1.7".*/
-        def subproject2Iml = Files.asCharSource(new File(projectDir, "subproject2/subproject2.iml"),
-                Charsets.UTF_8).read()
-        subproject2Iml ==~ /(?s).*orderEntry[^\\n]*jdkName="1.8".*/
-    }
-
     def 'Idea project has copyright configuration'() {
         when:
         buildFile << standardBuildFile


### PR DESCRIPTION
## Before this PR
- The `baseline-idea` plugin explicitly sets the JDK version for each module instead of inheriting the JDK version from the idea project.
  - This makes it cumbersome to change the JDK version for an entire idea project because it requires changing it for each module individually.
  - It seems a bit strange to allow different modules in the same project to use different JDK versions.
  - This is broken if the user does not have all the necessary JDK versions installed. Users should only need a single JDK version, as long as it is compatible with the desired language levels.
- The `baseline-idea` plugin configures the project language level when applying the plugin to each module (even if modules have different language levels).

## After this PR
- The `baseline-idea` plugin configures modules to inherit the JDK version from the idea project (this is the [default behavior of the idea plugin](https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.html#org.gradle.plugins.ide.idea.model.IdeaModule:jdkName)).
    - This means that all modules in a project will now use the same JDK version. Note that this is different than the language level, which determines what features are allowed in a module.
- The `baseline-idea` plugin no longer sets the project language level to the source compatibility. In fact, the [documentation specifically recommends](https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.idea.model.IdeaProject.html#org.gradle.plugins.ide.idea.model.IdeaProject:languageLevel) _not_ setting this value.

    > Generally, it isn't recommended to change this value. Instead, you are encouraged to set sourceCompatibility and targetCompatibility for your Gradle projects which allows you to have full control over language levels in Gradle projects, and means that Gradle and IDEA will use the same settings when compiling.
    >
    > When not explicitly set, this is calculated as the maximum language level for the Idea modules of this Idea project.

<br>

As always, these options can be overridden by modifying the idea plugin config (for example, if a project truly needs to use different JDK versions in different modules). But I think this change results in a better default idea configuration.