### PR TITLE
Include more checks to be patched

### DIFF
--- a/changelog/@unreleased/pr-751.v2.yml
+++ b/changelog/@unreleased/pr-751.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Apply the suggested fixes for `MutableConstantField`, `UnusedMethod`, and `UnusedVariable`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/751

--- a/changelog/@unreleased/pr-751.v2.yml
+++ b/changelog/@unreleased/pr-751.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Apply the suggested fixes for `MutableConstantField`, `UnusedMethod`, and `UnusedVariable`.
+  description: Apply the suggested fixes for `UnusedMethod` and `UnusedVariable`.
   links:
   - https://github.com/palantir/gradle-baseline/pull/751

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -34,7 +34,6 @@ public class BaselineErrorProneExtension {
             // Built-in checks
             "ArrayEquals",
             "MissingOverride",
-            "MutableConstantField",
             "UnusedMethod",
             "UnusedVariable");
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -33,7 +33,10 @@ public class BaselineErrorProneExtension {
 
             // Built-in checks
             "ArrayEquals",
-            "MissingOverride");
+            "MissingOverride",
+            "MutableConstantField",
+            "UnusedMethod",
+            "UnusedVariable");
 
     private final ListProperty<String> patchChecks;
 


### PR DESCRIPTION
## Before this PR
`MutableConstantField`, `UnusedMethod`, and `UnusedVariable` suggested fixes are not automatically applied.

## After this PR
`MutableConstantField`, `UnusedMethod`, and `UnusedVariable` suggested fixes are automatically applied.