### PR TITLE
Delete FindBugs

### DIFF
--- a/changelog/@unreleased/pr-766.v2.yml
+++ b/changelog/@unreleased/pr-766.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: baseline-circleci no longer integrates with the (deprecated) FindBugs
+    plugin, as a pre-requisite for Gradle 6.0 compatibility.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/766

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/StyleTaskTimer.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/StyleTaskTimer.java
@@ -19,7 +19,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.quality.Checkstyle;
-import org.gradle.api.plugins.quality.FindBugs;
 import org.gradle.api.tasks.TaskState;
 import org.gradle.api.tasks.compile.JavaCompile;
 
@@ -55,6 +54,6 @@ public final class StyleTaskTimer implements TaskTimer {
     }
 
     public static boolean isStyleTask(Task task) {
-        return task instanceof Checkstyle || task instanceof FindBugs || task instanceof JavaCompile;
+        return task instanceof Checkstyle || task instanceof JavaCompile;
     }
 }


### PR DESCRIPTION
## Before this PR

Our usage of FindBugs is blocking baseline's compatibility with the upcoming Gradle 6.0 release.

## After this PR
==COMMIT_MSG==
baseline-circleci no longer integrates with the (deprecated) FindBugs plugin, as a pre-requisite for Gradle 6.0 compatibility.
==COMMIT_MSG==

## Possible downsides?

- surely nobody was relying on this.

