### PR TITLE
fix #748: Apply InputStreamSlowMultibyteRead at ERROR severity

### DIFF
--- a/changelog/@unreleased/pr-749.v2.yml
+++ b/changelog/@unreleased/pr-749.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Apply `InputStreamSlowMultibyteRead` error prone check at ERROR severity
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/749

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -96,6 +96,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                             errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
                             errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
                             errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
+                            errorProneOptions.check("InputStreamSlowMultibyteRead", CheckSeverity.ERROR);
 
                             if (jdkVersion.compareTo(JavaVersion.toVersion("12.0.1")) >= 0) {
                                 // Errorprone isn't officially compatible with Java12, but in practise everything


### PR DESCRIPTION
==COMMIT_MSG==
Apply `InputStreamSlowMultibyteRead` error prone check at ERROR severity
==COMMIT_MSG==