### PR TITLE
More Java 13 pre-reqs

### DIFF
--- a/changelog/@unreleased/pr-767.v2.yml
+++ b/changelog/@unreleased/pr-767.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The `TypeParameterUnusedInFormals` errorprone check is disabled when
+    compiling on Java 13, to workaround an error-prone bug.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/767

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile 'net.ltgt.gradle:gradle-errorprone-plugin'
     compile 'org.apache.maven.shared:maven-dependency-analyzer'
     compile 'org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit'
 
     testCompile gradleTestKit()
     testCompile 'com.github.stefanbirkner:system-rules'

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -106,6 +106,12 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 errorProneOptions.check("Finally", CheckSeverity.OFF);
                             }
 
+                            if (jdkVersion.compareTo(JavaVersion.toVersion("13.0.0")) >= 0) {
+                                // Errorprone isn't officially compatible with Java13 either
+                                // https://github.com/google/error-prone/issues/1106
+                                errorProneOptions.check("TypeParameterUnusedInFormals", CheckSeverity.OFF);
+                            }
+
                             if (javaCompile.equals(compileRefaster)) {
                                 // Don't apply refaster to itself...
                                 return;

--- a/versions.props
+++ b/versions.props
@@ -12,6 +12,7 @@ org.apache.maven.shared:maven-dependency-analyzer = 1.11.1
 org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11 = 1.0.1
 org.inferred:freebuilder = 1.14.6
 org.slf4j:slf4j-api = 1.7.25
+org.eclipse.jgit:org.eclipse.jgit = 5.3.2.201906051522-r
 
 # test deps
 com.netflix.nebula:nebula-test = 7.2.5

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,4 @@
-com.diffplug.spotless:spotless-plugin-gradle = 3.14.0
+com.diffplug.spotless:spotless-plugin-gradle = 3.24.2
 com.google.auto.service:auto-service = 1.0-rc4
 com.google.errorprone:error_prone_annotations = 2.3.3
 com.google.errorprone:error_prone_core = 2.3.3


### PR DESCRIPTION
## Before this PR

Using baseline on Java13 triggers this apparently well known errorprone bug (which even has open PRs to solve!)

```
> Task :tracing:compileJava FAILED
/Volumes/git/tracing-java/tracing/src/main/java/com/palantir/tracing/DeferredTracer.java:100: error: An unhandled exception was thrown by the Error Prone static analysis plugin.
    public <T, E extends Throwable> T withTrace(Tracers.ThrowingCallable<T, E> inner) throws E {
                                      ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:

     error-prone version: 2.3.3
     BugPattern: TypeParameterUnusedInFormals
     Stack Trace:
     java.lang.NoSuchFieldError: bound
        at com.google.errorprone.bugpatterns.TypeParameterUnusedInFormals.matchMethod(TypeParameterUnusedInFormals.java:71)
        at com.google.errorprone.scanner.ErrorProneScanner.processMatchers(ErrorProneScanner.java:433)
        at com.google.errorprone.scanner.ErrorProneScanner.visitMethod(ErrorProneScanner.java:725)
        at com.google.errorprone.scanner.ErrorProneScanner.visitMethod(ErrorProneScanner.java:150)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(JCTree.java:908)
        at jdk.compiler/com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:82)
        at com.google.errorprone.scanner.Scanner.scan(Scanner.java:71)
        at com.google.errorprone.scanner.Scanner.scan(Scanner.java:45)
        at jdk.compiler/com.sun.source.util.TreeScanner.scanAndReduce(TreeScanner.java:91)
        at jdk.compiler/com.sun.source.util.TreeScanner.scan(TreeScanner.java:106)
        at jdk.compiler/com.sun.source.util.TreeScanner.scanAndReduce(TreeScanner.java:114)
        at jdk.compiler/com.sun.source.util.TreeScanner.visitClass(TreeScanner.java:188)
```

Also `spotlessJava` would fail:

```
* What went wrong:
Execution failed for task ':tracing-api:spotlessJava'.
> You must declare outputs or use `TaskOutputs.upToDateWhen()` when using the incremental task API

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':tracing-api:spotlessJava'.
        at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:38)
```

## After this PR
==COMMIT_MSG==
The `TypeParameterUnusedInFormals` errorprone check is disabled when compiling on Java 13, to workaround an error-prone bug.
==COMMIT_MSG==

## Possible downsides?
I intend to make our projects dual compile on CI (i.e. both java 8 and 13, or maybe both 11 and 13), so this check will still get run on one of those compile nodes.

