### PR TITLE
ErrorProne PreferAssertj migration to AssertJ from org.junit.Assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `SafeLoggingExceptionMessageFormat`: SafeLoggable exceptions do not interpolate parameters.
 - `StrictUnusedVariable`: Functions shouldn't have unused parameters.
 - `StringBuilderConstantParameters`: StringBuilder with a constant number of parameters should be replaced by simple concatenation.
+- `PreferAssertj`: Prefer AssertJ fluent assertions.
 
 ## com.palantir.baseline-checkstyle
 Checkstyle rules can be suppressed on a per-line or per-block basis. (It is good practice to first consider formatting

--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testCompile 'org.slf4j:slf4j-api'
     testCompile 'org.apache.commons:commons-lang3'
     testCompile 'commons-lang:commons-lang'
+    testCompile 'org.assertj:assertj-core'
     testCompile 'org.junit.jupiter:junit-jupiter-api'
     testCompile gradleApi()
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-migrationsupport'

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -57,8 +57,6 @@ import java.util.function.BiConsumer;
         summary = "Prefer AssertJ fluent assertions")
 public final class PreferAssertj extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
-    private static final String MESSAGE = "Prefer AssertJ fluent assertions";
-
     private static final String ASSERTJ_ASSERTIONS = "org.assertj.core.api.Assertions";
     private static final String ASSERT_THAT = "assertThat";
     private static final String ASSERTJ_ASSERT_THAT = ASSERTJ_ASSERTIONS + '.' + ASSERT_THAT;
@@ -267,7 +265,6 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         }
         if (FAIL_DESCRIPTION.matches(tree, state) || FAIL.matches(tree, state)) {
             return buildDescription(tree)
-                    .setMessage(MESSAGE)
                     .addFix(SuggestedFix.builder()
                             .removeStaticImport("org.junit.Assert.fail")
                             .addStaticImport(ASSERTJ_ASSERTIONS + ".fail")
@@ -321,9 +318,7 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
             } else {
                 // Does not fix assertArrayEquals(double[], double[], double)
                 // or assertArrayEquals(float[], float[], float)
-                return buildDescription(tree)
-                        .setMessage(MESSAGE)
-                        .build();
+                return describeMatch(tree);
             }
         }
         if (ASSERT_NOT_EQUALS_CATCHALL.matches(tree, state)) {
@@ -342,9 +337,7 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
                                 + argSource(tree, state, 1) + ")"));
             } else {
                 // I'm not aware of anything that should hit this.
-                return buildDescription(tree)
-                        .setMessage(MESSAGE)
-                        .build();
+                return describeMatch(tree);
             }
         }
         return Description.NO_MATCH;
@@ -369,7 +362,6 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         }
         assertThat.accept(qualified, fix);
         return buildDescription(tree)
-                .setMessage(MESSAGE)
                 .addFix(fix.build())
                 .build();
     }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -1,0 +1,404 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/**
+ * {@link PreferAssertj} provides an automated path from legacy test libraries to AssertJ. Our goal is to migrate
+ * existing assertions to AssertJ without losing any information. It's an explicit non-goal to take advantage
+ * of better assertions provided by AssertJ, because those should be implemented in such a way to improve poor
+ * uses of AssertJ as well, which may run after the suggested fixes provided by this checker.
+ *
+ * Remaining work: This doesn't handle Assert.assertThat(value, matcher). We should be able to handle common
+ * cases relatively easily.
+ */
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "PreferAssertj",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.SUGGESTION,
+        summary = "Prefer AssertJ fluent assertions")
+public final class PreferAssertj extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final String MESSAGE = "Prefer AssertJ fluent assertions";
+
+    private static final String ASSERTJ_ASSERTIONS = "org.assertj.core.api.Assertions";
+    private static final String ASSERT_THAT = "assertThat";
+
+    private static final Matcher<ExpressionTree> ASSERT_TRUE =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertTrue")
+                    .withParameters(boolean.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_TRUE_DESCRIPTION =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertTrue")
+                    .withParameters(String.class.getName(), boolean.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_FALSE =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertFalse")
+                    .withParameters(boolean.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_FALSE_DESCRIPTION =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertFalse")
+                    .withParameters(String.class.getName(), boolean.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_NULL =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNull")
+                    .withParameters(Object.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_NULL_DESCRIPTION =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNull")
+                    .withParameters(String.class.getName(), Object.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_NOT_NULL =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNotNull")
+                    .withParameters(Object.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_NOT_NULL_DESCRIPTION =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNotNull")
+                    .withParameters(String.class.getName(), Object.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_SAME =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertSame")
+                    .withParameters(Object.class.getName(), Object.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_SAME_DESCRIPTION =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertSame")
+                    .withParameters(String.class.getName(), Object.class.getName(), Object.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_NOT_SAME =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNotSame")
+                    .withParameters(Object.class.getName(), Object.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_NOT_SAME_DESCRIPTION =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNotSame")
+                    .withParameters(String.class.getName(), Object.class.getName(), Object.class.getName());
+
+    private static final Matcher<ExpressionTree> FAIL =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("fail")
+                    .withParameters();
+
+    private static final Matcher<ExpressionTree> FAIL_DESCRIPTION =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("fail")
+                    .withParameters(String.class.getName());
+
+    private static final Matcher<ExpressionTree> ASSERT_EQUALS_FLOATING = Matchers.anyOf(
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertEquals")
+                    .withParameters("double", "double", "double"),
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertEquals")
+                    .withParameters("float", "float", "float"));
+
+    private static final Matcher<ExpressionTree> ASSERT_EQUALS_FLOATING_DESCRIPTION = Matchers.anyOf(
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertEquals")
+                    .withParameters(String.class.getName(), "double", "double", "double"),
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertEquals")
+                    .withParameters(String.class.getName(), "float", "float", "float"));
+
+    private static final Matcher<ExpressionTree> ASSERT_NOT_EQUALS_FLOATING = Matchers.anyOf(
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNotEquals")
+                    .withParameters("double", "double", "double"),
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNotEquals")
+                    .withParameters("float", "float", "float"));
+
+    private static final Matcher<ExpressionTree> ASSERT_NOT_EQUALS_FLOATING_DESCRIPTION = Matchers.anyOf(
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNotEquals")
+                    .withParameters(String.class.getName(), "double", "double", "double"),
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .named("assertNotEquals")
+                    .withParameters(String.class.getName(), "float", "float", "float"));
+
+    // Does not match specific patterns, this handles all overloads of both assertEquals and assertArrayEquals.
+    // Order is important, more specific (e.g. floating point) checks must execute first.
+    private static final Matcher<ExpressionTree> ASSERT_EQUALS_CATCHALL =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    .namedAnyOf("assertEquals", "assertArrayEquals");
+
+    private static final Matcher<ExpressionTree> ASSERT_NOT_EQUALS_CATCHALL =
+            MethodMatchers.staticMethod()
+                    .onClass("org.junit.Assert")
+                    // There is no Assert.assertArrayNotEquals
+                    .named("assertNotEquals");
+
+    @Override
+    @SuppressWarnings("CyclomaticComplexity")
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (ASSERT_TRUE.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ").isTrue()"));
+        }
+        if (ASSERT_TRUE_DESCRIPTION.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                            + ").describedAs(" + argSource(tree, state, 0) + ").isTrue()"));
+        }
+        if (ASSERT_FALSE.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ").isFalse()"));
+        }
+        if (ASSERT_FALSE_DESCRIPTION.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                            + ").describedAs(" + argSource(tree, state, 0) + ").isFalse()"));
+        }
+        if (ASSERT_NULL.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ").isNull()"));
+        }
+        if (ASSERT_NULL_DESCRIPTION.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                            + ").describedAs(" + argSource(tree, state, 0) + ").isNull()"));
+        }
+        if (ASSERT_NOT_NULL.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ").isNotNull()"));
+        }
+        if (ASSERT_NOT_NULL_DESCRIPTION.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                            + ").describedAs(" + argSource(tree, state, 0) + ").isNotNull()"));
+        }
+        if (ASSERT_SAME.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                            + ").isSameAs(" + argSource(tree, state, 0) + ")"));
+        }
+        if (ASSERT_SAME_DESCRIPTION.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 2)
+                            + ").describedAs(" + argSource(tree, state, 0) + ").isSameAs("
+                            + argSource(tree, state, 1) + ")"));
+        }
+        if (ASSERT_NOT_SAME.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                            + ").isNotSameAs(" + argSource(tree, state, 0) + ")"));
+        }
+        if (ASSERT_NOT_SAME_DESCRIPTION.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 2)
+                            + ").describedAs(" + argSource(tree, state, 0) + ").isNotSameAs("
+                            + argSource(tree, state, 1) + ")"));
+        }
+        if (FAIL.matches(tree, state)) {
+            return withQualified(ASSERTJ_ASSERTIONS, "fail", tree, state, (fail, fix) ->
+                    fix.replace(tree, fail + "(\"fail\")"));
+        }
+        if (FAIL_DESCRIPTION.matches(tree, state)) {
+            return withQualified(ASSERTJ_ASSERTIONS, "fail", tree, state, (fail, fix) ->
+                    fix.replace(tree, fail + "(" + argSource(tree, state, 0) + ")"));
+        }
+        if (ASSERT_EQUALS_FLOATING.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) -> fix
+                    .addStaticImport("org.assertj.core.api.Assertions.within")
+                    .replace(tree, assertThat + "(" + argSource(tree, state, 1) + ").isCloseTo("
+                            + argSource(tree, state, 0) + ", within(" + argSource(tree, state, 2) + "))"));
+        }
+        if (ASSERT_EQUALS_FLOATING_DESCRIPTION.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) -> fix
+                    .addStaticImport("org.assertj.core.api.Assertions.within")
+                    .replace(tree, assertThat + "(" + argSource(tree, state, 2)
+                            + ").describedAs(" + argSource(tree, state, 0) + ").isCloseTo("
+                            + argSource(tree, state, 1) + ", within(" + argSource(tree, state, 3) + "))"));
+        }
+        if (ASSERT_NOT_EQUALS_FLOATING.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) -> fix
+                    .addStaticImport("org.assertj.core.api.Assertions.within")
+                    .replace(tree, assertThat + "(" + argSource(tree, state, 1) + ").isNotCloseTo("
+                            + argSource(tree, state, 0) + ", within(" + argSource(tree, state, 2) + "))"));
+        }
+        if (ASSERT_NOT_EQUALS_FLOATING_DESCRIPTION.matches(tree, state)) {
+            return withAssertThat(tree, state, (assertThat, fix) -> fix
+                    .addStaticImport("org.assertj.core.api.Assertions.within")
+                    .replace(tree, assertThat + "(" + argSource(tree, state, 2)
+                            + ").describedAs(" + argSource(tree, state, 0) + ").isNotCloseTo("
+                            + argSource(tree, state, 1) + ", within(" + argSource(tree, state, 3) + "))"));
+        }
+        if (ASSERT_EQUALS_CATCHALL.matches(tree, state)) {
+            int parameters = tree.getArguments().size();
+            if (parameters == 2) {
+                return withAssertThat(tree, state, (assertThat, fix) ->
+                        fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                                + ").isEqualTo(" + argSource(tree, state, 0) + ")"));
+            } else if (parameters == 3 && ASTHelpers.isSameType(
+                    ASTHelpers.getType(tree.getArguments().get(0)),
+                    state.getTypeFromString(String.class.getName()),
+                    state)) {
+                return withAssertThat(tree, state, (assertThat, fix) ->
+                        fix.replace(tree, assertThat + "(" + argSource(tree, state, 2)
+                                + ").describedAs(" + argSource(tree, state, 0) + ").isEqualTo("
+                                + argSource(tree, state, 1) + ")"));
+            } else {
+                // Does not fix assertArrayEquals(double[], double[], double)
+                // or assertArrayEquals(float[], float[], float)
+                return buildDescription(tree)
+                        .setMessage(MESSAGE)
+                        .build();
+            }
+        }
+        if (ASSERT_NOT_EQUALS_CATCHALL.matches(tree, state)) {
+            int parameters = tree.getArguments().size();
+            if (parameters == 2) {
+                return withAssertThat(tree, state, (assertThat, fix) ->
+                        fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                                + ").isNotEqualTo(" + argSource(tree, state, 0) + ")"));
+            } else if (parameters == 3 && ASTHelpers.isSameType(
+                    ASTHelpers.getType(tree.getArguments().get(0)),
+                    state.getTypeFromString(String.class.getName()),
+                    state)) {
+                return withAssertThat(tree, state, (assertThat, fix) ->
+                        fix.replace(tree, assertThat + "(" + argSource(tree, state, 2)
+                                + ").describedAs(" + argSource(tree, state, 0) + ").isNotEqualTo("
+                                + argSource(tree, state, 1) + ")"));
+            } else {
+                // I'm not aware of anything that should hit this.
+                return buildDescription(tree)
+                        .setMessage(MESSAGE)
+                        .build();
+            }
+        }
+        return Description.NO_MATCH;
+    }
+
+    /**
+     * Provides a qualified 'assertThat' name. We attempt to use a static import if possible, otherwise fall back
+     * to as qualified as possible.
+     */
+    private Description withAssertThat(
+            MethodInvocationTree tree,
+            VisitorState state,
+            BiConsumer<String, SuggestedFix.Builder> assertThat) {
+        return withQualified(ASSERTJ_ASSERTIONS, ASSERT_THAT, tree, state, assertThat);
+    }
+
+    private Description withQualified(
+            String fullyQualifiedClass,
+            String functionName,
+            MethodInvocationTree tree,
+            VisitorState state,
+            BiConsumer<String, SuggestedFix.Builder> qualifiedConsumer) {
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        String qualified;
+        String fullyQualifiedFunction = fullyQualifiedClass + '.' + functionName;
+        if (useStaticAssertjImport(fullyQualifiedClass, functionName, state)) {
+            fix.addStaticImport(fullyQualifiedFunction);
+            qualified = functionName;
+        } else {
+            qualified = SuggestedFixes.qualifyType(state, fix, fullyQualifiedFunction);
+        }
+        qualifiedConsumer.accept(qualified, fix);
+        return buildDescription(tree)
+                .setMessage(MESSAGE)
+                .addFix(fix.build())
+                .build();
+    }
+
+    private static boolean useStaticAssertjImport(String fullyQualifiedClass, String functionName, VisitorState state) {
+        for (ImportTree importTree : state.getPath().getCompilationUnit().getImports()) {
+            if (!importTree.isStatic()) {
+                continue;
+            }
+            Tree identifier = importTree.getQualifiedIdentifier();
+            if (!(identifier instanceof MemberSelectTree)) {
+                continue;
+            }
+            MemberSelectTree memberSelectTree = (MemberSelectTree) identifier;
+            if (!memberSelectTree.getIdentifier().contentEquals(functionName)) {
+                continue;
+            }
+            // if an 'assertThat' is already imported, and it's not AssertJ, use a qualified name
+            return ASTHelpers.isSameType(
+                    ASTHelpers.getType(memberSelectTree.getExpression()),
+                    state.getTypeFromString(fullyQualifiedClass),
+                    state);
+        }
+        // If we did not encounter an assertThat static import, we can import and use it.
+        return true;
+    }
+
+    private static String argSource(MethodInvocationTree invocation, VisitorState state, int index) {
+        checkArgument(index >= 0, "Index must be non-negative");
+        List<? extends ExpressionTree> arguments = checkNotNull(invocation, "MethodInvocationTree").getArguments();
+        checkArgument(index < arguments.size(), "Index is out of bounds");
+        return checkNotNull(state.getSourceForNode(arguments.get(index)), "Failed to find argument source");
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -61,128 +62,132 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
     private static final String ASSERTJ_ASSERTIONS = "org.assertj.core.api.Assertions";
     private static final String ASSERT_THAT = "assertThat";
     private static final String ASSERTJ_ASSERT_THAT = ASSERTJ_ASSERTIONS + '.' + ASSERT_THAT;
+    private static final ImmutableSet<String> LEGACY_ASSERT_CLASSES = ImmutableSet.of(
+            "org.junit.Assert",
+            "junit.framework.TestCase",
+            "junit.framework.Assert");
 
     private static final Matcher<ExpressionTree> ASSERT_TRUE =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertTrue")
                     .withParameters(boolean.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_TRUE_DESCRIPTION =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertTrue")
                     .withParameters(String.class.getName(), boolean.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_FALSE =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertFalse")
                     .withParameters(boolean.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_FALSE_DESCRIPTION =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertFalse")
                     .withParameters(String.class.getName(), boolean.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_NULL =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNull")
                     .withParameters(Object.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_NULL_DESCRIPTION =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNull")
                     .withParameters(String.class.getName(), Object.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_NOT_NULL =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNotNull")
                     .withParameters(Object.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_NOT_NULL_DESCRIPTION =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNotNull")
                     .withParameters(String.class.getName(), Object.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_SAME =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertSame")
                     .withParameters(Object.class.getName(), Object.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_SAME_DESCRIPTION =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertSame")
                     .withParameters(String.class.getName(), Object.class.getName(), Object.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_NOT_SAME =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNotSame")
                     .withParameters(Object.class.getName(), Object.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_NOT_SAME_DESCRIPTION =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNotSame")
                     .withParameters(String.class.getName(), Object.class.getName(), Object.class.getName());
 
     private static final Matcher<ExpressionTree> FAIL =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("fail")
                     .withParameters();
 
     private static final Matcher<ExpressionTree> FAIL_DESCRIPTION =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("fail")
                     .withParameters(String.class.getName());
 
     private static final Matcher<ExpressionTree> ASSERT_EQUALS_FLOATING = Matchers.anyOf(
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertEquals")
                     .withParameters("double", "double", "double"),
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertEquals")
                     .withParameters("float", "float", "float"));
 
     private static final Matcher<ExpressionTree> ASSERT_EQUALS_FLOATING_DESCRIPTION = Matchers.anyOf(
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertEquals")
                     .withParameters(String.class.getName(), "double", "double", "double"),
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertEquals")
                     .withParameters(String.class.getName(), "float", "float", "float"));
 
     private static final Matcher<ExpressionTree> ASSERT_NOT_EQUALS_FLOATING = Matchers.anyOf(
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNotEquals")
                     .withParameters("double", "double", "double"),
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNotEquals")
                     .withParameters("float", "float", "float"));
 
     private static final Matcher<ExpressionTree> ASSERT_NOT_EQUALS_FLOATING_DESCRIPTION = Matchers.anyOf(
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNotEquals")
                     .withParameters(String.class.getName(), "double", "double", "double"),
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .named("assertNotEquals")
                     .withParameters(String.class.getName(), "float", "float", "float"));
 
@@ -190,12 +195,12 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
     // Order is important, more specific (e.g. floating point) checks must execute first.
     private static final Matcher<ExpressionTree> ASSERT_EQUALS_CATCHALL =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     .namedAnyOf("assertEquals", "assertArrayEquals");
 
     private static final Matcher<ExpressionTree> ASSERT_NOT_EQUALS_CATCHALL =
             MethodMatchers.staticMethod()
-                    .onClass("org.junit.Assert")
+                    .onClassAny(LEGACY_ASSERT_CLASSES)
                     // There is no Assert.assertArrayNotEquals
                     .named("assertNotEquals");
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -1,0 +1,890 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+
+@SuppressWarnings("RegexpSinglelineJava") // Testing against assertions that aren't allowed
+public class PreferAssertjTests {
+
+    @Test
+    public void fix_assertFalse() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    Assert.assertFalse(b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    assertThat(b).isFalse();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertFalseDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    Assert.assertFalse(\"desc\", b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    assertThat(b).describedAs(\"desc\").isFalse();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertTrue() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    Assert.assertTrue(b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    assertThat(b).isTrue();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertTrueDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    Assert.assertTrue(\"desc\", b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    assertThat(b).describedAs(\"desc\").isTrue();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fixAssertFalse_existingAssertThat() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertThat;",
+                        "",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    assertThat(true, org.hamcrest.CoreMatchers.equalTo(false));",
+                        "    Assert.assertFalse(b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertThat;",
+                        "",
+                        "import org.assertj.core.api.Assertions;",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    assertThat(true, org.hamcrest.CoreMatchers.equalTo(false));",
+                        "    Assertions.assertThat(b).isFalse();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNull() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNull;",
+                        "class Test {",
+                        "  void foo(String s) {",
+                        "    assertNull(s);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNull;",
+                        "class Test {",
+                        "  void foo(String s) {",
+                        "    assertThat(s).isNull();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNullDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNull;",
+                        "class Test {",
+                        "  void foo(String s) {",
+                        "    assertNull(\"desc\", s);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNull;",
+                        "class Test {",
+                        "  void foo(String s) {",
+                        "    assertThat(s).describedAs(\"desc\").isNull();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotNull() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotNull;",
+                        "class Test {",
+                        "  void foo(String s) {",
+                        "    assertNotNull(s);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNotNull;",
+                        "class Test {",
+                        "  void foo(String s) {",
+                        "    assertThat(s).isNotNull();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotNullDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotNull;",
+                        "class Test {",
+                        "  void foo(String s) {",
+                        "    assertNotNull(\"desc\", s);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNotNull;",
+                        "class Test {",
+                        "  void foo(String s) {",
+                        "    assertThat(s).describedAs(\"desc\").isNotNull();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertSame() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertSame;",
+                        "class Test {",
+                        "  void foo(String a, String b) {",
+                        "    assertSame(a, b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertSame;",
+                        "class Test {",
+                        "  void foo(String a, String b) {",
+                        "    assertThat(b).isSameAs(a);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertSameDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertSame;",
+                        "class Test {",
+                        "  void foo(String a, String b) {",
+                        "    assertSame(\"desc\", a, b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertSame;",
+                        "class Test {",
+                        "  void foo(String a, String b) {",
+                        "    assertThat(b).describedAs(\"desc\").isSameAs(a);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotSame() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertSame;",
+                        "class Test {",
+                        "  void foo(String a, String b) {",
+                        "    assertSame(a, b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertSame;",
+                        "class Test {",
+                        "  void foo(String a, String b) {",
+                        "    assertThat(b).isSameAs(a);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotSameDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotSame;",
+                        "class Test {",
+                        "  void foo(String a, String b) {",
+                        "    assertNotSame(\"desc\", a, b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNotSame;",
+                        "class Test {",
+                        "  void foo(String a, String b) {",
+                        "    assertThat(b).describedAs(\"desc\").isNotSameAs(a);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_fail() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.fail;",
+                        "class Test {",
+                        "  void foo() {",
+                        "    fail();",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.assertj.core.api.Assertions;",
+                        "class Test {",
+                        "  void foo() {",
+                        "    Assertions.fail(\"fail\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_failDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.fail;",
+                        "class Test {",
+                        "  void foo() {",
+                        "    fail(\"desc\");",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.assertj.core.api.Assertions;",
+                        "class Test {",
+                        "  void foo() {",
+                        "    Assertions.fail(\"desc\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_failDescriptionNonStaticImport() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo() {",
+                        "    Assert.fail(\"desc\");",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.fail;",
+                        "",
+                        "import org.junit.Assert;",
+                        "class Test {",
+                        "  void foo() {",
+                        "    fail(\"desc\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsFloat() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(float value) {",
+                        "    assertEquals(.1f, value, .01f);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.assertj.core.api.Assertions.within;",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(float value) {",
+                        "    assertThat(value).isCloseTo(.1f, within(.01f));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsFloatDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(float value) {",
+                        "    assertEquals(\"desc\", .1f, value, .01f);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.assertj.core.api.Assertions.within;",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(float value) {",
+                        "    assertThat(value).describedAs(\"desc\").isCloseTo(.1f, within(.01f));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsDouble() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(double value) {",
+                        "    assertEquals(.1D, value, .01D);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.assertj.core.api.Assertions.within;",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(double value) {",
+                        "    assertThat(value).isCloseTo(.1D, within(.01D));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsDoubleDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(double value) {",
+                        "    assertEquals(\"desc\", .1D, value, .01D);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.assertj.core.api.Assertions.within;",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(double value) {",
+                        "    assertThat(value).describedAs(\"desc\").isCloseTo(.1D, within(.01D));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotEqualsFloat() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(float value) {",
+                        "    assertNotEquals(.1f, value, .01f);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.assertj.core.api.Assertions.within;",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(float value) {",
+                        "    assertThat(value).isNotCloseTo(.1f, within(.01f));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotEqualsFloatDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(float value) {",
+                        "    assertNotEquals(\"desc\", .1f, value, .01f);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.assertj.core.api.Assertions.within;",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(float value) {",
+                        "    assertThat(value).describedAs(\"desc\").isNotCloseTo(.1f, within(.01f));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotEqualsDouble() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(double value) {",
+                        "    assertNotEquals(.1D, value, .01D);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.assertj.core.api.Assertions.within;",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(double value) {",
+                        "    assertThat(value).isNotCloseTo(.1D, within(.01D));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotEqualsDoubleDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(double value) {",
+                        "    assertNotEquals(\"desc\", .1D, value, .01D);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.assertj.core.api.Assertions.within;",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(double value) {",
+                        "    assertThat(value).describedAs(\"desc\").isNotCloseTo(.1D, within(.01D));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsInt() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertEquals(1, value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertThat(value).isEqualTo(1);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsString() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertEquals(\"1\", value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).isEqualTo(\"1\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsIntDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertEquals(\"desc\", 1, value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertThat(value).describedAs(\"desc\").isEqualTo(1);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsStringDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertEquals(\"desc\", \"1\", value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).describedAs(\"desc\").isEqualTo(\"1\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertArrayEqualsInt() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertArrayEquals;",
+                        "class Test {",
+                        "  void foo(int[] value) {",
+                        "    assertArrayEquals(new int[] { 1 }, value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertArrayEquals;",
+                        "class Test {",
+                        "  void foo(int[] value) {",
+                        "    assertThat(value).isEqualTo(new int[] { 1 });",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertArrayEqualsIntDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertArrayEquals;",
+                        "class Test {",
+                        "  void foo(int[] value) {",
+                        "    assertArrayEquals(\"desc\", new int[] { 1 }, value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertArrayEquals;",
+                        "class Test {",
+                        "  void foo(int[] value) {",
+                        "    assertThat(value).describedAs(\"desc\").isEqualTo(new int[] { 1 });",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fails_assertArrayEqualsDelta_double() {
+        CompilationTestHelper.newInstance(PreferAssertj.class, getClass()).addSourceLines(
+                "Test.java",
+                "import static org.junit.Assert.assertArrayEquals;",
+                "class Test {",
+                "  void f(double[] param) {",
+                "    // BUG: Diagnostic contains: Prefer AssertJ",
+                "    assertArrayEquals(param, new double[] { 1D }, .1D);",
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    @Test
+    public void fails_assertArrayEqualsDeltaDescription_double() {
+        CompilationTestHelper.newInstance(PreferAssertj.class, getClass()).addSourceLines(
+                "Test.java",
+                "import static org.junit.Assert.assertArrayEquals;",
+                "class Test {",
+                "  void f(double[] param) {",
+                "    // BUG: Diagnostic contains: Prefer AssertJ",
+                "    assertArrayEquals(\"desc\", param, new double[] { 1D }, .1D);",
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    @Test
+    public void fails_assertArrayEqualsDelta_float() {
+        CompilationTestHelper.newInstance(PreferAssertj.class, getClass()).addSourceLines(
+                "Test.java",
+                "import static org.junit.Assert.assertArrayEquals;",
+                "class Test {",
+                "  void f(float[] param) {",
+                "    // BUG: Diagnostic contains: Prefer AssertJ",
+                "    assertArrayEquals(param, new float[] { 1f }, .1f);",
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    @Test
+    public void fails_assertArrayEqualsDeltaDescription_float() {
+        CompilationTestHelper.newInstance(PreferAssertj.class, getClass()).addSourceLines(
+                "Test.java",
+                "import static org.junit.Assert.assertArrayEquals;",
+                "class Test {",
+                "  void f(float[] param) {",
+                "    // BUG: Diagnostic contains: Prefer AssertJ",
+                "    assertArrayEquals(\"desc\", param, new float[] { 1f }, .1f);",
+                "  }",
+                "}")
+                .doTest();
+    }
+
+    // assertNotEquals
+
+    @Test
+    public void fix_assertNotEqualsInt() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertNotEquals(1, value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertThat(value).isNotEqualTo(1);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotEqualsString() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertNotEquals(\"1\", value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).isNotEqualTo(\"1\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotEqualsIntDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertNotEquals(\"desc\", 1, value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertThat(value).describedAs(\"desc\").isNotEqualTo(1);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertNotEqualsStringDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertNotEquals(\"desc\", \"1\", value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.junit.Assert.assertNotEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).describedAs(\"desc\").isNotEqualTo(\"1\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    private BugCheckerRefactoringTestHelper test() {
+        return BugCheckerRefactoringTestHelper.newInstance(new PreferAssertj(), getClass());
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -345,12 +345,10 @@ public class PreferAssertjTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import static org.junit.Assert.fail;",
-                        "",
-                        "import org.assertj.core.api.Assertions;",
+                        "import static org.assertj.core.api.Assertions.fail;",
                         "class Test {",
                         "  void foo() {",
-                        "    Assertions.fail(\"fail\");",
+                        "    fail(\"fail\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -369,12 +367,10 @@ public class PreferAssertjTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import static org.junit.Assert.fail;",
-                        "",
-                        "import org.assertj.core.api.Assertions;",
+                        "import static org.assertj.core.api.Assertions.fail;",
                         "class Test {",
                         "  void foo() {",
-                        "    Assertions.fail(\"desc\");",
+                        "    fail(\"desc\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -120,6 +120,28 @@ public class PreferAssertjTests {
     }
 
     @Test
+    public void fix_assertThat_matcherAssert() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    assertThat(\"desc\", b);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "class Test {",
+                        "  void foo(boolean b) {",
+                        "    assertThat(b).describedAs(\"desc\").isTrue();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
     public void fixAssertFalse_existingAssertThat() {
         test()
                 .addInputLines(
@@ -135,14 +157,14 @@ public class PreferAssertjTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import static org.junit.Assert.assertThat;",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
                         "",
-                        "import org.assertj.core.api.Assertions;",
+                        "import org.assertj.core.api.HamcrestCondition;",
                         "import org.junit.Assert;",
                         "class Test {",
                         "  void foo(boolean b) {",
-                        "    assertThat(true, org.hamcrest.CoreMatchers.equalTo(false));",
-                        "    Assertions.assertThat(b).isFalse();",
+                        "    assertThat(true).is(new HamcrestCondition<>(org.hamcrest.CoreMatchers.equalTo(false)));",
+                        "    assertThat(b).isFalse();",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -832,8 +854,6 @@ public class PreferAssertjTests {
                 .doTest();
     }
 
-    // assertNotEquals
-
     @Test
     public void fix_assertNotEqualsInt() {
         test()
@@ -921,6 +941,110 @@ public class PreferAssertjTests {
                         "class Test {",
                         "  void foo(String value) {",
                         "    assertThat(value).describedAs(\"desc\").isNotEqualTo(\"1\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThatInt() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertThat;",
+                        "import static org.hamcrest.Matchers.is;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertThat(value, is(1));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.is;",
+                        "",
+                        "import org.assertj.core.api.HamcrestCondition;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertThat(value).is(new HamcrestCondition<>(is(1)));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThatIntDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.junit.Assert.assertThat;",
+                        "import static org.hamcrest.Matchers.is;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertThat(\"desc\", value, is(1));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.is;",
+                        "",
+                        "import org.assertj.core.api.HamcrestCondition;",
+                        "class Test {",
+                        "  void foo(int value) {",
+                        "    assertThat(value).describedAs(\"desc\").is(new HamcrestCondition<>(is(1)));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_matcherAssertThatString() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.is;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value, is(\"str\"));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.is;",
+                        "",
+                        "import org.assertj.core.api.HamcrestCondition;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).is(new HamcrestCondition<>(is(\"str\")));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_matcherAssertThatStringDescription() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.is;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(\"desc\", value, is(\"str\"));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.is;",
+                        "",
+                        "import org.assertj.core.api.HamcrestCondition;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).describedAs(\"desc\").is(new HamcrestCondition<>(is(\"str\")));",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -639,6 +639,52 @@ public class PreferAssertjTests {
     }
 
     @Test
+    public void fix_assertEqualsString_testcase() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static junit.framework.TestCase.assertEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertEquals(\"1\", value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static junit.framework.TestCase.assertEquals;",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).isEqualTo(\"1\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertEqualsString_frameworkAssert() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static junit.framework.Assert.assertEquals;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertEquals(\"1\", value);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static junit.framework.Assert.assertEquals;",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).isEqualTo(\"1\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
     public void fix_assertEqualsIntDescription() {
         test()
                 .addInputLines(

--- a/changelog/@unreleased/pr-841.v2.yml
+++ b/changelog/@unreleased/pr-841.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ErrorProne PreferAssertj migration to AssertJ from org.junit.Assert
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/841

--- a/changelog/@unreleased/pr-841.v2.yml
+++ b/changelog/@unreleased/pr-841.v2.yml
@@ -1,5 +1,9 @@
 type: improvement
 improvement:
-  description: ErrorProne PreferAssertj migration to AssertJ from org.junit.Assert
+  description: Added a new ErrorProne check `PreferAssertj` to assist migration to AssertJ from
+    legacy test frameworks. It may be necessary to add a dependency on `org.assertj:assertj-core`
+    in modules which do not already depend on AssertJ. If there's a technical reason that AssertJ
+    cannot be used, `PreferAssertj` may be explicitly disabled to prevent future upgrades from
+    attempting to re-run the migration.
   links:
   - https://github.com/palantir/gradle-baseline/pull/841

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -26,6 +26,7 @@ public class BaselineErrorProneExtension {
             // Baseline checks
             "LambdaMethodReference",
             "OptionalOrElseMethodInvocation",
+            "PreferAssertj",
             "PreferBuiltInConcurrentKeySet",
             "PreferCollectionTransform",
             "PreferListsPartition",


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
ErrorProne PreferAssertj migration to AssertJ from org.junit.Assert
==COMMIT_MSG==

## Possible downsides?
There are a few cases this doesn't cover, `Assert.assertThat(T, Matcher<T>)` being the most common. I did not enable this check by default because it doesn't add a dependency on assertj, and I want to avoid blocking baseline upgrades in modules which don't already depend on assertj.
This might be a candidate for a separate library or module since it's mostly a one-time migration, however it's also helpful if we can fail when folks attempt to use `org.junit.Assert` methods again.