### PR TITLE
Allow suppression of TODO checkstyle check

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -374,6 +374,11 @@
             <property name="message" value="Redundant ''static'' modifier."/>
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="id" value="TodoFormat"/>
+            <property name="format" value="\/\/TODO|\/\/ TODO(?!\([^()\s]+\): )"/>
+            <property name="message" value="TODO format: '// TODO(#issue): explanation' or '// TODO(username): explanation'"/>
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>
             <property name="message" value="Test setup/teardown methods are called before(), beforeClass(), after(), afterClass(), but not setUp, teardown, etc."/>
         </module>

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -374,10 +374,6 @@
             <property name="message" value="Redundant ''static'' modifier."/>
         </module>
         <module name="RegexpSinglelineJava">
-            <property name="format" value="\/\/TODO|\/\/ TODO(?!\([^()\s]+\): )"/>
-            <property name="message" value="TODO format: // TODO(#issue): explanation"/>
-        </module>
-        <module name="RegexpSinglelineJava">
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>
             <property name="message" value="Test setup/teardown methods are called before(), beforeClass(), after(), afterClass(), but not setUp, teardown, etc."/>
         </module>

--- a/changelog/@unreleased/pr-727.v2.yml
+++ b/changelog/@unreleased/pr-727.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: "Allow suppression of the TODO checkstyle check by giving it an ID. Clarify its comment to allow // TODO(username): ..."
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/727


### PR DESCRIPTION
## Before this PR
Allow suppression of the `TODO` checkstyle check by giving it an ID. Clarify its comment to allow `// TODO(username): ...`

## After this PR
==COMMIT_MSG==
No more unhelpful checkstyle demand for a ticket associated with each TODO.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

