### PR TITLE
Refaster to use `execute` over `submit` when the result is ignored

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/ExecutorSubmitRunnableFutureIgnored.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/ExecutorSubmitRunnableFutureIgnored.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Uncaught exceptions from {@link ExecutorService#submit(Runnable)} are not logged by the uncaught exception handler
+ * because it is assumed that the returned future is used to watch for failures.
+ * When the returned future is ignored, using {@link ExecutorService#execute(Runnable)} is preferred because
+ * failures are recorded.
+ */
+public final class ExecutorSubmitRunnableFutureIgnored {
+
+    @BeforeTemplate
+    @SuppressWarnings("FutureReturnValueIgnored")
+    void submit(ExecutorService executor, Runnable runnable) {
+        executor.submit(runnable);
+    }
+
+    @AfterTemplate
+    void execute(ExecutorService executor, Runnable runnable) {
+        executor.execute(runnable);
+    }
+
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/ExecutorSubmitRunnableFutureIgnoredTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/ExecutorSubmitRunnableFutureIgnoredTest.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class ExecutorSubmitRunnableFutureIgnoredTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(ExecutorSubmitRunnableFutureIgnored.class)
+                .withInputLines(
+                        "Test",
+                        "import java.util.concurrent.Executors;",
+                        "public class Test {",
+                        "  static {",
+                        "    Executors.newSingleThreadExecutor().submit(() -> {});",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import java.util.concurrent.Executors;",
+                        "public class Test {",
+                        "  static {",
+                        "    Executors.newSingleThreadExecutor().execute(() -> {});",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void testConsumedFutureUnchanged() {
+        RefasterTestHelper
+                .forRefactoring(ExecutorSubmitRunnableFutureIgnored.class)
+                .withInputLines(
+                        "Test",
+                        "import java.util.concurrent.Executors;",
+                        "import java.util.concurrent.Future;",
+                        "public class Test {",
+                        "  Future<?> future = Executors.newSingleThreadExecutor().submit(() -> {});",
+                        "}")
+                .hasOutputLines(
+                        "import java.util.concurrent.Executors;",
+                        "import java.util.concurrent.Future;",
+                        "public class Test {",
+                        "  Future<?> future = Executors.newSingleThreadExecutor().submit(() -> {});",
+                        "}");
+    }
+
+}

--- a/changelog/@unreleased/pr-741.v2.yml
+++ b/changelog/@unreleased/pr-741.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refaster to use `execute` over `submit` when the result is ignored
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/741


### PR DESCRIPTION
## Before this PR
the ignored future warning fired, but it's often ignored.

## After this PR
==COMMIT_MSG==
Refaster to use `execute` over `submit` when the result is ignored
==COMMIT_MSG==

## Possible downsides?
none

