### PR TITLE
Promote two error-prone checks to error

### DIFF
--- a/changelog/@unreleased/pr-758.v2.yml
+++ b/changelog/@unreleased/pr-758.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: error-prone now detects `Duration#getNanos` mistakes and bans URL in
+    equals methods
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/758

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -97,6 +97,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
                             errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
                             errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
                             errorProneOptions.check("InputStreamSlowMultibyteRead", CheckSeverity.ERROR);
+                            errorProneOptions.check("JavaDurationGetSecondsGetNano", CheckSeverity.ERROR);
+                            errorProneOptions.check("URLEqualsHashCode", CheckSeverity.ERROR);
 
                             if (jdkVersion.compareTo(JavaVersion.toVersion("12.0.1")) >= 0) {
                                 // Errorprone isn't officially compatible with Java12, but in practise everything


### PR DESCRIPTION
## Before this PR

Real documented suffering could have been prevented by errorprone:

- https://github.com/palantir/gradle-baseline/issues/469
- https://github.com/palantir/gradle-baseline/issues/657

## After this PR
==COMMIT_MSG==
error-prone now detects `Duration#getNanos` mistakes and bans URL in equals methods
==COMMIT_MSG==

## Possible downsides?

- there's always a risk of some false positives here

