### PR TITLE
Fix spotless apply with eclipse config

### DIFF
--- a/changelog/@unreleased/pr-724.v2.yml
+++ b/changelog/@unreleased/pr-724.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Correctly set dependency between spotlessApply and baselineUpdateConfig
+    to prevent a race
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/724

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -65,10 +65,11 @@ class BaselineFormat extends AbstractBaselinePlugin {
             Task formatTask = project.task("format");
             project.afterEvaluate(p -> {
                 Task spotlessJava = project.getTasks().getByName("spotlessJava");
+                Task spotlessApply = project.getTasks().getByName("spotlessApply");
                 if (eclipseFormattingEnabled(project) && !Files.exists(eclipseXml)) {
                     spotlessJava.dependsOn(project.getTasks().findByPath(":baselineUpdateConfig"));
                 }
-                formatTask.dependsOn(spotlessJava);
+                formatTask.dependsOn(spotlessApply);
                 project.getTasks().withType(JavaCompile.class).configureEach(spotlessJava::mustRunAfter);
             });
         });

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -63,11 +63,11 @@ class BaselineFormat extends AbstractBaselinePlugin {
 
             // necessary because SpotlessPlugin creates tasks in an afterEvaluate block
             Task formatTask = project.task("format");
-            if (eclipseFormattingEnabled(project) && !Files.exists(eclipseXml)) {
-                formatTask.dependsOn(project.getTasks().findByPath(":baselineUpdateConfig"));
-            }
             project.afterEvaluate(p -> {
                 Task spotlessApply = project.getTasks().getByName("spotlessApply");
+                if (eclipseFormattingEnabled(project) && !Files.exists(eclipseXml)) {
+                    spotlessApply.dependsOn(project.getTasks().findByPath(":baselineUpdateConfig"));
+                }
                 formatTask.dependsOn(spotlessApply);
                 project.getTasks().withType(JavaCompile.class).configureEach(spotlessApply::mustRunAfter);
             });

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -64,12 +64,12 @@ class BaselineFormat extends AbstractBaselinePlugin {
             // necessary because SpotlessPlugin creates tasks in an afterEvaluate block
             Task formatTask = project.task("format");
             project.afterEvaluate(p -> {
-                Task spotlessApply = project.getTasks().getByName("spotlessApply");
+                Task spotlessJava = project.getTasks().getByName("spotlessJava");
                 if (eclipseFormattingEnabled(project) && !Files.exists(eclipseXml)) {
-                    spotlessApply.dependsOn(project.getTasks().findByPath(":baselineUpdateConfig"));
+                    spotlessJava.dependsOn(project.getTasks().findByPath(":baselineUpdateConfig"));
                 }
-                formatTask.dependsOn(spotlessApply);
-                project.getTasks().withType(JavaCompile.class).configureEach(spotlessApply::mustRunAfter);
+                formatTask.dependsOn(spotlessJava);
+                project.getTasks().withType(JavaCompile.class).configureEach(spotlessJava::mustRunAfter);
             });
         });
     }


### PR DESCRIPTION
## Before this PR
There was a race when running spotlessApply with eclipse formatting enabled for the first time since `:baselineUpdateConfig` and `spotlessApply` would run concurrently

## After this PR
==COMMIT_MSG==
Correctly set dependency between spotlessApply and baselineUpdateConfig to prevent a race
==COMMIT_MSG==

## Possible downsides?
N/A

@diogoholanda for SA
