### PR TITLE
Fix: formatter no longer adds whitespace to blank lines

### DIFF
--- a/changelog/@unreleased/pr-800.v2.yml
+++ b/changelog/@unreleased/pr-800.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Don''t add whitespace to blank lines inside comments. Fixes #799'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/800

--- a/gradle-baseline-java-config/resources/spotless/eclipse.xml
+++ b/gradle-baseline-java-config/resources/spotless/eclipse.xml
@@ -116,12 +116,12 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="80"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="48"/>
-        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>

--- a/gradle-baseline-java-config/resources/spotless/eclipse.xml
+++ b/gradle-baseline-java-config/resources/spotless/eclipse.xml
@@ -116,12 +116,13 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="80"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="48"/>
-        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>

--- a/gradle-baseline-java-config/resources/spotless/eclipse.xml
+++ b/gradle-baseline-java-config/resources/spotless/eclipse.xml
@@ -116,7 +116,6 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="80"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="48"/>
-        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -52,11 +52,12 @@ class BaselineFormat extends AbstractBaselinePlugin {
                 java.removeUnusedImports();
                 // use empty string to specify one group for all non-static imports
                 java.importOrder("");
-                java.trimTrailingWhitespace();
 
                 if (eclipseFormattingEnabled(project)) {
                     java.eclipse().configFile(project.file(eclipseXml.toString()));
                 }
+
+                java.trimTrailingWhitespace();
             });
 
             // necessary because SpotlessPlugin creates tasks in an afterEvaluate block

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -65,7 +65,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
                 Task spotlessJava = project.getTasks().getByName("spotlessJava");
                 Task spotlessApply = project.getTasks().getByName("spotlessApply");
                 if (eclipseFormattingEnabled(project) && !Files.exists(eclipseXml)) {
-                    spotlessJava.dependsOn(project.getTasks().findByPath(":baselineUpdateConfig"));
+                    spotlessJava.dependsOn(":baselineUpdateConfig");
                 }
                 formatTask.dependsOn(spotlessApply);
                 project.getTasks().withType(JavaCompile.class).configureEach(spotlessJava::mustRunAfter);

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -155,17 +155,18 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
         result.task(":spotlessJava").outcome == TaskOutcome.SUCCESS
     }
 
-    def 'format trims blank lines in block or javadoc comment'() {
+    def 'eclipse format trims blank lines in block or javadoc comment'() {
         when:
         buildFile << standardBuildFile
-        def javaFileContents = resourceAsString("blank-lines-in-comments.java")
-        file('src/main/java/test/Test.java').text = javaFileContents
+        file('gradle.properties') << """
+            com.palantir.baseline-format.eclipse=true
+        """.stripIndent()
+        file('src/main/java/test/Test.java').text = resourceAsString("blank-lines-in-comments.java")
 
         then:
         BuildResult result = with('format').build()
         result.task(":spotlessJavaApply").outcome == TaskOutcome.SUCCESS
-        def javaFileContentsFixed = resourceAsString("blank-lines-in-comments-fixed.java")
-        file('src/main/java/test/Test.java').text == javaFileContentsFixed
+        file('src/main/java/test/Test.java').text == resourceAsString("blank-lines-in-comments-fixed.java")
     }
 
     private String resourceAsString(String fileName) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -155,16 +155,21 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
         result.task(":spotlessJava").outcome == TaskOutcome.SUCCESS
     }
 
-    def 'format ignores blank lines in block or javadoc comment'() {
+    def 'format trims blank lines in block or javadoc comment'() {
         when:
         buildFile << standardBuildFile
-        def javaFileContents = Resources.toString(Resources.getResource(this.class, "blank-lines-in-comments.java"), Charset.defaultCharset())
+        def javaFileContents = resourceAsString("blank-lines-in-comments.java")
         file('src/main/java/test/Test.java').text = javaFileContents
 
         then:
-        BuildResult result = with('spotlessJavaCheck').build()
-        result.task(":spotlessJava").outcome == TaskOutcome.SUCCESS
-        file('src/main/java/test/Test.java').text == javaFileContents
+        BuildResult result = with('format').build()
+        result.task(":spotlessJavaApply").outcome == TaskOutcome.SUCCESS
+        def javaFileContentsFixed = resourceAsString("blank-lines-in-comments-fixed.java")
+        file('src/main/java/test/Test.java').text == javaFileContentsFixed
+    }
+
+    private String resourceAsString(String fileName) {
+        Resources.toString(Resources.getResource(this.class, fileName), Charset.defaultCharset())
     }
 
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package com.palantir.baseline
 
+import com.google.common.io.Resources
+import java.nio.charset.Charset
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
@@ -152,4 +154,17 @@ class BaselineFormatIntegrationTest extends AbstractPluginTest {
         BuildResult result = with('spotlessJavaCheck').build()
         result.task(":spotlessJava").outcome == TaskOutcome.SUCCESS
     }
+
+    def 'format ignores blank lines in block or javadoc comment'() {
+        when:
+        buildFile << standardBuildFile
+        def javaFileContents = Resources.toString(Resources.getResource(this.class, "blank-lines-in-comments.java"), Charset.defaultCharset())
+        file('src/main/java/test/Test.java').text = javaFileContents
+
+        then:
+        BuildResult result = with('spotlessJavaCheck').build()
+        result.task(":spotlessJava").outcome == TaskOutcome.SUCCESS
+        file('src/main/java/test/Test.java').text == javaFileContents
+    }
+
 }

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/blank-lines-in-comments-fixed.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/blank-lines-in-comments-fixed.java
@@ -2,10 +2,13 @@ package test;
 
 public class Test {
     /**
-    Docstring.
+     Docstring that looks like a list:
 
-    with blank line.
-    */
+     1. hey
+     2. there
+
+     with blank line.
+     */
     Void test() {
         /*
         Normal comment

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/blank-lines-in-comments-fixed.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/blank-lines-in-comments-fixed.java
@@ -3,13 +3,13 @@ package test;
 public class Test {
     /**
     Docstring.
-    
+
     with blank line.
     */
     Void test() {
         /*
         Normal comment
-        
+
         with blank line.
         */
     }

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/blank-lines-in-comments.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/blank-lines-in-comments.java
@@ -2,10 +2,13 @@ package test;
 
 public class Test {
     /**
-    Docstring.
-    
-    with blank line.
-    */
+     Docstring that looks like a list:
+     
+     1. hey
+     2. there
+     
+     with blank line.
+     */
     Void test() {
         /*
         Normal comment

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/blank-lines-in-comments.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/blank-lines-in-comments.java
@@ -1,0 +1,16 @@
+package test;
+
+/**
+ Docstring.
+
+ with blank line.
+ */
+public class Test {
+    Void test() {
+        /*
+        Normal comment
+
+        with blank line.
+        */
+    }
+}


### PR DESCRIPTION
## Before this PR

Formatter adds whitespace to blank lines in block/javadoc comments, failing checkstyle

## After this PR
==COMMIT_MSG==
Don't add whitespace to blank lines inside comments. Fixes #799
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->