### PR TITLE
Error Prone LambdaMethodReference check

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `NonComparableStreamSort`: Stream.sorted() should only be called on streams of Comparable types.
 - `DangerousStringInternUsage`: Disallow String.intern() invocations in favor of more predictable, scalable alternatives.
 - `OptionalOrElseThrowThrows`: Optional.orElseThrow argument must return an exception, not throw one.
+- `LambdaMethodReference`: Lambda should use a method reference.
 
 ## com.palantir.baseline-checkstyle
 Checkstyle rules can be suppressed on a per-line or per-block basis. (It is good practice to first consider formatting

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol;
+import java.util.Optional;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "LambdaMethodReference",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.SUGGESTION,
+        summary = "Lambda should be a method reference")
+public final class LambdaMethodReference extends BugChecker implements BugChecker.LambdaExpressionTreeMatcher {
+
+    private static final String MESSAGE = "Lambda should be a method reference";
+
+    @Override
+    public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
+        // Only handle simple no-arg method references for the time being, don't worry about
+        // simplifying map.forEach((k, v) -> func(k, v)) to map.forEach(this::func)
+        if (!tree.getParameters().isEmpty()) {
+            return Description.NO_MATCH;
+        }
+        LambdaExpressionTree.BodyKind bodyKind = tree.getBodyKind();
+        Tree body = tree.getBody();
+        // n.b. These checks are meant to avoid any and all cleverness. The goal is to be confident
+        // that we can fix the most basic problems correctly, not to take risks and produce code
+        // that may not compile.
+        switch (bodyKind) {
+            case EXPRESSION:
+                if (!(body instanceof MethodInvocationTree)) {
+                    return Description.NO_MATCH;
+                }
+                return checkMethodInvocation((MethodInvocationTree) body, tree, state);
+            case STATEMENT:
+                if (!(body instanceof BlockTree)) {
+                    return Description.NO_MATCH;
+                }
+                BlockTree block = (BlockTree) body;
+                if (block.getStatements().size() != 1) {
+                    return Description.NO_MATCH;
+                }
+                StatementTree statement = block.getStatements().get(0);
+                if (!(statement instanceof ReturnTree)) {
+                    return Description.NO_MATCH;
+                }
+                ReturnTree returnStatement = (ReturnTree) statement;
+                ExpressionTree returnExpression = returnStatement.getExpression();
+                if (!(returnExpression instanceof MethodInvocationTree)) {
+                    return Description.NO_MATCH;
+                }
+                return checkMethodInvocation((MethodInvocationTree) returnExpression, tree, state);
+        }
+        throw new IllegalStateException("Unexpected BodyKind: " + bodyKind);
+    }
+
+    private Description checkMethodInvocation(
+            MethodInvocationTree methodInvocation, LambdaExpressionTree root, VisitorState state) {
+        if (!methodInvocation.getArguments().isEmpty()
+                || !methodInvocation.getTypeArguments().isEmpty()) {
+            return Description.NO_MATCH;
+        }
+        return buildDescription(root)
+                .setMessage(MESSAGE)
+                .addFix(buildFix(methodInvocation, root, state))
+                .build();
+    }
+
+    private static Optional<SuggestedFix> buildFix(
+            MethodInvocationTree invocation,
+            LambdaExpressionTree root,
+            VisitorState state) {
+        return Optional.ofNullable(ASTHelpers.getSymbol(invocation))
+                // Only support static invocations for the time being to avoid erroneously
+                // rewriting '() -> foo()' to 'ClassName::foo' instead of 'this::foo'
+                .filter(Symbol::isStatic)
+                .flatMap(symbol -> {
+                    SuggestedFix.Builder builder = SuggestedFix.builder();
+                    return toMethodReference(SuggestedFixes.qualifyType(state, builder, symbol))
+                            .map(qualified -> builder.replace(root, qualified).build());
+                });
+    }
+
+    private static Optional<String> toMethodReference(String qualifiedMethodName) {
+        int index = qualifiedMethodName.lastIndexOf('.');
+        if (index > 0) {
+            return Optional.of(qualifiedMethodName.substring(0, index)
+                    + "::" + qualifiedMethodName.substring(index + 1));
+        }
+        return Optional.empty();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
@@ -1,0 +1,261 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LambdaMethodReferenceTest {
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(LambdaMethodReference.class, getClass());
+    }
+
+    @Test
+    public void testMethodReference() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import " + ImmutableList.class.getName() + ';',
+                "import " + List.class.getName() + ';',
+                "import " + Optional.class.getName() + ';',
+                "class Test {",
+                "  public List<Object> foo(Optional<List<Object>> optional) {",
+                "    return optional.orElseGet(ImmutableList::of);",
+                "  }",
+                "}").doTest();
+    }
+
+    @Test
+    public void testPositive_block() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import " + ImmutableList.class.getName() + ';',
+                "import " + List.class.getName() + ';',
+                "import " + Optional.class.getName() + ';',
+                "class Test {",
+                "  public List<Object> foo(Optional<List<Object>> optional) {",
+                "    // BUG: Diagnostic contains: Lambda should be a method reference",
+                "    return optional.orElseGet(() -> { return ImmutableList.of(); });",
+                "  }",
+                "}").doTest();
+    }
+
+    @Test
+    public void testAutoFix_block() {
+        BugCheckerRefactoringTestHelper.newInstance(new LambdaMethodReference(), getClass())
+                .addInputLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + List.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public List<Object> foo(Optional<List<Object>> optional) {",
+                        "    return optional.orElseGet(() -> { return ImmutableList.of(); });",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + List.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public List<Object> foo(Optional<List<Object>> optional) {",
+                        "    return optional.orElseGet(ImmutableList::of);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testPositive_block_localMethod() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import " + ImmutableList.class.getName() + ';',
+                "import " + List.class.getName() + ';',
+                "import " + Optional.class.getName() + ';',
+                "class Test {",
+                "  public List<Object> foo(Optional<List<Object>> optional) {",
+                "    // BUG: Diagnostic contains: Lambda should be a method reference",
+                "    return optional.orElseGet(() -> { return bar(); });",
+                "  }",
+                "  private List<Object> bar() {",
+                "    return ImmutableList.of();",
+                "  }",
+                "}").doTest();
+    }
+
+    @Test
+    public void testAutoFix_block_localMethod() {
+        BugCheckerRefactoringTestHelper.newInstance(new LambdaMethodReference(), getClass())
+                .addInputLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + List.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public List<Object> foo(Optional<List<Object>> optional) {",
+                        "    return optional.orElseGet(() -> { return bar(); });",
+                        "  }",
+                        "  private List<Object> bar() {",
+                        "    return ImmutableList.of();",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + List.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public List<Object> foo(Optional<List<Object>> optional) {",
+                        // This is not modified, may be improved later
+                        "    return optional.orElseGet(() -> { return bar(); });",
+                        "  }",
+                        "  private List<Object> bar() {",
+                        "    return ImmutableList.of();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testNegative_block() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import " + ImmutableList.class.getName() + ';',
+                "import " + List.class.getName() + ';',
+                "import " + Optional.class.getName() + ';',
+                "class Test {",
+                "  public List<Object> foo(Optional<List<Object>> optional) {",
+                "    return optional.orElseGet(() -> { return ImmutableList.of(1); });",
+                "  }",
+                "}").doTest();
+    }
+
+    @Test
+    public void testPositive_expression() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import " + ImmutableList.class.getName() + ';',
+                "import " + List.class.getName() + ';',
+                "import " + Optional.class.getName() + ';',
+                "class Test {",
+                "  public List<Object> foo(Optional<List<Object>> optional) {",
+                "    // BUG: Diagnostic contains: Lambda should be a method reference",
+                "    return optional.orElseGet(() -> ImmutableList.of());",
+                "  }",
+                "}").doTest();
+    }
+
+    @Test
+    public void testAutoFix_expression() {
+        BugCheckerRefactoringTestHelper.newInstance(new LambdaMethodReference(), getClass())
+                .addInputLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + List.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public List<Object> foo(Optional<List<Object>> optional) {",
+                        "    return optional.orElseGet(() -> ImmutableList.of());",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + List.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public List<Object> foo(Optional<List<Object>> optional) {",
+                        "    return optional.orElseGet(ImmutableList::of);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testPositive_expression_localMethod() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import " + ImmutableList.class.getName() + ';',
+                "import " + List.class.getName() + ';',
+                "import " + Optional.class.getName() + ';',
+                "class Test {",
+                "  public List<Object> foo(Optional<List<Object>> optional) {",
+                "    // BUG: Diagnostic contains: Lambda should be a method reference",
+                "    return optional.orElseGet(() -> bar());",
+                "  }",
+                "  private List<Object> bar() {",
+                "    return ImmutableList.of();",
+                "  }",
+                "}").doTest();
+    }
+
+    @Test
+    public void testAutoFix_expression_localMethod() {
+        BugCheckerRefactoringTestHelper.newInstance(new LambdaMethodReference(), getClass())
+                .addInputLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + List.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public List<Object> foo(Optional<List<Object>> optional) {",
+                        "    return optional.orElseGet(() -> bar());",
+                        "  }",
+                        "  private List<Object> bar() {",
+                        "    return ImmutableList.of();",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + List.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public List<Object> foo(Optional<List<Object>> optional) {",
+                        // This is not modified, may be improved later
+                        "    return optional.orElseGet(() -> bar());",
+                        "  }",
+                        "  private List<Object> bar() {",
+                        "    return ImmutableList.of();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testNegative_expression() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import " + ImmutableList.class.getName() + ';',
+                "import " + List.class.getName() + ';',
+                "import " + Optional.class.getName() + ';',
+                "class Test {",
+                "  public List<Object> foo(Optional<List<Object>> optional) {",
+                "    return optional.orElseGet(() -> ImmutableList.of(1));",
+                "  }",
+                "}").doTest();
+    }
+}

--- a/changelog/@unreleased/pr-763.v2.yml
+++ b/changelog/@unreleased/pr-763.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Error Prone LambdaMethodReference check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/763

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -24,12 +24,13 @@ public class BaselineErrorProneExtension {
 
     private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
+            "LambdaMethodReference",
+            "OptionalOrElseMethodInvocation",
             "PreferBuiltInConcurrentKeySet",
             "PreferCollectionTransform",
             "PreferListsPartition",
             "PreferSafeLoggableExceptions",
             "PreferSafeLoggingPreconditions",
-            "OptionalOrElseMethodInvocation",
 
             // Built-in checks
             "ArrayEquals",


### PR DESCRIPTION
This check uses `SeverityLevel.SUGGESTION`, and doesn't block
compilation, but is used by default with  `errorProneApply`.
This is meant to pair with `OptionalOrElseMethodInvocation` to
produce safe, legible code.

## Before this PR
```java
optional.orElseGet(() -> ImmutableList.of())
```

## After this PR
```java
optional.orElseGet(ImmutableList::of)
```
==COMMIT_MSG==
Error Prone LambdaMethodReference check
==COMMIT_MSG==

## Possible downsides?
It's possible I missed a case that could cause compile breaks.

