### PR TITLE
Add error-prone strict mode

### DIFF
--- a/changelog/@unreleased/pr-784.v2.yml
+++ b/changelog/@unreleased/pr-784.v2.yml
@@ -1,0 +1,15 @@
+type: improvement
+improvement:
+  description: |-
+    Setting the following will promote all upstream & baseline provided
+    error-prone checks to error, enable compiler lint checks (`-Werror`,
+    `-Xlint:deprecation`, `-Xlint:unchecked`), and also promote all compiler
+    warnings to error.
+
+    ```
+    plugins.withId('com.palantir.baseline-error-prone', {
+        ext.'com.palantir.baseline-error-prone.strict' = true
+    })
+    ```
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/784

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     compile 'net.ltgt.gradle:gradle-errorprone-plugin'
     compile 'org.apache.maven.shared:maven-dependency-analyzer'
     compile 'org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11'
+
+    implementation project(':baseline-error-prone')
     implementation 'org.eclipse.jgit:org.eclipse.jgit'
 
     testCompile gradleTestKit()

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -17,8 +17,14 @@
 package com.palantir.baseline.extensions;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugCheckerInfo;
 import org.gradle.api.Project;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.options.Option;
 
 public class BaselineErrorProneExtension {
 
@@ -36,14 +42,55 @@ public class BaselineErrorProneExtension {
             "ArrayEquals",
             "MissingOverride");
 
+    private static final ImmutableSet<String> DEFAULT_DISABLED_CHECKS = ImmutableSet.of(
+            "AndroidJdkLibsChecker", // ignore Android
+            "Java7ApiChecker", // we require JDK8+
+            "StaticOrDefaultInterfaceMethod", // Android specific
+            "Var" // high noise, low signal
+    );
+
     private final ListProperty<String> patchChecks;
+
+    private final SetProperty<String> disabledChecks;
+
+    private final Property<Boolean> isStrict;
 
     public BaselineErrorProneExtension(Project project) {
         patchChecks = project.getObjects().listProperty(String.class);
         patchChecks.set(DEFAULT_PATCH_CHECKS);
+        disabledChecks = project.getObjects().setProperty(String.class);
+        disabledChecks.set(DEFAULT_DISABLED_CHECKS);
+        isStrict = project.getObjects().property(Boolean.class);
+        isStrict.set(false);
     }
 
     public final ListProperty<String> getPatchChecks() {
         return patchChecks;
+    }
+
+    public final boolean isStrict() {
+        return Boolean.TRUE.equals(isStrict.get());
+    }
+
+    @Option(option = "strict", description = "Whether to apply strict compilation checks")
+    public final void strict(boolean shouldEnableStrict) {
+        this.isStrict.set(shouldEnableStrict);
+    }
+
+    public final void strict(Provider<Boolean> shouldEnableStrict) {
+        this.isStrict.set(shouldEnableStrict);
+    }
+
+    public final boolean isCheckEnabled(BugCheckerInfo check) {
+        return isCheckEnabled(check.canonicalName());
+    }
+
+    public final boolean isCheckEnabled(String check) {
+        return !disabledChecks.get().contains(check);
+    }
+
+    @Option(option = "disableCheck", description = "Disable specific error-prone check")
+    public final void disableCheck(String check) {
+        this.disabledChecks.add(check);
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -72,7 +72,6 @@ public class BaselineErrorProneExtension {
         return Boolean.TRUE.equals(isStrict.get());
     }
 
-    @Option(option = "strict", description = "Whether to apply strict compilation checks")
     public final void strict(boolean shouldEnableStrict) {
         this.isStrict.set(shouldEnableStrict);
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -233,7 +233,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         });
     }
 
-    private Action<ErrorProneOptions> configureErrorProne(
+    private static Action<ErrorProneOptions> configureErrorProne(
             Project project,
             JavaCompile javaCompile,
             JavaVersion jdkVersion,
@@ -303,20 +303,24 @@ public final class BaselineErrorProne implements Plugin<Project> {
         };
     }
 
-    private boolean isRefactoring(Project project) {
+    private static boolean isRefactoring(Project project) {
         return isRefasterRefactoring(project) || isErrorProneRefactoring(project);
     }
 
-    private boolean isRefasterRefactoring(Project project) {
+    private static boolean isRefasterRefactoring(Project project) {
         return project.hasProperty(PROP_REFASTER_APPLY);
     }
 
-    private boolean isErrorProneRefactoring(Project project) {
+    private static boolean isErrorProneRefactoring(Project project) {
         return project.hasProperty(PROP_ERROR_PRONE_APPLY);
     }
 
-    private boolean isStrict(Project project) {
-        return project.hasProperty(PROP_STRICT) && Boolean.TRUE.equals(project.property(PROP_STRICT));
+    private static boolean isStrict(Project project) {
+        return project.hasProperty(PROP_STRICT) && isTrue(project.property(PROP_STRICT));
+    }
+
+    private static boolean isTrue(Object property) {
+        return Boolean.TRUE.equals(property) || "true".equalsIgnoreCase(String.valueOf(property));
     }
 
     private static Set<String> strictModeChecksToPromote() {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Promoting baseline provided error-prone checks & compiler lint warnings or suggestions to errors requires a [bunch of `build.gradle` mess (e.g. in tritium)](https://github.com/palantir/tritium/blob/f6fc389/build.gradle#L81-L124).

## After this PR
==COMMIT_MSG==
Setting the following will promote all upstream & baseline provided
error-prone checks to error, enable compiler lint checks (`-Werror`,
`-Xlint:deprecation`, `-Xlint:unchecked`), and also promote all compiler
warnings to error.

```
baselineErrorProne {
    strict true
}
```
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Baseline tends to avoid configuration of any kind, though it balances that with not enabling overly aggressive default changes that would cause major breaks in consumer projects. Allowing configuration of strict mode maintains the current defaults, and the ideal here would be that new projects would default to strict mode enabled, and legacy projects could enable strict mode as they are cleaned up.

