### PR TITLE
Fix: Filter out pom only artifacts from dependnecies in checkUnusedDependencies

### DIFF
--- a/changelog/@unreleased/pr-773.v2.yml
+++ b/changelog/@unreleased/pr-773.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove pom only dependencies from analysis in checkUnusedDependencies
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/773

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -74,6 +74,8 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
                 .collect(Collectors.toSet());
         Set<ResolvedArtifact> declaredArtifacts = declaredDependencies.stream()
                 .flatMap(dependency -> dependency.getModuleArtifacts().stream())
+                .filter(dependency -> BaselineExactDependencies.VALID_ARTIFACT_EXTENSIONS
+                        .contains(dependency.getExtension()))
                 .collect(Collectors.toSet());
 
         List<ResolvedArtifact> declaredButUnused = Sets.difference(declaredArtifacts, necessaryArtifacts).stream()
@@ -93,6 +95,8 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
                 ResolvedDependency dependency = BaselineExactDependencies.INDEXES
                         .artifactsFromDependency(resolvedArtifact);
                 Set<ResolvedArtifact> didYouMean = dependency.getAllModuleArtifacts().stream()
+                        .filter(artifact -> BaselineExactDependencies.VALID_ARTIFACT_EXTENSIONS
+                                .contains(artifact.getExtension()))
                         .flatMap(BaselineExactDependencies.INDEXES::classesFromArtifact)
                         .filter(referencedClasses()::contains)
                         .map(BaselineExactDependencies.INDEXES::classToDependency)


### PR DESCRIPTION
## Before this PR
With pom only dependencies you would see #594 

## After this PR
==COMMIT_MSG==
Remove pom only dependencies from analysis in checkUnusedDependencies
==COMMIT_MSG==
fixes #594 

## Possible downsides?
We only take jar and project dependencies into consideration. There could be others that the maven dependency analyzer handles but we would be ignoring them

