### PR TITLE
Enforce spotless format

### DIFF
--- a/changelog/@unreleased/pr-722.v2.yml
+++ b/changelog/@unreleased/pr-722.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enforce that all source passes spotless format
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/722

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -40,7 +40,9 @@ class BaselineFormat extends AbstractBaselinePlugin {
         project.getPluginManager().withPlugin("java", plugin -> {
             project.getPluginManager().apply("com.diffplug.gradle.spotless");
 
-            project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
+            SpotlessExtension spotlessExt = project.getExtensions().getByType(SpotlessExtension.class);
+            spotlessExt.setEnforceCheck(true);
+            spotlessExt.java(java -> {
                 // Configure a lazy FileCollection then pass it as the target
                 ConfigurableFileCollection allJavaFiles = project.files();
                 project


### PR DESCRIPTION
## Before this PR
We did not enforce spotless format. This was OK since the checkstyle would catch the format violations. This breaks down when a repo opts into using the eclipse formatter since nothing ensures that your code is well formatted

## After this PR
==COMMIT_MSG==
Enforce that all source passes spotless format
==COMMIT_MSG==

## Possible downsides?
There may be some red PRs if users had previously disabled checkstyle. In those cases, users can always opt out through the spotless extension

