### PR TITLE
baseline-idea: configures IntelliJ EclipseCodeFormatter plugin

### DIFF
--- a/changelog/@unreleased/pr-794.v2.yml
+++ b/changelog/@unreleased/pr-794.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Automatically configure the [Intellij Eclipse format plugin](https://plugins.jetbrains.com/plugin/6546-eclipse-code-formatter)
+    to use the eclipse formatter
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/794

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -19,7 +19,6 @@ package com.palantir.baseline.plugins;
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -35,10 +34,9 @@ class BaselineFormat extends AbstractBaselinePlugin {
     public void apply(Project project) {
         this.project = project;
 
-        Path eclipseXml = Paths.get(getConfigDir(), "spotless/eclipse.xml");
-
         project.getPluginManager().withPlugin("java", plugin -> {
             project.getPluginManager().apply("com.diffplug.gradle.spotless");
+            Path eclipseXml = eclipseConfigFile(project);
 
             project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
                 // Configure a lazy FileCollection then pass it as the target
@@ -77,5 +75,9 @@ class BaselineFormat extends AbstractBaselinePlugin {
 
     static boolean eclipseFormattingEnabled(Project project) {
         return project.hasProperty(ECLIPSE_FORMATTING);
+    }
+
+    static Path eclipseConfigFile(Project project) {
+        return project.getRootDir().toPath().resolve(".baseline/spotless/eclipse.xml");
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -142,6 +142,12 @@ class BaselineIdea extends AbstractBaselinePlugin {
             project.logger.debug "Baseline: Skipping IDEA eclipse format configuration since baseline-format not applied"
             return
         }
+
+        if (!BaselineFormat.eclipseFormattingEnabled(project)) {
+            project.logger.debug "Baseline: Not configuring EclipseCodeFormatter because com.palantir.baseline-format.eclipse is not enabled in gradle.properties"
+            return
+        }
+
         project.logger.debug "Baseline: Configuring EclipseCodeFormatter plugin for Idea"
         node.append(new XmlParser().parseText("""
              <component name="EclipseCodeFormatterProjectSettings">

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -137,13 +137,12 @@ class BaselineIdea extends AbstractBaselinePlugin {
     }
 
     private void addEclipseFormat(node) {
-        def checkstyle = project.plugins.findPlugin(BaselineFormat)
-        if (checkstyle == null) {
+        def baselineFormat = project.plugins.findPlugin(BaselineFormat)
+        if (baselineFormat == null) {
             project.logger.debug "Baseline: Skipping IDEA eclipse format configuration since baseline-format not applied"
             return
         }
-        project.logger.debug "Baseline: Configuring Eclipse format for Idea"
-        def checkstyleFile = "LOCAL_FILE:\$PROJECT_DIR\$/.baseline/checkstyle/checkstyle.xml"
+        project.logger.debug "Baseline: Configuring EclipseCodeFormatter plugin for Idea"
         node.append(new XmlParser().parseText("""
              <component name="EclipseCodeFormatterProjectSettings">
                 <option name="projectSpecificProfile">

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -157,7 +157,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
               </component>
             """))
         def externalDependencies = matchOrCreateChild(node, 'component', [name: 'ExternalDependencies'])
-        matchOrCreateChild(externalDependencies, 'plugin', [id: 'EclipseCodeFormatterProjectSettings'])
+        matchOrCreateChild(externalDependencies, 'plugin', [id: 'EclipseCodeFormatter'])
     }
 
     private void addCheckstyle(node) {
@@ -185,6 +185,8 @@ class BaselineIdea extends AbstractBaselinePlugin {
               </option>
             </component>
             """.stripIndent()))
+        def externalDependencies = matchOrCreateChild(node, 'component', [name: 'ExternalDependencies'])
+        matchOrCreateChild(externalDependencies, 'plugin', [id: 'CheckStyle-IDEA'])
     }
 
     /**

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -19,6 +19,7 @@ package com.palantir.baseline.plugins
 import groovy.transform.CompileStatic
 import groovy.xml.XmlUtil
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.transport.URIish
@@ -145,6 +146,12 @@ class BaselineIdea extends AbstractBaselinePlugin {
 
         if (!BaselineFormat.eclipseFormattingEnabled(project)) {
             project.logger.debug "Baseline: Not configuring EclipseCodeFormatter because com.palantir.baseline-format.eclipse is not enabled in gradle.properties"
+            return;
+        }
+
+        Path formatterConfig = BaselineFormat.eclipseConfigFile(project)
+        if (!Files.exists(formatterConfig)) {
+            project.logger.warn "Please run ./gradlew baselineUpdateConfig to create eclipse formatter config: " + formatterConfig
             return
         }
 


### PR DESCRIPTION
## Before this PR
There was no IDE integration when using the eclipse formatter locally.

## After this PR
==COMMIT_MSG==
Automatically configure the [Intellij Eclipse format plugin](https://plugins.jetbrains.com/plugin/6546-eclipse-code-formatter) to use the eclipse formatter
==COMMIT_MSG==

Users will get a little prompt in the bottom-right of their IDE:

<img width="426" alt="Screenshot 2019-09-09 at 10 50 32" src="https://user-images.githubusercontent.com/3473798/64542590-d1c7e300-d2f1-11e9-8c7f-a504d6f5007f.png">

Clicking 'Install required plugins' will get the right formatter set up.

<img width="799" alt="Screenshot 2019-09-09 at 10 50 40" src="https://user-images.githubusercontent.com/3473798/64542597-d42a3d00-d2f1-11e9-85ec-9c92a440ddbb.png">


## Possible downsides?


