### PR TITLE
Eliminate some warnings/deprecations

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousJsonTypeInfoUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousJsonTypeInfoUsage.java
@@ -50,7 +50,7 @@ public final class DangerousJsonTypeInfoUsage extends BugChecker implements BugC
                     )));
 
     private static Matcher<ExpressionTree> treeEqualsStringMatcher(String value) {
-        return (expressionTree, state) -> expressionTree.toString().equals(value);
+        return (expressionTree, state) -> state.getSourceForNode(expressionTree).equals(value);
     }
 
     @Override

--- a/baseline-refaster-testing/src/main/java/com/palantir/baseline/refaster/RefasterTestHelper.java
+++ b/baseline-refaster-testing/src/main/java/com/palantir/baseline/refaster/RefasterTestHelper.java
@@ -37,6 +37,7 @@ import java.util.List;
 import javax.tools.JavaFileObject;
 import org.assertj.core.api.Assertions;
 
+@SuppressWarnings("PreferSafeLoggableExceptions")
 public final class RefasterTestHelper {
 
     private final List<CodeTransformer> transformers;
@@ -65,7 +66,7 @@ public final class RefasterTestHelper {
         return new RefactoringTestInput(transformers, JavaFileObjects.forSourceLines(fullyQualifiedName, lines));
     }
 
-    public final class RefactoringTestInput {
+    public static final class RefactoringTestInput {
 
         private List<CodeTransformer> transformers;
         private JavaFileObject input;

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/CheckstyleReportHandler.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/CheckstyleReportHandler.java
@@ -48,9 +48,6 @@ public final class CheckstyleReportHandler extends ReportHandler<Checkstyle> {
                         .message(attributes.getValue("message"))
                         .build());
                 break;
-
-            default:
-                break;
         }
     }
 

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/StyleTaskTimer.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/StyleTaskTimer.java
@@ -28,6 +28,7 @@ public final class StyleTaskTimer implements TaskTimer {
     private long lastStartTime;
 
     @Override
+    @SuppressWarnings("PreferSafeLoggableExceptions")
     public long getTaskTimeNanos(Task styleTask) {
         if (!isStyleTask(styleTask)) {
             throw new ClassCastException("not a style task");

--- a/gradle-junit-reports/src/test/java/com/palantir/gradle/junit/JunitReportsFinalizerTests.java
+++ b/gradle-junit-reports/src/test/java/com/palantir/gradle/junit/JunitReportsFinalizerTests.java
@@ -104,7 +104,7 @@ public class JunitReportsFinalizerTests {
         String modifiedReportXml = originalReportXml.replace(
                 ROOT.toString(), projectDir.getRoot().getCanonicalPath());
         File modifiedReportFile = projectDir.newFile();
-        Files.write(modifiedReportXml, modifiedReportFile, StandardCharsets.UTF_8);
+        Files.write(modifiedReportXml.getBytes(StandardCharsets.UTF_8), modifiedReportFile);
 
         xmlReport.setDestination(modifiedReportFile);
         return checkstyle;


### PR DESCRIPTION
We have one `import org.gradle.api.plugins.quality.FindBugs` line which makes baseline unusable in Gradle 6.0.  Interestingly, this has been deprecated for a while, but we didn't notice because we haven't been running with `-Werror` or `-Xlint:deprecation` (?!?!)
