### PR TITLE
add flag to not fail if implicit deps are found.  

### DIFF
--- a/changelog/@unreleased/pr-734.v2.yml
+++ b/changelog/@unreleased/pr-734.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: add flag to not fail if implicit deps are found.  This is so the task can be used in workflow where
+    its outputs are used by subsequent tasks.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/734

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -16,10 +16,9 @@
 
 package com.palantir.baseline
 
+import java.nio.file.Files
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
-
-import java.nio.file.Files
 
 class BaselineExactDependenciesTest extends AbstractPluginTest {
 
@@ -102,6 +101,22 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.output.contains("Found 1 implicit dependencies")
     }
 
+    def 'checkImplicitDependencies does not fail if failIfImplicitDependencies is set to false'() {
+        when:
+        setupMultiProject()
+        buildFile << """
+            checkImplicitDependencies {
+                failIfImplicitDependencies false
+            }
+        """.stripIndent()
+
+        then:
+        BuildResult result = with('checkImplicitDependencies', '--stacktrace').withDebug(true).buildAndFail()
+        //handy to check for this because then get full output string in test output if it fails
+        !result.output.contains("GradleScriptException")
+        result.task(':checkImplicitDependencies').getOutcome() == TaskOutcome.SUCCESS
+    }
+
     def 'checkImplicitDependencies succeeds when cross-project dependencies properly declared'() {
         when:
         setupMultiProject()
@@ -113,7 +128,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
 
     }
 
-    def 'checkImplicitDependencies fails on transitive project dependency'() {
+    def 'checkImplicitDependencies fails on implicit project dependency'() {
         when:
         setupMultiProject()
 
@@ -185,6 +200,5 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
             }
         }
         '''.stripIndent()
-
     }
 }


### PR DESCRIPTION
This is so the task can be used in workflow where its outputs are used.

## Before this PR
The set of implicit dependencies is not accessible to other tasks, such as one that may attempt to automatically update the gradle config files for you.  This is the first step in letting the task be used in such a way.

An alternative approach would be to separate out all the logic to an "Analyzer" class like is done in for the CheckClassUniquenessTask/ClassUniquenessAnalyzer, but that would involve a lot of duplication of properties, so this seemed cleaner.

## After this PR
==COMMIT_MSG==
Task can be used without stopping the build on failure.
==COMMIT_MSG==

## Possible downsides?
None

