### PR TITLE
PreferAssertj provides better hamcrest replacements

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -513,10 +513,15 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
                         .named("notNullValue")
                         .withParameters("java.lang.Class"));
 
-        private static final Matcher<ExpressionTree> HAS_ITEM = MethodMatchers.staticMethod()
-                .onClassAny(MATCHERS)
-                .namedAnyOf("hasItem", "hasItemInArray")
-                .withParameters(Object.class.getName());
+        private static final Matcher<ExpressionTree> CONTAINS = Matchers.anyOf(
+                MethodMatchers.staticMethod()
+                        .onClassAny(MATCHERS)
+                        .namedAnyOf("hasItem", "hasItemInArray")
+                        .withParameters(Object.class.getName()),
+                MethodMatchers.staticMethod()
+                        .onClassAny(MATCHERS)
+                        .named("containsString")
+                        .withParameters(String.class.getName()));
 
         // Note: cannot match array/vararg arguments
         private static final Matcher<ExpressionTree> HAS_ITEMS = MethodMatchers.staticMethod()
@@ -542,6 +547,16 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
                 .onClassAny(MATCHERS)
                 .namedAnyOf("sameInstance", "theInstance")
                 .withParameters(Object.class.getName());
+
+        private static final Matcher<ExpressionTree> STARTS_WITH = MethodMatchers.staticMethod()
+                .onClassAny(MATCHERS)
+                .namedAnyOf("startsWith")
+                .withParameters(String.class.getName());
+
+        private static final Matcher<ExpressionTree> ENDS_WITH = MethodMatchers.staticMethod()
+                .onClassAny(MATCHERS)
+                .namedAnyOf("endsWith")
+                .withParameters(String.class.getName());
 
         private final boolean negated;
 
@@ -574,7 +589,7 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
             if (NOT_NULL.matches(node, state)) {
                 return Optional.of(negated ? ".isNull()" : ".isNotNull()");
             }
-            if (HAS_ITEM.matches(node, state)) {
+            if (CONTAINS.matches(node, state)) {
                 return Optional.of((negated ? ".doesNotContain(" : ".contains(") + argSource(node, state, 0) + ')');
             }
             if (IS_EMPTY.matches(node, state)) {
@@ -582,6 +597,12 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
             }
             if (SAME_INSTANCE.matches(node, state)) {
                 return Optional.of((negated ? ".isNotSameAs(" : ".isSameAs(") + argSource(node, state, 0) + ')');
+            }
+            if (STARTS_WITH.matches(node, state)) {
+                return Optional.of((negated ? ".doesNotStartWith(" : ".startsWith(") + argSource(node, state, 0) + ')');
+            }
+            if (ENDS_WITH.matches(node, state)) {
+                return Optional.of((negated ? ".doesNotEndWith(" : ".endsWith(") + argSource(node, state, 0) + ')');
             }
             if (HAS_SIZE.matches(node, state)) {
                 if (negated) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -289,40 +289,48 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         if (ASSERT_EQUALS_FLOATING.matches(tree, state)) {
             return withAssertThat(tree, state, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + (isConstantZero(tree.getArguments().get(2))
-                                    ? ").isEqualTo(" + argSource(tree, state, 0) + ')'
-                                    : (").isCloseTo(" + argSource(tree, state, 0)
-                            + ", within(" + argSource(tree, state, 2) + "))"))));
+                    .replace(tree, String.format("%s(%s)%s",
+                            assertThat,
+                            argSource(tree, state, 1),
+                            isConstantZero(tree.getArguments().get(2))
+                                    ? String.format(".isEqualTo(%s)", argSource(tree, state, 0))
+                                    : String.format(".isCloseTo(%s, within(%s))",
+                                    argSource(tree, state, 0), argSource(tree, state, 2)))));
         }
         if (ASSERT_EQUALS_FLOATING_DESCRIPTION.matches(tree, state)) {
             return withAssertThat(tree, state, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, assertThat + "(" + argSource(tree, state, 2)
-                            + ").describedAs(" + argSource(tree, state, 0)
-                            + (isConstantZero(tree.getArguments().get(3))
-                            ? ").isEqualTo(" + argSource(tree, state, 1) + ')'
-                            : (").isCloseTo(" + argSource(tree, state, 1)
-                            + ", within(" + argSource(tree, state, 3) + "))"))));
+                    .replace(tree, String.format("%s(%s).describedAs(%s)%s",
+                            assertThat,
+                            argSource(tree, state, 2),
+                            argSource(tree, state, 0),
+                            isConstantZero(tree.getArguments().get(3))
+                                    ? String.format(".isEqualTo(%s)", argSource(tree, state, 1))
+                                    : String.format(".isCloseTo(%s, within(%s))",
+                                    argSource(tree, state, 1), argSource(tree, state, 3)))));
         }
         if (ASSERT_NOT_EQUALS_FLOATING.matches(tree, state)) {
             return withAssertThat(tree, state, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + (isConstantZero(tree.getArguments().get(2))
-                            ? ").isNotEqualTo(" + argSource(tree, state, 0) + ')'
-                            : ").isNotCloseTo(" + argSource(tree, state, 0)
-                            + ", within(" + argSource(tree, state, 2) + "))")));
+                    .replace(tree, String.format("%s(%s)%s",
+                            assertThat,
+                            argSource(tree, state, 1),
+                            isConstantZero(tree.getArguments().get(2))
+                                    ? String.format(".isNotEqualTo(%s)", argSource(tree, state, 0))
+                                    : String.format(".isNotCloseTo(%s, within(%s))",
+                                    argSource(tree, state, 0), argSource(tree, state, 2)))));
         }
         if (ASSERT_NOT_EQUALS_FLOATING_DESCRIPTION.matches(tree, state)) {
             return withAssertThat(tree, state, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, assertThat + "(" + argSource(tree, state, 2)
-                            + ").describedAs(" + argSource(tree, state, 0)
-                            + (isConstantZero(tree.getArguments().get(3))
-                            ? ").isNotEqualTo(" + argSource(tree, state, 1) + ')'
-                            : ").isNotCloseTo(" + argSource(tree, state, 1)
-                            + ", within(" + argSource(tree, state, 3) + "))")));
+                    .replace(tree, String.format("%s(%s).describedAs(%s)%s",
+                            assertThat,
+                            argSource(tree, state, 2),
+                            argSource(tree, state, 0),
+                            isConstantZero(tree.getArguments().get(3))
+                                    ? String.format(".isNotEqualTo(%s)", argSource(tree, state, 1))
+                                    : String.format(".isNotCloseTo(%s, within(%s))",
+                                    argSource(tree, state, 1), argSource(tree, state, 3)))));
         }
         if (ASSERT_THAT.matches(tree, state)) {
             Optional<String> replacement = tree.getArguments().get(1)

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -289,28 +289,40 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         if (ASSERT_EQUALS_FLOATING.matches(tree, state)) {
             return withAssertThat(tree, state, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, assertThat + "(" + argSource(tree, state, 1) + ").isCloseTo("
-                            + argSource(tree, state, 0) + ", within(" + argSource(tree, state, 2) + "))"));
+                    .replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                            + (isConstantZero(tree.getArguments().get(2))
+                                    ? ").isEqualTo(" + argSource(tree, state, 0) + ')'
+                                    : (").isCloseTo(" + argSource(tree, state, 0)
+                            + ", within(" + argSource(tree, state, 2) + "))"))));
         }
         if (ASSERT_EQUALS_FLOATING_DESCRIPTION.matches(tree, state)) {
             return withAssertThat(tree, state, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
                     .replace(tree, assertThat + "(" + argSource(tree, state, 2)
-                            + ").describedAs(" + argSource(tree, state, 0) + ").isCloseTo("
-                            + argSource(tree, state, 1) + ", within(" + argSource(tree, state, 3) + "))"));
+                            + ").describedAs(" + argSource(tree, state, 0)
+                            + (isConstantZero(tree.getArguments().get(3))
+                            ? ").isEqualTo(" + argSource(tree, state, 1) + ')'
+                            : (").isCloseTo(" + argSource(tree, state, 1)
+                            + ", within(" + argSource(tree, state, 3) + "))"))));
         }
         if (ASSERT_NOT_EQUALS_FLOATING.matches(tree, state)) {
             return withAssertThat(tree, state, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, assertThat + "(" + argSource(tree, state, 1) + ").isNotCloseTo("
-                            + argSource(tree, state, 0) + ", within(" + argSource(tree, state, 2) + "))"));
+                    .replace(tree, assertThat + "(" + argSource(tree, state, 1)
+                            + (isConstantZero(tree.getArguments().get(2))
+                            ? ").isNotEqualTo(" + argSource(tree, state, 0) + ')'
+                            : ").isNotCloseTo(" + argSource(tree, state, 0)
+                            + ", within(" + argSource(tree, state, 2) + "))")));
         }
         if (ASSERT_NOT_EQUALS_FLOATING_DESCRIPTION.matches(tree, state)) {
             return withAssertThat(tree, state, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
                     .replace(tree, assertThat + "(" + argSource(tree, state, 2)
-                            + ").describedAs(" + argSource(tree, state, 0) + ").isNotCloseTo("
-                            + argSource(tree, state, 1) + ", within(" + argSource(tree, state, 3) + "))"));
+                            + ").describedAs(" + argSource(tree, state, 0)
+                            + (isConstantZero(tree.getArguments().get(3))
+                            ? ").isNotEqualTo(" + argSource(tree, state, 1) + ')'
+                            : ").isNotCloseTo(" + argSource(tree, state, 1)
+                            + ", within(" + argSource(tree, state, 3) + "))")));
         }
         if (ASSERT_THAT.matches(tree, state)) {
             Optional<String> replacement = tree.getArguments().get(1)
@@ -422,6 +434,11 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         }
         // If we did not encounter an assertThat static import, we can import and use it.
         return true;
+    }
+
+    private static boolean isConstantZero(Tree tree) {
+        Object constantValue = ASTHelpers.constValue(tree);
+        return constantValue instanceof Number && ((Number) constantValue).doubleValue() == 0D;
     }
 
     private static boolean isExpressionSameType(VisitorState state, MemberSelectTree memberSelectTree, String type) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -1211,6 +1211,40 @@ public class PreferAssertjTests {
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
+    @Test
+    public void fix_assertThat_wrongImport() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.core.Is.is;",
+                        "import static org.hamcrest.core.IsEqual.equalTo;",
+                        "import static org.hamcrest.core.IsNot.not;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value, is(\"str\"));",
+                        "    assertThat(value, equalTo(\"str\"));",
+                        "    assertThat(value, not(is(\"str\")));",
+                        "    assertThat(value, not(equalTo(\"str\")));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.core.Is.is;",
+                        "import static org.hamcrest.core.IsEqual.equalTo;",
+                        "import static org.hamcrest.core.IsNot.not;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).isEqualTo(\"str\");",
+                        "    assertThat(value).isEqualTo(\"str\");",
+                        "    assertThat(value).isNotEqualTo(\"str\");",
+                        "    assertThat(value).isNotEqualTo(\"str\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
     private BugCheckerRefactoringTestHelper test() {
         return BugCheckerRefactoringTestHelper.newInstance(new PreferAssertj(), getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -855,21 +855,21 @@ public class PreferAssertjTests {
                 .addInputLines(
                         "Test.java",
                         "import static org.hamcrest.MatcherAssert.assertThat;",
-                        "import static org.hamcrest.Matchers.startsWith;",
+                        "import static org.hamcrest.Matchers.hasToString;",
                         "class Test {",
                         "  void foo(String value) {",
-                        "    assertThat(value, startsWith(\"str\"));",
+                        "    assertThat(value, hasToString(\"str\"));",
                         "  }",
                         "}")
                 .addOutputLines(
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.hamcrest.Matchers.startsWith;",
+                        "import static org.hamcrest.Matchers.hasToString;",
                         "",
                         "import org.assertj.core.api.HamcrestCondition;",
                         "class Test {",
                         "  void foo(String value) {",
-                        "    assertThat(value).is(new HamcrestCondition<>(startsWith(\"str\")));",
+                        "    assertThat(value).is(new HamcrestCondition<>(hasToString(\"str\")));",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -1042,6 +1042,7 @@ public class PreferAssertjTests {
                         "    assertThat(arrayValue, arrayContainingInAnyOrder(\"one\", \"two\"));",
                         "    assertThat(value, not(hasItem(\"str\")));",
                         "    assertThat(arrayValue, not(hasItemInArray(\"str\")));",
+                        "    assertThat(arrayValue[0], containsString(\"str\"));",
                         "  }",
                         "}")
                 .addOutputLines(
@@ -1056,6 +1057,7 @@ public class PreferAssertjTests {
                         "    assertThat(arrayValue).contains(\"one\", \"two\");",
                         "    assertThat(value).doesNotContain(\"str\");",
                         "    assertThat(arrayValue).doesNotContain(\"str\");",
+                        "    assertThat(arrayValue[0]).contains(\"str\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -1170,6 +1172,40 @@ public class PreferAssertjTests {
                         "    assertThat(a).isSameAs(b);",
                         "    assertThat(a).isNotSameAs(b);",
                         "    assertThat(a).isNotSameAs(b);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThat_strings() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value, containsString(\"str\"));",
+                        "    assertThat(value, not(containsString(\"str\")));",
+                        "    assertThat(value, startsWith(\"str\"));",
+                        "    assertThat(value, not(startsWith(\"str\")));",
+                        "    assertThat(value, endsWith(\"str\"));",
+                        "    assertThat(value, not(endsWith(\"str\")));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).contains(\"str\");",
+                        "    assertThat(value).doesNotContain(\"str\");",
+                        "    assertThat(value).startsWith(\"str\");",
+                        "    assertThat(value).doesNotStartWith(\"str\");",
+                        "    assertThat(value).endsWith(\"str\");",
+                        "    assertThat(value).doesNotEndWith(\"str\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -422,14 +422,26 @@ public class PreferAssertjTests {
     }
 
     @Test
-    public void fix_assertEqualsFloat() {
+    public void fix_assertEqualsFloating() {
         test()
                 .addInputLines(
                         "Test.java",
                         "import static org.junit.Assert.assertEquals;",
+                        "import static org.junit.Assert.assertNotEquals;",
                         "class Test {",
-                        "  void foo(float value) {",
-                        "    assertEquals(.1f, value, .01f);",
+                        "  void foo(float fl, double db) {",
+                        "    assertEquals(.1f, fl, .01f);",
+                        "    assertEquals(\"desc\", .1f, fl, .01f);",
+                        "    assertEquals(.1D, db, .01D);",
+                        "    assertEquals(\"desc\", .1D, db, .01D);",
+                        "    assertEquals(\"desc\", .1D, db, 0);",
+                        "    assertEquals(.1D, db, 0D);",
+                        "    assertNotEquals(.1f, fl, .01f);",
+                        "    assertNotEquals(\"desc\", .1f, fl, .01f);",
+                        "    assertNotEquals(.1D, db, .01D);",
+                        "    assertNotEquals(\"desc\", .1D, db, .01D);",
+                        "    assertNotEquals(\"desc\", .1D, db, 0.0);",
+                        "    assertNotEquals(.1D, db, 0D);",
                         "  }",
                         "}")
                 .addOutputLines(
@@ -437,177 +449,21 @@ public class PreferAssertjTests {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import static org.assertj.core.api.Assertions.within;",
                         "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(float value) {",
-                        "    assertThat(value).isCloseTo(.1f, within(.01f));",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertEqualsFloatDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(float value) {",
-                        "    assertEquals(\"desc\", .1f, value, .01f);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.assertj.core.api.Assertions.within;",
-                        "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(float value) {",
-                        "    assertThat(value).describedAs(\"desc\").isCloseTo(.1f, within(.01f));",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertEqualsDouble() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(double value) {",
-                        "    assertEquals(.1D, value, .01D);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.assertj.core.api.Assertions.within;",
-                        "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(double value) {",
-                        "    assertThat(value).isCloseTo(.1D, within(.01D));",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertEqualsDoubleDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(double value) {",
-                        "    assertEquals(\"desc\", .1D, value, .01D);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.assertj.core.api.Assertions.within;",
-                        "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(double value) {",
-                        "    assertThat(value).describedAs(\"desc\").isCloseTo(.1D, within(.01D));",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotEqualsFloat() {
-        test()
-                .addInputLines(
-                        "Test.java",
                         "import static org.junit.Assert.assertNotEquals;",
                         "class Test {",
-                        "  void foo(float value) {",
-                        "    assertNotEquals(.1f, value, .01f);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.assertj.core.api.Assertions.within;",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(float value) {",
-                        "    assertThat(value).isNotCloseTo(.1f, within(.01f));",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotEqualsFloatDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(float value) {",
-                        "    assertNotEquals(\"desc\", .1f, value, .01f);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.assertj.core.api.Assertions.within;",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(float value) {",
-                        "    assertThat(value).describedAs(\"desc\").isNotCloseTo(.1f, within(.01f));",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotEqualsDouble() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(double value) {",
-                        "    assertNotEquals(.1D, value, .01D);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.assertj.core.api.Assertions.within;",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(double value) {",
-                        "    assertThat(value).isNotCloseTo(.1D, within(.01D));",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotEqualsDoubleDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(double value) {",
-                        "    assertNotEquals(\"desc\", .1D, value, .01D);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.assertj.core.api.Assertions.within;",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(double value) {",
-                        "    assertThat(value).describedAs(\"desc\").isNotCloseTo(.1D, within(.01D));",
+                        "  void foo(float fl, double db) {",
+                        "    assertThat(fl).isCloseTo(.1f, within(.01f));",
+                        "    assertThat(fl).describedAs(\"desc\").isCloseTo(.1f, within(.01f));",
+                        "    assertThat(db).isCloseTo(.1D, within(.01D));",
+                        "    assertThat(db).describedAs(\"desc\").isCloseTo(.1D, within(.01D));",
+                        "    assertThat(db).describedAs(\"desc\").isEqualTo(.1D);",
+                        "    assertThat(db).isEqualTo(.1D);",
+                        "    assertThat(fl).isNotCloseTo(.1f, within(.01f));",
+                        "    assertThat(fl).describedAs(\"desc\").isNotCloseTo(.1f, within(.01f));",
+                        "    assertThat(db).isNotCloseTo(.1D, within(.01D));",
+                        "    assertThat(db).describedAs(\"desc\").isNotCloseTo(.1D, within(.01D));",
+                        "    assertThat(db).describedAs(\"desc\").isNotEqualTo(.1D);",
+                        "    assertThat(db).isNotEqualTo(.1D);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -159,11 +159,10 @@ public class PreferAssertjTests {
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "",
-                        "import org.assertj.core.api.HamcrestCondition;",
                         "import org.junit.Assert;",
                         "class Test {",
                         "  void foo(boolean b) {",
-                        "    assertThat(true).is(new HamcrestCondition<>(org.hamcrest.CoreMatchers.equalTo(false)));",
+                        "    assertThat(true).isEqualTo(false);",
                         "    assertThat(b).isFalse();",
                         "  }",
                         "}")
@@ -962,11 +961,9 @@ public class PreferAssertjTests {
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import static org.hamcrest.Matchers.is;",
-                        "",
-                        "import org.assertj.core.api.HamcrestCondition;",
                         "class Test {",
                         "  void foo(int value) {",
-                        "    assertThat(value).is(new HamcrestCondition<>(is(1)));",
+                        "    assertThat(value).isEqualTo(1);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -988,63 +985,335 @@ public class PreferAssertjTests {
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import static org.hamcrest.Matchers.is;",
-                        "",
-                        "import org.assertj.core.api.HamcrestCondition;",
                         "class Test {",
                         "  void foo(int value) {",
-                        "    assertThat(value).describedAs(\"desc\").is(new HamcrestCondition<>(is(1)));",
+                        "    assertThat(value).describedAs(\"desc\").isEqualTo(1);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
     @Test
-    public void fix_matcherAssertThatString() {
+    public void fix_matcherAssertThatString_startsWith() {
         test()
                 .addInputLines(
                         "Test.java",
                         "import static org.hamcrest.MatcherAssert.assertThat;",
-                        "import static org.hamcrest.Matchers.is;",
+                        "import static org.hamcrest.Matchers.startsWith;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value, startsWith(\"str\"));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.startsWith;",
+                        "",
+                        "import org.assertj.core.api.HamcrestCondition;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).is(new HamcrestCondition<>(startsWith(\"str\")));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThat_instanceOf() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value, instanceOf(String.class));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).isInstanceOf(String.class);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThat_is_instanceOf() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value, is(instanceOf(String.class)));",
+                        "    assertThat(value, instanceOf(String.class));",
+                        "    assertThat(value, is(not(instanceOf(String.class))));",
+                        "    assertThat(value, not(instanceOf(String.class)));",
+                        "    assertThat(\"desc\", value, is(instanceOf(String.class)));",
+                        "    assertThat(\"desc\", value, instanceOf(String.class));",
+                        "    assertThat(\"desc\", value, is(not(instanceOf(String.class))));",
+                        "    assertThat(\"desc\", value, not(instanceOf(String.class)));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(String value) {",
+                        "    assertThat(value).isInstanceOf(String.class);",
+                        "    assertThat(value).isInstanceOf(String.class);",
+                        "    assertThat(value).isNotInstanceOf(String.class);",
+                        "    assertThat(value).isNotInstanceOf(String.class);",
+                        "    assertThat(value).describedAs(\"desc\").isInstanceOf(String.class);",
+                        "    assertThat(value).describedAs(\"desc\").isInstanceOf(String.class);",
+                        "    assertThat(value).describedAs(\"desc\").isNotInstanceOf(String.class);",
+                        "    assertThat(value).describedAs(\"desc\").isNotInstanceOf(String.class);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThat_equality() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
                         "class Test {",
                         "  void foo(String value) {",
                         "    assertThat(value, is(\"str\"));",
+                        "    assertThat(value, equalTo(\"str\"));",
+                        "    assertThat(value, is(equalTo(\"str\")));",
+                        "    assertThat(value, org.hamcrest.CoreMatchers.equalToObject(\"str\"));",
+                        "    assertThat(value, not(not(equalTo(\"str\"))));",
+                        "    assertThat(value, not(is(\"str\")));",
+                        "    assertThat(value, not(equalTo(\"str\")));",
+                        "    assertThat(value, is(not(equalTo(\"str\"))));",
+                        "    assertThat(value, not(org.hamcrest.CoreMatchers.equalToObject(\"str\")));",
+                        "    assertThat(value, not(not(not(equalTo(\"str\")))));",
+                        "    assertThat(\"desc\", value, not(not(not(equalTo(\"str\")))));",
                         "  }",
                         "}")
                 .addOutputLines(
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.hamcrest.Matchers.is;",
-                        "",
-                        "import org.assertj.core.api.HamcrestCondition;",
+                        "import static org.hamcrest.Matchers.*;",
                         "class Test {",
                         "  void foo(String value) {",
-                        "    assertThat(value).is(new HamcrestCondition<>(is(\"str\")));",
+                        "    assertThat(value).isEqualTo(\"str\");",
+                        "    assertThat(value).isEqualTo(\"str\");",
+                        "    assertThat(value).isEqualTo(\"str\");",
+                        "    assertThat(value).isEqualTo(\"str\");",
+                        "    assertThat(value).isEqualTo(\"str\");",
+                        "    assertThat(value).isNotEqualTo(\"str\");",
+                        "    assertThat(value).isNotEqualTo(\"str\");",
+                        "    assertThat(value).isNotEqualTo(\"str\");",
+                        "    assertThat(value).isNotEqualTo(\"str\");",
+                        "    assertThat(value).isNotEqualTo(\"str\");",
+                        "    assertThat(value).describedAs(\"desc\").isNotEqualTo(\"str\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
     @Test
-    public void fix_matcherAssertThatStringDescription() {
+    public void fix_assertThat_nullness() {
         test()
                 .addInputLines(
                         "Test.java",
                         "import static org.hamcrest.MatcherAssert.assertThat;",
-                        "import static org.hamcrest.Matchers.is;",
+                        "import static org.hamcrest.Matchers.*;",
                         "class Test {",
                         "  void foo(String value) {",
-                        "    assertThat(\"desc\", value, is(\"str\"));",
+                        "    assertThat(value, is(not(is(notNullValue(String.class)))));",
+                        "    assertThat(value, is(not(is(nullValue(String.class)))));",
+                        "    assertThat(value, is(nullValue(String.class)));",
+                        "    assertThat(value, nullValue());",
+                        "    assertThat(value, is(notNullValue(String.class)));",
+                        "    assertThat(value, notNullValue());",
+                        "    assertThat(\"desc\", value, is(not(is(notNullValue(String.class)))));",
+                        "    assertThat(\"desc\", value, is(not(is(nullValue(String.class)))));",
+                        "    assertThat(\"desc\", value, is(nullValue(String.class)));",
+                        "    assertThat(\"desc\", value, nullValue());",
+                        "    assertThat(\"desc\", value, is(notNullValue(String.class)));",
+                        "    assertThat(\"desc\", value, notNullValue());",
                         "  }",
                         "}")
                 .addOutputLines(
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.hamcrest.Matchers.is;",
-                        "",
-                        "import org.assertj.core.api.HamcrestCondition;",
+                        "import static org.hamcrest.Matchers.*;",
                         "class Test {",
                         "  void foo(String value) {",
-                        "    assertThat(value).describedAs(\"desc\").is(new HamcrestCondition<>(is(\"str\")));",
+                        "    assertThat(value).isNull();",
+                        "    assertThat(value).isNotNull();",
+                        "    assertThat(value).isNull();",
+                        "    assertThat(value).isNull();",
+                        "    assertThat(value).isNotNull();",
+                        "    assertThat(value).isNotNull();",
+                        "    assertThat(value).describedAs(\"desc\").isNull();",
+                        "    assertThat(value).describedAs(\"desc\").isNotNull();",
+                        "    assertThat(value).describedAs(\"desc\").isNull();",
+                        "    assertThat(value).describedAs(\"desc\").isNull();",
+                        "    assertThat(value).describedAs(\"desc\").isNotNull();",
+                        "    assertThat(value).describedAs(\"desc\").isNotNull();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThat_contains() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(Iterable<String> value, String[] arrayValue) {",
+                        "    assertThat(value, hasItem(\"str\"));",
+                        "    assertThat(arrayValue, hasItemInArray(\"str\"));",
+                        "    assertThat(value, hasItems(\"one\", \"two\"));",
+                        "    assertThat(arrayValue, arrayContainingInAnyOrder(\"one\", \"two\"));",
+                        "    assertThat(value, not(hasItem(\"str\")));",
+                        "    assertThat(arrayValue, not(hasItemInArray(\"str\")));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(Iterable<String> value, String[] arrayValue) {",
+                        "    assertThat(value).contains(\"str\");",
+                        "    assertThat(arrayValue).contains(\"str\");",
+                        "    assertThat(value).contains(\"one\", \"two\");",
+                        "    assertThat(arrayValue).contains(\"one\", \"two\");",
+                        "    assertThat(value).doesNotContain(\"str\");",
+                        "    assertThat(arrayValue).doesNotContain(\"str\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThat_empty() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  void foo(Iterable<String> it, String[] ar, List<String> li) {",
+                        "    assertThat(li, empty());",
+                        "    assertThat(li, emptyIterable());",
+                        "    assertThat(li, emptyCollectionOf(String.class));",
+                        "    assertThat(it, emptyIterable());",
+                        "    assertThat(it, emptyIterableOf(String.class));",
+                        "    assertThat(ar, emptyArray());",
+                        "    assertThat(li, is(not(empty())));",
+                        "    assertThat(li, not(emptyIterable()));",
+                        "    assertThat(li, not(emptyCollectionOf(String.class)));",
+                        "    assertThat(it, not(emptyIterable()));",
+                        "    assertThat(it, not(emptyIterableOf(String.class)));",
+                        "    assertThat(ar, not(emptyArray()));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  void foo(Iterable<String> it, String[] ar, List<String> li) {",
+                        "    assertThat(li).isEmpty();",
+                        "    assertThat(li).isEmpty();",
+                        "    assertThat(li).isEmpty();",
+                        "    assertThat(it).isEmpty();",
+                        "    assertThat(it).isEmpty();",
+                        "    assertThat(ar).isEmpty();",
+                        "    assertThat(li).isNotEmpty();",
+                        "    assertThat(li).isNotEmpty();",
+                        "    assertThat(li).isNotEmpty();",
+                        "    assertThat(it).isNotEmpty();",
+                        "    assertThat(it).isNotEmpty();",
+                        "    assertThat(ar).isNotEmpty();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThat_size() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  void foo(Iterable<String> it, String[] ar, List<String> li) {",
+                        "    assertThat(li, hasSize(3));",
+                        "    assertThat(li, iterableWithSize(3));",
+                        "    assertThat(it, iterableWithSize(3));",
+                        "    assertThat(ar, arrayWithSize(3));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  void foo(Iterable<String> it, String[] ar, List<String> li) {",
+                        "    assertThat(li).hasSize(3);",
+                        "    assertThat(li).hasSize(3);",
+                        "    assertThat(it).hasSize(3);",
+                        "    assertThat(ar).hasSize(3);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_assertThat_same() {
+        test()
+                .addInputLines(
+                        "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(Object a, Object b) {",
+                        "    assertThat(a, theInstance(b));",
+                        "    assertThat(a, sameInstance(b));",
+                        "    assertThat(a, is(not(theInstance(b))));",
+                        "    assertThat(a, not(sameInstance(b)));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import static org.hamcrest.Matchers.*;",
+                        "class Test {",
+                        "  void foo(Object a, Object b) {",
+                        "    assertThat(a).isSameAs(b);",
+                        "    assertThat(a).isSameAs(b);",
+                        "    assertThat(a).isNotSameAs(b);",
+                        "    assertThat(a).isNotSameAs(b);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/changelog/@unreleased/pr-850.v2.yml
+++ b/changelog/@unreleased/pr-850.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: PreferAssertj provides better replacements fixes
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/850

--- a/changelog/@unreleased/pr-850.v2.yml
+++ b/changelog/@unreleased/pr-850.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: PreferAssertj provides better replacements fixes
   links:
   - https://github.com/palantir/gradle-baseline/pull/850


### PR DESCRIPTION
Avoids using the less ergonomic HamcrestCondition in common
cases.

## Before this PR
```java
assertThat(value).describedAs("desc").is(new HamcrestCondition<>(is("str")));
```

## After this PR
```java
assertThat(value).isEqualTo("str");
```
==COMMIT_MSG==
PreferAssertj provides better replacements fixes
==COMMIT_MSG==

