### PR TITLE
Fix compilation of baseline-error-prone to be deterministic

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -1,5 +1,3 @@
-import net.ltgt.gradle.errorprone.CheckSeverity
-
 apply plugin: 'nebula.maven-publish'
 apply plugin: 'nebula.source-jar'
 apply plugin: 'java-library'

--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -1,3 +1,5 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 apply plugin: 'nebula.maven-publish'
 apply plugin: 'nebula.source-jar'
 apply plugin: 'java-library'
@@ -20,4 +22,11 @@ dependencies {
 
     annotationProcessor 'com.google.auto.service:auto-service'
     compileOnly 'com.google.auto.service:auto-service'
+}
+
+// This is necessary to prevent the errorprone plugin from using this very project's output directory
+def originalGroup = project.group
+group = originalGroup + '-internal'
+publishing.publications.nebula {
+    groupId = originalGroup
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 buildscript {
     repositories {
         jcenter()
@@ -48,8 +50,10 @@ allprojects {
         tasks.withType(JavaCompile) {
             options.compilerArgs += ['-Werror', '-Xlint:deprecation']
             options.errorprone {
-                disable("Slf4jLogsafeArgs", "PreferSafeLoggableExceptions",
-                        "PreferSafeLoggingPreconditions", "PreconditionsConstantMessage")
+                check("Slf4jLogsafeArgs", CheckSeverity.OFF)
+                check("PreferSafeLoggableExceptions", CheckSeverity.OFF)
+                check("PreferSafeLoggingPreconditions", CheckSeverity.OFF)
+                check("PreconditionsConstantMessage", CheckSeverity.OFF)
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import net.ltgt.gradle.errorprone.CheckSeverity
-
 buildscript {
     repositories {
         jcenter()
@@ -50,10 +48,8 @@ allprojects {
         tasks.withType(JavaCompile) {
             options.compilerArgs += ['-Werror', '-Xlint:deprecation']
             options.errorprone {
-                check("Slf4jLogsafeArgs", CheckSeverity.OFF)
-                check("PreferSafeLoggableExceptions", CheckSeverity.OFF)
-                check("PreferSafeLoggingPreconditions", CheckSeverity.OFF)
-                check("PreconditionsConstantMessage", CheckSeverity.OFF)
+                disable("Slf4jLogsafeArgs", "PreferSafeLoggableExceptions",
+                        "PreferSafeLoggingPreconditions", "PreconditionsConstantMessage")
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 buildscript {
     repositories {
         jcenter()
@@ -47,6 +49,12 @@ allprojects {
         sourceCompatibility = 1.8
         tasks.withType(JavaCompile) {
             options.compilerArgs += ['-Werror', '-Xlint:deprecation']
+            options.errorprone {
+                check("Slf4jLogsafeArgs", CheckSeverity.OFF)
+                check("PreferSafeLoggableExceptions", CheckSeverity.OFF)
+                check("PreferSafeLoggingPreconditions", CheckSeverity.OFF)
+                check("PreconditionsConstantMessage", CheckSeverity.OFF)
+            }
         }
     }
 


### PR DESCRIPTION
## Before this PR

The current errorprone project ends up using errorprone rules from _its own output directory_ leading to all sorts of confusion when running locally, especially after compiling from different branches where you might have remaining class files lying around. 

This occurrs when the local checkout's version is higher (according to gradle) than the baseline version used in buildscript. This is almost always true unless checking out an old branch.

The reason for this is gradle's aggressive replacing of external dependencies with a project dependency if the `group:name` matches.

## After this PR
==COMMIT_MSG==
Make baseline-error-prone pick up buildscript baseline's errorprone rules correctly so compilation is deterministic.

This avoids the confusing feedback loop where this project's own compilation output would be used to determine errorprone rules in future compilations of itself.

Additionally, disabled some checks globally which make no sense in projects that are not services.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

