### PR TITLE
Fix: Checkstyle no longer verifies resources

### DIFF
--- a/changelog/@unreleased/pr-830.v2.yml
+++ b/changelog/@unreleased/pr-830.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Checkstyle tasks only check their own source set and only actual java
+    sources. They don't look in your `src/*/resources` directory anymore.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/830

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java
@@ -17,10 +17,8 @@
 package com.palantir.baseline.plugins;
 
 import java.nio.file.Paths;
-import java.util.stream.Stream;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.plugins.quality.CheckstyleExtension;
 import org.gradle.api.plugins.quality.CheckstylePlugin;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -55,20 +53,6 @@ public final class BaselineCheckstyle extends AbstractBaselinePlugin {
                         javadoc.options(javadocOptions -> ((StandardJavadocDocletOptions) javadocOptions)
                                 .addStringOption("Xdoclint:none", "-quiet")));
             }
-            project.getTasks().withType(Checkstyle.class, checkstyle -> {
-                // Make checkstyle include files in src/main/resources and src/test/resources, e.g.,
-                // for whitespace checks.
-                javaConvention.getSourceSets()
-                        .forEach(sourceSet -> sourceSet.getResources().getSrcDirs()
-                                .forEach(resourceDir -> checkstyle.source(resourceDir.toString())));
-                // These sources are only checked by gradle, NOT by Eclipse.
-                Stream.of("checks", "manifests", "scripts", "templates").forEach(checkstyle::source);
-                // Make sure java files are still included. This should match list in etc/eclipse-template/.checkstyle.
-                // Currently not enforced, but could be eventually.
-                Stream.of(
-                        "java", "cfg", "coffee", "erb", "groovy", "handlebars", "json", "less", "pl", "pp", "sh", "xml")
-                        .forEach(extension -> checkstyle.include("**/*." + extension));
-            });
         });
 
         project.getExtensions().getByType(CheckstyleExtension.class)

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineCheckstyleTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineCheckstyleTest.groovy
@@ -17,14 +17,10 @@
 package com.palantir.baseline
 
 import com.palantir.baseline.plugins.BaselineCheckstyle
-import com.palantir.baseline.plugins.BaselineEclipse
-import nebula.test.multiproject.MultiProjectIntegrationHelper
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CheckstylePlugin
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 class BaselineCheckstyleTest extends Specification {
@@ -46,7 +42,7 @@ class BaselineCheckstyleTest extends Specification {
         project.plugins.hasPlugin(CheckstylePlugin.class)
     }
 
-    def includesResources() {
+    def doesNotIncludeResources() {
         def file = new File(project.projectDir, 'src/test/resources/checkstyle.xml')
         file.getParentFile().mkdirs()
         when:
@@ -57,7 +53,7 @@ class BaselineCheckstyleTest extends Specification {
         then:
         def tasks = project.tasks.withType(Checkstyle.class)
         for (Checkstyle task : tasks) {
-            assert task.getSource().getFiles().contains(file)
+            assert !task.getSource().getFiles().contains(file)
         }
     }
 }

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/XmlReportFailuresSupplier.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/XmlReportFailuresSupplier.java
@@ -55,7 +55,11 @@ public final class XmlReportFailuresSupplier implements FailuresSupplier {
     @Override
     public List<Failure> getFailures() throws IOException {
         File sourceReport = reporting.getReports().findByName("xml").getDestination();
-        return XmlUtils.parseXml(reportHandler, new FileInputStream(sourceReport)).failures();
+        try {
+            return XmlUtils.parseXml(reportHandler, new FileInputStream(sourceReport)).failures();
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Failed to parse failures XML: %s", sourceReport), e);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Before this PR

Checkstyle was going into the resources dirs, with seemingly no way to turn it off.
It can sometimes crash on these files which makes it almost impossible to exclude them.

## After this PR
==COMMIT_MSG==
Checkstyle tasks only check their own source set and only actual java sources. They don't look in your `src/*/resources` directory anymore.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

