### PR TITLE
failing test: OptionalOrElseMethodInvocation suggestion fails compilation

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocationTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocationTests.java
@@ -175,4 +175,32 @@ public final class OptionalOrElseMethodInvocationTests {
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
+
+    @Test
+    public void testComplexReplacement() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "import java.util.Optional;",
+                        "class Test {",
+                        "  String f(Optional<String> input, String defaultValue) {",
+                        "    if (defaultValue == null) {",
+                        "        defaultValue = \"default\";",
+                        "    }",
+                        "    return input.orElse(defaultValue.toLowerCase());",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.util.Optional;",
+                        "class Test {",
+                        "  String f(Optional<String> input, String defaultValue) {",
+                        "    if (defaultValue == null) {",
+                        "        defaultValue = \"default\";",
+                        "    }",
+                        "    return input.orElseGet(() -> defaultValue.toLowerCase());",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
 }


### PR DESCRIPTION
The method target and parameters must be effectively final.

## After this PR
==COMMIT_MSG==
OptionalOrElseMethodInvocation suggestion fails compilation
==COMMIT_MSG==
