### PR TITLE
print out suggestion for module dependencies inclusion in useful format

### DIFF
--- a/changelog/@unreleased/pr-733.v2.yml
+++ b/changelog/@unreleased/pr-733.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: print out suggestion for module dependencies inclusion in useful format
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/733

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -81,7 +81,6 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
                 .filter(artifact -> !shouldIgnore(artifact))
                 .collect(Collectors.toList());
         if (!usedButUndeclared.isEmpty()) {
-
             String suggestion = usedButUndeclared.stream()
                     .map(artifact -> getSuggestionString(artifact))
                     .sorted()
@@ -97,17 +96,17 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
     }
 
     private String getSuggestionString(ResolvedArtifact artifact) {
-        String artifactNameString = isProjectArtifact(artifact) ?
-            String.format("project('%s')", ((ProjectComponentIdentifier)artifact.getId().getComponentIdentifier()).getProjectPath()) :
-            String.format("'%s:%s'", artifact.getModuleVersion().getId().getGroup(), artifact.getModuleVersion().getId().getName());
+        String artifactNameString = isProjectArtifact(artifact)
+                ? String.format("project('%s')",
+                        ((ProjectComponentIdentifier) artifact.getId().getComponentIdentifier()).getProjectPath())
+                : String.format("'%s:%s'",
+                        artifact.getModuleVersion().getId().getGroup(), artifact.getModuleVersion().getId().getName());
         return String.format("        implementation %s", artifactNameString);
     }
 
     /**
      * Return true if the resolved artifact is derived from a project in the current build rather than an
      * external jar.
-     * @param artifact
-     * @return
      */
     private boolean isProjectArtifact(ResolvedArtifact artifact) {
         return artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier;

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -19,6 +19,14 @@ package com.palantir.baseline.tasks;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.palantir.baseline.plugins.BaselineExactDependencies;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
@@ -34,10 +42,6 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
-
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class CheckImplicitDependenciesTask extends DefaultTask {
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -93,16 +93,9 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
     }
 
     private String getSuggestionString(ResolvedArtifact artifact) {
-        String artifactNameString;
-        if (isProjectArtifact(artifact)) {
-            artifactNameString = String.format("project('%s')",
-                    ((ProjectComponentIdentifier)artifact.getId().getComponentIdentifier()).getProjectPath());
-        }
-        else {
-            artifactNameString = String.format("'%s:%s'",
-                    artifact.getModuleVersion().getId().getGroup(),
-                    artifact.getModuleVersion().getId().getName());
-        }
+        String artifactNameString = isProjectArtifact(artifact) ?
+            String.format("project('%s')", ((ProjectComponentIdentifier)artifact.getId().getComponentIdentifier()).getProjectPath()) :
+            String.format("'%s:%s'", artifact.getModuleVersion().getId().getGroup(), artifact.getModuleVersion().getId().getName());
         return String.format("        implementation %s", artifactNameString);
     }
 


### PR DESCRIPTION
using "project(':project-name')" rather than treating it as a jar.

## Before this PR
Suggestions for adding implicit dependency to another module in the same project were not useful because they displayed as artifacts (like jars)

## After this PR
==COMMIT_MSG==
print out suggestion for module dependencies inclusion in useful format
using "project(':project-name')" rather than treating it as a jar.
==COMMIT_MSG==

## Possible downsides?
none

