### PR TITLE
detect if dependency is actually the current project.

### DIFF
--- a/changelog/@unreleased/pr-736.v2.yml
+++ b/changelog/@unreleased/pr-736.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: detect if dependency is actually the current project
+  description: "The `checkImplicitDependencies` task will no longer suggest a fix of the current project."
   links:
   - https://github.com/palantir/gradle-baseline/pull/736
   - https://github.com/palantir/gradle-baseline/issues/567

--- a/changelog/@unreleased/pr-736.v2.yml
+++ b/changelog/@unreleased/pr-736.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: detect if dependency is actually the current project
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/736
+  - https://github.com/palantir/gradle-baseline/issues/567

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -71,6 +71,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
                 .map(BaselineExactDependencies.INDEXES::classToDependency)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
+                .filter(x -> !isArtifactFromCurrentProject(x))
                 .collect(Collectors.toSet());
         Set<ResolvedArtifact> declaredArtifacts = declaredDependencies.stream()
                 .flatMap(dependency -> dependency.getModuleArtifacts().stream())
@@ -111,6 +112,19 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
     private boolean isProjectArtifact(ResolvedArtifact artifact) {
         return artifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier;
     }
+
+    /**
+     * Return true if the resolved artifact is derived from a project in the current build rather than an
+     * external jar.
+     */
+    private boolean isArtifactFromCurrentProject(ResolvedArtifact artifact) {
+        if (!isProjectArtifact(artifact)) {
+            return false;
+        }
+        return ((ProjectComponentIdentifier) artifact.getId().getComponentIdentifier()).getProjectPath()
+                .equals(getProject().getPath());
+    }
+
 
     /** All classes which are mentioned in this project's source code. */
     private Set<String> referencedClasses() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -16,10 +16,9 @@
 
 package com.palantir.baseline
 
+import java.nio.file.Files
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
-
-import java.nio.file.Files
 
 class BaselineExactDependenciesTest extends AbstractPluginTest {
 
@@ -123,6 +122,15 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.task(':checkImplicitDependencies').getOutcome() == TaskOutcome.FAILED
         result.output.contains("Found 1 implicit dependencies")
         result.output.contains("implementation project(':sub-project-no-deps')")
+    }
+
+    def 'checkImplicitDependencies should not report circular dependency on current project'() {
+        when:
+        setupMultiProject()
+
+        then:
+        BuildResult result = with(':sub-project-with-deps:checkImplicitDependencies', ':sub-project-no-deps:checkImplicitDependencies', '--stacktrace').withDebug(true).build()
+        result.task(':sub-project-no-deps:checkImplicitDependencies').getOutcome() == TaskOutcome.SUCCESS
     }
 
     /**


### PR DESCRIPTION

## Before this PR
Described here: https://github.com/palantir/gradle-baseline/issues/567

This can happen if you have a multimodule build.  If you run the implicit deps task on module A that depends o module B and then run the task on module B, the artifact for module B will already be in the artifact cache and so will be detected and returned.

## After this PR
==COMMIT_MSG==
We filter out artifacts from the current project
==COMMIT_MSG==

## Possible downsides?
None
