### PR TITLE
Junit5RuleUsage respects migration support

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testCompile 'commons-lang:commons-lang'
     testCompile 'org.junit.jupiter:junit-jupiter-api'
     testCompile gradleApi()
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-migrationsupport'
 
     annotationProcessor 'com.google.auto.service:auto-service'
     compileOnly 'com.google.auto.service:auto-service'

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/JUnit5RuleUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/JUnit5RuleUsage.java
@@ -37,16 +37,20 @@ public final class JUnit5RuleUsage extends BugChecker implements BugChecker.Clas
     private static final String JUNIT4_RULE = "org.junit.Rule";
     private static final String JUNIT4_CLASS_RULE = "org.junit.ClassRule";
     private static final String JUNIT5_TEST_ANNOTATION = "org.junit.jupiter.api.Test";
+    private static final String RULE_MIGRATION_SUPPORT =
+            "org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport";
 
+    private static final Matcher<ClassTree> hasMigrationSupport = Matchers.hasAnnotation(RULE_MIGRATION_SUPPORT);
     private static final Matcher<ClassTree> hasJunit5TestCases =
             Matchers.hasMethod(Matchers.hasAnnotationOnAnyOverriddenMethod(JUNIT5_TEST_ANNOTATION));
-
     private static final Matcher<ClassTree> hasJunit4Rules = hasVariable(
             Matchers.anyOf(hasAnnotationOnVariable(JUNIT4_CLASS_RULE), hasAnnotationOnVariable(JUNIT4_RULE)));
 
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
-        if (hasJunit5TestCases.matches(tree, state) && hasJunit4Rules.matches(tree, state)) {
+        if (!hasMigrationSupport.matches(tree, state)
+                && hasJunit5TestCases.matches(tree, state)
+                && hasJunit4Rules.matches(tree, state)) {
             return buildDescription(tree)
                     .setMessage("Do not use Rule/ClassRule with junit-jupiter")
                     .build();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JUnit5RuleUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JUnit5RuleUsageTest.java
@@ -60,6 +60,22 @@ public class JUnit5RuleUsageTest {
     }
 
     @Test
+    public void test_rule_migration_support() {
+        compilationHelper.addSourceLines(
+                "TestCase.java",
+                "import org.junit.Rule;",
+                "import org.junit.jupiter.api.Test;",
+                "import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;",
+                "@EnableRuleMigrationSupport",
+                "class TestCase {",
+                "@Rule public static int foo = 1;",
+                "@Test",
+                "public void test() { }",
+                "}")
+                .doTest();
+    }
+
+    @Test
     public void test_rule_with_junit4() {
         compilationHelper.addSourceLines(
                 "TestCase.java",

--- a/changelog/@unreleased/pr-725.v2.yml
+++ b/changelog/@unreleased/pr-725.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Correctly handle `EnableRuleMigrationSupport` in `JUnit5RuleUsage`
+    errorprone-rule
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/725


### PR DESCRIPTION
## Before this PR
We would incorrectly throw an error if users had junit-jupiter tests with junit4 Rule and EnableRuleMigrationSupport

## After this PR
==COMMIT_MSG==
Correctly handle `EnableRuleMigrationSupport` in `JUnit5RuleUsage` errorprone-rule
==COMMIT_MSG==

## Possible downsides?
N/A

