### PR TITLE
Fix: Long try-with-resources adheres to palantir style

### DIFF
--- a/changelog/@unreleased/pr-835.v2.yml
+++ b/changelog/@unreleased/pr-835.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Long try-with-resources statements are now aligned such that the first
+    assignment stays on the first line.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/835

--- a/gradle-baseline-java-config/resources/spotless/eclipse.xml
+++ b/gradle-baseline-java-config/resources/spotless/eclipse.xml
@@ -177,7 +177,7 @@
         <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
         <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="80"/>

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/googlejavaformat-expected/B21465217.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/googlejavaformat-expected/B21465217.java
@@ -1,7 +1,6 @@
 class B21465217 {
     void m() {
-        try (
-                JimfsOutputStream out2 = newOutputStream(false);
+        try (JimfsOutputStream out2 = newOutputStream(false);
                 BufferedOutputStream bout = new BufferedOutputStream(out2);
                 OutputStreamWriter writer = new OutputStreamWriter(bout, UTF_8___________________________)) {}
 

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/googlejavaformat-expected/TryWithResources.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/googlejavaformat-expected/TryWithResources.java
@@ -8,9 +8,8 @@ class TryWtihResources {
         try (@A
         final @B C c = c();) {}
 
-        try (
-                final BufferedWriter writer =
-                        new BufferedWriter(new OutputStreamWriter(testFile, Charset.defaultCharset()))) {
+        try (final BufferedWriter writer =
+                new BufferedWriter(new OutputStreamWriter(testFile, Charset.defaultCharset()))) {
             writer.append("tom cruise\n").append("avatar\n");
             writer.flush();
         }


### PR DESCRIPTION
## Before this PR

Long try-with-resources statements would be aligned such that the first statement would be on a new line.

## After this PR
==COMMIT_MSG==
Long try-with-resources statements are now aligned such that the first assignment stays on the first line.
==COMMIT_MSG==

FYI how to construct an aligment mask: https://github.com/eclipse/eclipse.jdt.core/blob/master/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java#L41-L95

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

