### PR TITLE
Error prone validation that Stream.sort is invoked on comparable streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferBuiltInConcurrentKeySet`: Discourage relying on Guava's `com.google.common.collect.Sets.newConcurrentHashSet()`, when Java's `java.util.concurrent.ConcurrentHashMap.newKeySet()` serves the same purpose.
 - `JUnit5RuleUsage`: Prevent accidental usage of `org.junit.Rule`/`org.junit.ClassRule` within Junit5 tests
 - `DangerousCompletableFutureUsage`: Disallow CompletableFuture asynchronous operations without an Executor.
+- `NonComparableStreamSort`: Stream.sorted() should only be called on streams of Comparable types.
 
 ## com.palantir.baseline-checkstyle
 Checkstyle rules can be suppressed on a per-line or per-block basis. (It is good practice to first consider formatting

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/NonComparableStreamSort.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/NonComparableStreamSort.java
@@ -29,6 +29,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
+import java.util.stream.Stream;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -40,7 +41,7 @@ public final class NonComparableStreamSort extends BugChecker implements BugChec
 
     private static final Matcher<ExpressionTree> SORTED_CALL_ON_JAVA_STREAM_MATCHER =
             MethodMatchers.instanceMethod()
-                    .onDescendantOf("java.util.stream.Stream")
+                    .onDescendantOf(Stream.class.getName())
                     .named("sorted")
                     .withParameters();
 
@@ -49,7 +50,6 @@ public final class NonComparableStreamSort extends BugChecker implements BugChec
         if (!SORTED_CALL_ON_JAVA_STREAM_MATCHER.matches(tree, state)) {
             return Description.NO_MATCH;
         }
-
         Type returnType = ASTHelpers.getReturnType(tree);
         if (returnType == null || returnType.getTypeArguments().size() != 1) {
             return Description.NO_MATCH;

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/NonComparableStreamSort.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/NonComparableStreamSort.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.Iterables;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Type;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "NonComparableStreamSort",
+        severity = SeverityLevel.ERROR,
+        summary = "Stream.sorted() should only be called on streams of Comparable types.")
+public final class NonComparableStreamSort extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+    private static final long serialVersionUID = 1L;
+
+    private static final Matcher<ExpressionTree> SORTED_CALL_ON_JAVA_STREAM_MATCHER =
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf("java.util.stream.Stream")
+                    .named("sorted")
+                    .withParameters();
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!SORTED_CALL_ON_JAVA_STREAM_MATCHER.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        Type returnType = ASTHelpers.getReturnType(tree);
+        if (returnType == null || returnType.getTypeArguments().size() != 1) {
+            return Description.NO_MATCH;
+        }
+        Type streamParameterType = Iterables.getOnlyElement(returnType.getTypeArguments());
+        if (ASTHelpers.isCastable(streamParameterType, state.getTypeFromString(Comparable.class.getName()), state)) {
+            return Description.NO_MATCH;
+        }
+        return buildDescription(tree)
+                .setMessage("Stream.sorted() should only be called on streams of Comparable types.")
+                .build();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NonComparableStreamSortTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NonComparableStreamSortTests.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NonComparableStreamSortTests {
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(NonComparableStreamSort.class, getClass());
+    }
+
+    @Test
+    public void should_fail_on_non_comparable_stream() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import java.util.List;",
+                "import java.util.ArrayList;",
+                "class Test {",
+                "   public static final void main(String[] args) {",
+                "       List<Object> list = new ArrayList<>();",
+                "       // BUG: Stream.sorted() should only be called on streams of Comparable types.",
+                "       list.stream().sorted();",
+                "   }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    public void should_on_comparable_stream() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import java.util.List;",
+                "import java.util.ArrayList;",
+                "class Test {",
+                "   public static final void main(String[] args) {",
+                "       List<String> list = new ArrayList<>();",
+                "       list.stream().sorted();",
+                "   }",
+                "}"
+        ).doTest();
+    }
+}

--- a/changelog/@unreleased/pr-753.v2.yml
+++ b/changelog/@unreleased/pr-753.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Error prone validation that Stream.sort is invoked on comparable streams
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/753


### PR DESCRIPTION
## Before this PR
ClassCastException was thrown at runtime for a problem we can detect at compile time.

## After this PR
==COMMIT_MSG==
Error prone validation that Stream.sort is invoked on comparable streams
==COMMIT_MSG==

