### PR TITLE
Fix: don't apply error prone patches for disabled checks

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
         linkType = BugPattern.LinkType.CUSTOM,
         severity = BugPattern.SeverityLevel.WARNING,
         summary = "Throw SafeLoggable exceptions to ensure the exception message will not be redacted")
+@SuppressWarnings("PreferSafeLoggableExceptions")
 public final class PreferSafeLoggableExceptions extends BugChecker implements BugChecker.NewClassTreeMatcher {
 
     private static final long serialVersionUID = 1L;

--- a/changelog/@unreleased/pr-793.v2.yml
+++ b/changelog/@unreleased/pr-793.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Stop applying error prone patches for checks that have been turned
+    off.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/793

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     testCompile 'junit:junit'
     testCompile 'net.lingala.zip4j:zip4j'
     testCompile 'org.assertj:assertj-core'
-    testRuntimeOnly 'org.slf4j:slf4j-api'
 
     annotationProcessor 'org.inferred:freebuilder'
     compileOnly 'org.inferred:freebuilder'

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testCompile 'junit:junit'
     testCompile 'net.lingala.zip4j:zip4j'
     testCompile 'org.assertj:assertj-core'
+    testRuntimeOnly 'org.slf4j:slf4j-api'
 
     annotationProcessor 'org.inferred:freebuilder'
     compileOnly 'org.inferred:freebuilder'

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -24,8 +24,10 @@ import com.palantir.baseline.tasks.RefasterCompileTask;
 import java.io.File;
 import java.util.AbstractList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.ltgt.gradle.errorprone.CheckSeverity;
 import net.ltgt.gradle.errorprone.ErrorProneOptions;
 import net.ltgt.gradle.errorprone.ErrorPronePlugin;
@@ -36,6 +38,8 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -43,6 +47,7 @@ import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
 
 public final class BaselineErrorProne implements Plugin<Project> {
+    private static final Logger log = Logging.getLogger(BaselineErrorProne.class);
 
     public static final String REFASTER_CONFIGURATION = "refaster";
     public static final String EXTENSION_NAME = "baselineErrorProne";
@@ -51,6 +56,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
     private static final String PROP_ERROR_PRONE_APPLY = "errorProneApply";
     private static final String PROP_REFASTER_APPLY = "refasterApply";
 
+    @SuppressWarnings("UnstableApiUsage")
     @Override
     public void apply(Project project) {
         project.getPluginManager().withPlugin("java", plugin -> {
@@ -132,10 +138,25 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                     // TODO(gatesn): Is there a way to discover error-prone checks?
                                     // Maybe service-load from a ClassLoader configured with annotation processor path?
                                     // https://github.com/google/error-prone/pull/947
-                                    errorProneOptions.getErrorproneArgumentProviders().add(() -> ImmutableList.of(
-                                            "-XepPatchChecks:" + Joiner.on(',')
-                                                    .join(errorProneExtension.getPatchChecks().get()),
-                                            "-XepPatchLocation:IN_PLACE"));
+                                    errorProneOptions.getErrorproneArgumentProviders().add(() -> {
+                                        // Don't apply checks that have been explicitly disabled
+                                        Stream<String> errorProneChecks = errorProneExtension
+                                                .getPatchChecks()
+                                                .get()
+                                                .stream()
+                                                .filter(check -> {
+                                                    if (checkExplicitlyDisabled(errorProneOptions, check)) {
+                                                        log.warn("Task {}: not applying errorprone check {} because it "
+                                                                + "has severity OFF in errorProneOptions",
+                                                                javaCompile.getPath(), check);
+                                                        return false;
+                                                    }
+                                                    return true;
+                                                });
+                                        return ImmutableList.of(
+                                                "-XepPatchChecks:" + Joiner.on(',').join(errorProneChecks.iterator()),
+                                                "-XepPatchLocation:IN_PLACE");
+                                    });
                                 }
                             }
                         });
@@ -206,6 +227,12 @@ public final class BaselineErrorProne implements Plugin<Project> {
 
     private boolean isErrorProneRefactoring(Project project) {
         return project.hasProperty(PROP_ERROR_PRONE_APPLY);
+    }
+
+    private static boolean checkExplicitlyDisabled(ErrorProneOptions errorProneOptions, String check) {
+        Map<String, CheckSeverity> checks = errorProneOptions.getChecks();
+        return checks.get(check) == CheckSeverity.OFF
+                || errorProneOptions.getErrorproneArgs().contains(String.format("-Xep:%s:OFF", check));
     }
 
     private static final class LazyConfigurationList extends AbstractList<File> {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -146,7 +146,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                                 .stream()
                                                 .filter(check -> {
                                                     if (checkExplicitlyDisabled(errorProneOptions, check)) {
-                                                        log.warn("Task {}: not applying errorprone check {} because it "
+                                                        log.info("Task {}: not applying errorprone check {} because it "
                                                                 + "has severity OFF in errorProneOptions",
                                                                 javaCompile.getPath(), check);
                                                         return false;

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -130,14 +130,14 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         '''.stripIndent()
     }
 
-    enum TurnOffMethod { ARG, DSL }
+    enum CheckConfigurationMethod { ARG, DSL }
 
     @Unroll
-    def 'compileJava does not apply patches for error-prone checks that were turned OFF via #turnOffMethod'() {
+    def 'compileJava does not apply patches for error-prone checks that were turned OFF via #checkConfigurationMethod'() {
         def checkName = "Slf4jLogsafeArgs"
         def turnOffCheck = [
-                (TurnOffMethod.ARG): "options.errorprone.errorproneArgs += ['-Xep:$checkName:OFF']",
-                (TurnOffMethod.DSL): """
+                (CheckConfigurationMethod.ARG): "options.errorprone.errorproneArgs += ['-Xep:$checkName:OFF']",
+                (CheckConfigurationMethod.DSL): """
                     options.errorprone {
                         check '$checkName', net.ltgt.gradle.errorprone.CheckSeverity.OFF
                     }                    
@@ -148,7 +148,7 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         buildFile << standardBuildFile
         buildFile << """
             tasks.withType(JavaCompile) {
-                ${turnOffCheck[turnOffMethod]}
+                ${turnOffCheck[checkConfigurationMethod]}
             }
             dependencies {
                 implementation 'org.slf4j:slf4j-api:1.7.25'
@@ -182,6 +182,6 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         '''.stripIndent()
 
         where:
-        turnOffMethod << TurnOffMethod.values()
+        checkConfigurationMethod << CheckConfigurationMethod.values()
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -144,7 +144,6 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
                 """.stripIndent(),
         ]
 
-        when:
         buildFile << standardBuildFile
         buildFile << """
             tasks.withType(JavaCompile) {
@@ -154,7 +153,8 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
                 implementation 'org.slf4j:slf4j-api:1.7.25'
             }
         """.stripIndent()
-        file('src/main/java/test/Test.java') << '''
+
+        def correctJavaFile = '''
         package test;
         import org.slf4j.LoggerFactory;
         import org.slf4j.Logger;
@@ -165,21 +165,12 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
             }
         }
         '''.stripIndent()
+        file('src/main/java/test/Test.java') << correctJavaFile
 
-        then:
+        expect:
         BuildResult result = with('compileJava', '-PerrorProneApply').build()
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
-        file('src/main/java/test/Test.java').text == '''
-        package test;
-        import org.slf4j.LoggerFactory;
-        import org.slf4j.Logger;
-        public class Test {
-            void test() {
-                Logger log = LoggerFactory.getLogger("foo");
-                log.info("Hi there {}", "non safe arg");
-            }
-        }
-        '''.stripIndent()
+        file('src/main/java/test/Test.java').text == correctJavaFile
 
         where:
         checkConfigurationMethod << CheckConfigurationMethod.values()

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -133,24 +133,16 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         when:
         buildFile << standardBuildFile
         buildFile << """
-            tasks.withType(Java) {
+            tasks.withType(JavaCompile) {
                 ${turnOffCheck}
             }
         """.stripIndent()
         file('src/main/java/test/Test.java') << '''
         package test;
-        import java.util.Optional;
         import org.slf4j.LoggerFactory;
         import org.slf4j.Logger;
         public class Test {
             void test() {
-                int[] a = {1, 2, 3};
-                int[] b = {1, 2, 3};
-                if (a.equals(b)) {
-                  System.out.println("arrays are equal!");
-                  Optional.of("hello").orElse(System.getProperty("world"));
-                  
-                }
                 Logger log = LoggerFactory.getLogger("foo");
                 log.info("Hi there {}", "non safe arg");
             }
@@ -162,18 +154,10 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
         file('src/main/java/test/Test.java').text == '''
         package test;
-        import java.util.Arrays;
-        import java.util.Optional;
         import org.slf4j.LoggerFactory;
         import org.slf4j.Logger;
         public class Test {
             void test() {
-                int[] a = {1, 2, 3};
-                int[] b = {1, 2, 3};
-                if (Arrays.equals(a, b)) {
-                  System.out.println("arrays are equal!");
-                  Optional.of("hello").orElseGet(() -> System.getProperty("world"));
-                }
                 Logger log = LoggerFactory.getLogger("foo");
                 log.info("Hi there {}", "non safe arg");
             }


### PR DESCRIPTION
## Before this PR

`-PapplyErrorProne` will rewrite code that fails all of the patch checks in the `baselineErrorProne` extension, whether they are enabled or not on a project.

## After this PR
==COMMIT_MSG==
Stop applying error prone patches for checks that have been turned off.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

