### PR TITLE
Enable applying refaster rules for repos with -Xlint:deprecation

### DIFF
--- a/changelog/@unreleased/pr-742.v2.yml
+++ b/changelog/@unreleased/pr-742.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: "Enable applying refaster rules for repos with -Xlint:deprecation\n\n##
+    Before this PR\nIf a repository configures -Werror or -Xlint:deprecation, then
+    the refaster refactoring can fail before its had a chance to refactor the code
+    away from the deprecated method.\n \n## After this PR\nWe disable these checks
+    when applying the refaster refactorings such that the refactoring is applied."
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/742

--- a/changelog/@unreleased/pr-742.v2.yml
+++ b/changelog/@unreleased/pr-742.v2.yml
@@ -1,9 +1,5 @@
 type: fix
 fix:
-  description: "Enable applying refaster rules for repos with -Xlint:deprecation\n\n##
-    Before this PR\nIf a repository configures -Werror or -Xlint:deprecation, then
-    the refaster refactoring can fail before its had a chance to refactor the code
-    away from the deprecated method.\n \n## After this PR\nWe disable these checks
-    when applying the refaster refactorings such that the refactoring is applied."
+  description: Enable applying refaster rules for repos with -Xlint:deprecation
   links:
   - https://github.com/palantir/gradle-baseline/pull/742

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -108,31 +108,48 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 return;
                             }
 
-                            if (project.hasProperty(PROP_REFASTER_APPLY)) {
-                                javaCompile.dependsOn(compileRefaster);
-                                disableWerrorAndDeprecationCompilerChecks(javaCompile);
-                                project.getLogger().error("ARGs: {}", javaCompile.getOptions().getAllCompilerArgs());
-
-                                errorProneOptions.getErrorproneArgumentProviders().add(() -> ImmutableList.of(
-                                        "-XepPatchChecks:refaster:" + refasterRulesFile.get().getAbsolutePath(),
-                                        "-XepPatchLocation:IN_PLACE"));
+                            if (isRefactoring(project)) {
                                 // Don't attempt to cache since it won't capture the source files that might be modified
                                 javaCompile.getOutputs().cacheIf(t -> false);
-                            } else if (project.hasProperty(PROP_ERROR_PRONE_APPLY)) {
-                                disableWerrorAndDeprecationCompilerChecks(javaCompile);
 
-                                // TODO(gatesn): Is there a way to discover error-prone checks?
-                                // Maybe service-load from a ClassLoader configured with annotation processor path?
-                                // https://github.com/google/error-prone/pull/947
-                                errorProneOptions.getErrorproneArgumentProviders().add(() -> ImmutableList.of(
-                                        "-XepPatchChecks:" + Joiner.on(',')
-                                                .join(errorProneExtension.getPatchChecks().get()),
-                                        "-XepPatchLocation:IN_PLACE"));
-                                // Don't attempt to cache since it won't capture the source files that might be modified
-                                javaCompile.getOutputs().cacheIf(t -> false);
+                                if (isRefasterRefactoring(project)) {
+                                    javaCompile.dependsOn(compileRefaster);
+                                    errorProneOptions.getErrorproneArgumentProviders().add(() -> ImmutableList.of(
+                                            "-XepPatchChecks:refaster:" + refasterRulesFile.get().getAbsolutePath(),
+                                            "-XepPatchLocation:IN_PLACE"));
+                                }
+
+                                if (isErrorProneRefactoring(project)) {
+                                    // TODO(gatesn): Is there a way to discover error-prone checks?
+                                    // Maybe service-load from a ClassLoader configured with annotation processor path?
+                                    // https://github.com/google/error-prone/pull/947
+                                    errorProneOptions.getErrorproneArgumentProviders().add(() -> ImmutableList.of(
+                                            "-XepPatchChecks:" + Joiner.on(',')
+                                                    .join(errorProneExtension.getPatchChecks().get()),
+                                            "-XepPatchLocation:IN_PLACE"));
+                                }
                             }
                         });
             });
+
+            // To allow refactoring of deprecated methods, even when -Xlint:deprecation is specified, we need to remove
+            // these compiler flags after all configuration has happened.
+            project.afterEvaluate(unused -> project.getTasks().withType(JavaCompile.class)
+                    .configureEach(javaCompile -> {
+                        if (javaCompile.equals(compileRefaster)) {
+                            return;
+                        }
+                        if (isRefactoring(project)) {
+                            javaCompile.getOptions().setWarnings(false);
+                            javaCompile.getOptions().setDeprecation(false);
+                            javaCompile.getOptions().setCompilerArgs(javaCompile.getOptions().getCompilerArgs()
+                                    .stream()
+                                    .filter(arg -> !arg.equals("-Werror"))
+                                    .filter(arg -> !arg.equals("-deprecation"))
+                                    .filter(arg -> !arg.equals("-Xlint:deprecation"))
+                                    .collect(Collectors.toList()));
+                        }
+                    }));
 
             project.getPluginManager().withPlugin("java-gradle-plugin", appliedPlugin -> {
                 project.getTasks().withType(JavaCompile.class).configureEach(javaCompile ->
@@ -169,13 +186,16 @@ public final class BaselineErrorProne implements Plugin<Project> {
         });
     }
 
-    private void disableWerrorAndDeprecationCompilerChecks(JavaCompile javaCompile) {
-        javaCompile.getOptions().setWarnings(false);
-        javaCompile.getOptions().setDeprecation(false);
-        javaCompile.getOptions().setCompilerArgs(javaCompile.getOptions().getCompilerArgs().stream()
-                .filter(arg -> !arg.toLowerCase().equals("-xlintdeprecation"))
-                .filter(arg -> !arg.toLowerCase().equals("-werror"))
-                .collect(Collectors.toList()));
+    private boolean isRefactoring(Project project) {
+        return isRefasterRefactoring(project) || isErrorProneRefactoring(project);
+    }
+
+    private boolean isRefasterRefactoring(Project project) {
+        return project.hasProperty(PROP_REFASTER_APPLY);
+    }
+
+    private boolean isErrorProneRefactoring(Project project) {
+        return project.hasProperty(PROP_ERROR_PRONE_APPLY);
     }
 
     private static final class LazyConfigurationList extends AbstractList<File> {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneRefasterIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneRefasterIntegrationTest.groovy
@@ -134,6 +134,7 @@ class BaselineErrorProneRefasterIntegrationTest extends AbstractPluginTest {
         package test;
         import com.google.common.base.CharMatcher;
         import com.google.common.base.Utf8;
+        import java.nio.charset.StandardCharsets;
         public class Test {
             CharMatcher matcher = CharMatcher.digit();  // Would normally fail with -Xlint:deprecation
             int i = Utf8.encodedLength("hello world");


### PR DESCRIPTION
## Before this PR
If a repository configures -Werror or -Xlint:deprecation, then the refaster refactoring can fail before its had a chance to refactor the code away from the deprecated method.
 
## After this PR
We disable these checks when applying the refaster refactorings such that the refactoring is applied.
