### PR TITLE
Add SCM information to POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         classpath 'com.gradle.publish:plugin-publish-plugin:0.10.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:13.2.0'
+        classpath 'com.netflix.nebula:gradle-info-plugin:5.0.3'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.65.0'
     }
 }

--- a/changelog/@unreleased/pr-769.v2.yml
+++ b/changelog/@unreleased/pr-769.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Publish scm information within POM
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/769

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -7,6 +7,7 @@ apply plugin: 'nebula.maven-nebula-publish'
 apply plugin: 'nebula.maven-base-publish'
 apply plugin: 'nebula.maven-developer'
 apply plugin: 'nebula.maven-manifest'
+apply plugin: 'nebula.info-scm'
 apply plugin: 'nebula.maven-scm'
 
 apply plugin: 'nebula.javadoc-jar'


### PR DESCRIPTION
## Before this PR
We did not apply `nebula.info-scm` so applying `nebula.maven-scm` was a no-op. This resulted in our published poms not including any scm information which prevents us from determining the source repository. ex: [POM](https://palantir.bintray.com/releases/com/palantir/baseline/gradle-baseline-java/1.16.0/gradle-baseline-java-1.16.0.pom)

## After this PR
==COMMIT_MSG==
Publish scm information within POM
==COMMIT_MSG==

## Possible downsides?
N/A

