### PR TITLE
SortedFirst refactor implementation for no-arg `sort()`

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/SortedFirstNatural.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/SortedFirstNatural.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.refaster;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.stream.Stream;

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/SortedFirstNatural.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/SortedFirstNatural.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Based on {@link SortedFirst}, but handles {@link Stream#sorted()} without a comparator.
+ */
+public final class SortedFirstNatural<T extends Comparable<T>> {
+
+    @BeforeTemplate
+    Optional<T> before(Stream<T> stream) {
+        return stream.sorted().findFirst();
+    }
+
+    @AfterTemplate
+    Optional<T> after(Stream<T> stream) {
+        return stream.min(Comparator.naturalOrder());
+    }
+
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/SortedFirstNaturalTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/SortedFirstNaturalTest.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class SortedFirstNaturalTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(SortedFirstNatural.class)
+                .withInputLines(
+                        "Test",
+                        "import java.util.*;",
+                        "import java.util.stream.Stream;",
+                        "public class Test {",
+                        "  Optional<Integer> i = Arrays.asList(5, -10, 7, -18, 23).stream()",
+                        "      .sorted()",
+                        "      .findFirst();",
+                        "}")
+                .hasOutputLines(
+                        "import java.util.*;",
+                        "import java.util.stream.Stream;",
+                        "public class Test {",
+                        "  Optional<Integer> i = Arrays.asList(5, -10, 7, -18, 23).stream()"
+                                + ".min(Comparator.naturalOrder());",
+                        "}");
+    }
+
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/SortedFirstNaturalTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/SortedFirstNaturalTest.java
@@ -35,6 +35,7 @@ public class SortedFirstNaturalTest {
                         "}")
                 .hasOutputLines(
                         "import java.util.*;",
+                        "import java.util.Comparator;",
                         "import java.util.stream.Stream;",
                         "public class Test {",
                         "  Optional<Integer> i = Arrays.asList(5, -10, 7, -18, 23).stream()"

--- a/changelog/@unreleased/pr-752.v2.yml
+++ b/changelog/@unreleased/pr-752.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refaster `stream.sorted().findFirst()` into `stream.min(Comparator.naturalOrder())`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/752


### PR DESCRIPTION
## Before this PR
Only auto-fixed `stream.sorted(<comparator>).findFirst()`, not the implementation using natural order.

## After this PR
==COMMIT_MSG==
Refaster `stream.sorted().findFirst()` into `stream.min(Comparator.naturalOrder())`
==COMMIT_MSG==

## Possible downsides?
None

