### PR TITLE
ignore module-info.class when checking class uniqueness

### DIFF
--- a/changelog/@unreleased/pr-823.v2.yml
+++ b/changelog/@unreleased/pr-823.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Avoid false positives caused by `module-info.class` when checking class
+    uniqueness
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/823

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/ClassUniquenessAnalyzer.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/ClassUniquenessAnalyzer.java
@@ -76,7 +76,7 @@ public final class ClassUniquenessAnalyzer {
                         continue;
                     }
 
-                    if (entry.getName().equals("module-info.class")) {
+                    if (entry.getName().contains("module-info.class")) {
                         // Java 9 allows jars to have a module-info.class file in the root,
                         // we shouldn't complain about these.
                         continue;


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Avoid false positives caused by `module-info.class` when checking class uniqueness 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

