### PR TITLE
Break: Add gradle 6.0-20190904072820+0000 compatibility. Compile with -Werror and -Xlint:deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See also the [Baseline Java Style Guide and Best Practises](./docs).
 
 
 ## Usage
-The baseline set of plugins requires at least Gradle 4.10.0.
+The baseline set of plugins requires at least Gradle 5.0.
 
 It is recommended to add `apply plugin: 'com.palantir.baseline'` to your root project's build.gradle.  Individual plugins will be automatically applied to appropriate subprojects.
 

--- a/baseline-refaster-javac-plugin/src/main/java/com/palantir/baseline/refaster/BaselineRefasterCompiler.java
+++ b/baseline-refaster-javac-plugin/src/main/java/com/palantir/baseline/refaster/BaselineRefasterCompiler.java
@@ -37,6 +37,7 @@ public final class BaselineRefasterCompiler implements Plugin {
     }
 
     @Override
+    @SuppressWarnings("PreferSafeLoggingPreconditions")
     public void init(JavacTask task, String... args) {
         List<String> listArgs = Arrays.asList(args);
         int outIndex = listArgs.indexOf("--out");

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ allprojects {
 
     pluginManager.withPlugin('java') {
         sourceCompatibility = 1.8
+        tasks.withType(JavaCompile) {
+            options.compilerArgs += ['-Werror', '-Xlint:deprecation']
+        }
     }
 
     apply plugin: 'org.inferred.processors'

--- a/changelog/@unreleased/pr-791.v2.yml
+++ b/changelog/@unreleased/pr-791.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Compile with `-Werror` and `-Xlint:deprecation` to catch deprecations
+    when they're introduced instead of when they become compilation error. This allows
+    us to future proof early before regular users are hit with those issues in their
+    projects
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/791

--- a/changelog/@unreleased/pr-791.v2.yml
+++ b/changelog/@unreleased/pr-791.v2.yml
@@ -1,8 +1,5 @@
-type: improvement
-improvement:
-  description: Compile with `-Werror` and `-Xlint:deprecation` to catch deprecations
-    when they're introduced instead of when they become compilation error. This allows
-    us to future proof early before regular users are hit with those issues in their
-    projects
+type: break
+break:
+  description: Add gradle 6.0-20190904072820+0000 compatibiltiy. This raises minimum required version of gradle for plugins from this repo to 5.0. Additionally add '-Werror' and '-Xlint:deprecation' so we can detect compatiblilty issues early
   links:
   - https://github.com/palantir/gradle-baseline/pull/791

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckBomConflictTask.java
@@ -43,7 +43,7 @@ import org.gradle.api.tasks.options.Option;
 public class CheckBomConflictTask extends DefaultTask {
 
     private final Property<Boolean> shouldFix = getProject().getObjects().property(Boolean.class);
-    private final RegularFileProperty propsFileProperty = newInputFile();
+    private final RegularFileProperty propsFileProperty = getProject().getObjects().fileProperty();
 
     public CheckBomConflictTask() {
         shouldFix.set(false);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckNoUnusedPinTask.java
@@ -42,7 +42,7 @@ import org.gradle.api.tasks.options.Option;
 public class CheckNoUnusedPinTask extends DefaultTask {
 
     private final Property<Boolean> shouldFix = getProject().getObjects().property(Boolean.class);
-    private final RegularFileProperty propsFileProperty = newInputFile();
+    private final RegularFileProperty propsFileProperty = getProject().getObjects().fileProperty();
 
     public CheckNoUnusedPinTask() {
         shouldFix.set(false);

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIntegrationTest.groovy
@@ -43,6 +43,6 @@ class BaselineIntegrationTest extends AbstractPluginTest {
         with().withArguments('-s').withGradleVersion(gradleVersion).build()
 
         where:
-        gradleVersion << ['4.10.2', '5.0-milestone-1']
+        gradleVersion << ['5.0']
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIntegrationTest.groovy
@@ -43,6 +43,6 @@ class BaselineIntegrationTest extends AbstractPluginTest {
         with().withArguments('-s').withGradleVersion(gradleVersion).build()
 
         where:
-        gradleVersion << ['5.0']
+        gradleVersion << ['5.0', '6.0-20190904072820+0000']
     }
 }

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsExtension.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsExtension.java
@@ -24,7 +24,7 @@ public class JunitReportsExtension {
     private final DirectoryProperty reportsDirectory;
 
     public JunitReportsExtension(Project project) {
-        this.reportsDirectory = project.getLayout().directoryProperty();
+        this.reportsDirectory = project.getObjects().directoryProperty();
         reportsDirectory.set(project.getLayout().getBuildDirectory().dir("junit-reports"));
     }
 

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsFinalizer.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsFinalizer.java
@@ -60,8 +60,8 @@ public class JunitReportsFinalizer extends DefaultTask {
     private Task styleTask;
     private TaskTimer taskTimer;
     private FailuresSupplier failuresSupplier;
-    private final RegularFileProperty targetFile = getProject().getLayout().fileProperty();
-    private final DirectoryProperty reportDir = getProject().getLayout().directoryProperty();
+    private final RegularFileProperty targetFile = getProject().getObjects().fileProperty();
+    private final DirectoryProperty reportDir = getProject().getObjects().directoryProperty();
 
     @Inject
     public JunitReportsFinalizer() { }

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsPlugin.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsPlugin.java
@@ -34,6 +34,7 @@ public final class JunitReportsPlugin implements Plugin<Project> {
     public static final String EXT_JUNIT_REPORTS = "junitReports";
 
     @Override
+    @SuppressWarnings("Slf4jLogsafeArgs")
     public void apply(Project project) {
         if (project != project.getRootProject()) {
             project.getLogger().warn(
@@ -82,7 +83,7 @@ public final class JunitReportsPlugin implements Plugin<Project> {
             int attemptNumber = 1;
             Path targetFile = dir.getAsFile().toPath().resolve("gradle").resolve("build.xml");
             while (targetFile.toFile().exists()) {
-                targetFile = dir.getAsFile().toPath().resolve("gradle").resolve("build" + (++attemptNumber) + ".xml");
+                targetFile = dir.getAsFile().toPath().resolve("gradle").resolve("build" + ++attemptNumber + ".xml");
             }
             return dir.file(targetFile.toAbsolutePath().toString());
         });


### PR DESCRIPTION
## Before this PR
Compilation would fail if baseline was used with gradle 6 snapshots due to deprecations being removed

## After this PR
==COMMIT_MSG==
Add gradle 6.0-20190904072820+0000 compatibility. This raises minimum required version of gradle for plugins from this repo to 5.0. Additionally add '-Werror' and '-Xlint:deprecation' so we can detect compatibility issues early
==COMMIT_MSG==

## Possible downsides?
This pr is naive and just requires min gradle version to be 5 instead of 4.10
