### PR TITLE
Message format checks use instanceof rather than catching

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsMessageFormat.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreconditionsMessageFormat.java
@@ -52,12 +52,17 @@ abstract class PreconditionsMessageFormat extends BugChecker implements BugCheck
             return Description.NO_MATCH;
         }
 
-        String message;
-        try {
-            message = (String) ((LiteralTree) messageArg).getValue();
-        } catch (ClassCastException exception) {
+        if (!(messageArg instanceof LiteralTree)) {
             return Description.NO_MATCH;
         }
+        LiteralTree literalTreeMessageArg = (LiteralTree) messageArg;
+
+        Object value = literalTreeMessageArg.getValue();
+
+        if (!(value instanceof String)) {
+            return Description.NO_MATCH;
+        }
+        String message = (String) value;
 
         return matchMessageFormat(tree, message, state);
     }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingExceptionMessageFormat.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingExceptionMessageFormat.java
@@ -65,12 +65,17 @@ public final class SafeLoggingExceptionMessageFormat extends BugChecker implemen
             return Description.NO_MATCH;
         }
 
-        String message;
-        try {
-            message = (String) ((LiteralTree) messageArg).getValue();
-        } catch (ClassCastException exception) {
+        if (!(messageArg instanceof LiteralTree)) {
             return Description.NO_MATCH;
         }
+        LiteralTree literalTreeMessageArg = (LiteralTree) messageArg;
+
+        Object value = literalTreeMessageArg.getValue();
+
+        if (!(value instanceof String)) {
+            return Description.NO_MATCH;
+        }
+        String message = (String) value;
 
         if (message.contains("{}")) {
             return buildDescription(tree)

--- a/changelog/@unreleased/pr-821.v2.yml
+++ b/changelog/@unreleased/pr-821.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Message format checks use instanceof rather than catching
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/821


### PR DESCRIPTION
Exceptions shouldn't be used for control flow

## After this PR
==COMMIT_MSG==
Message format checks use instanceof rather than catching
==COMMIT_MSG==

