### PR TITLE
Some low-effort AssertJ refasters

### DIFF
--- a/.baseline/checkstyle/custom-suppressions.xml
+++ b/.baseline/checkstyle/custom-suppressions.xml
@@ -8,4 +8,7 @@
 <suppressions>
     <!-- Do not lint class which is mostly copied -->
     <suppress files=".*StrictUnusedVariable.java" checks="." />
+
+    <!-- We have a special whitelist for AssertJ's assertThat method in test code, but we need it in prod code -->
+    <suppress files="src/main/java/com/palantir/baseline/refaster" checks="AvoidStaticImport" />
 </suppressions>

--- a/baseline-refaster-rules/build.gradle
+++ b/baseline-refaster-rules/build.gradle
@@ -5,6 +5,7 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
     compile 'com.google.errorprone:error_prone_refaster'
+    compileOnly 'org.assertj:assertj-core'
 
     testCompile 'junit:junit'
     testCompile project(':baseline-refaster-testing')

--- a/baseline-refaster-rules/build.gradle
+++ b/baseline-refaster-rules/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'java-library'
 apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
-    compile 'com.google.errorprone:error_prone_refaster'
-    compileOnly 'org.assertj:assertj-core'
+    implementation 'com.google.errorprone:error_prone_refaster'
+    implementation 'org.assertj:assertj-core'
 
     testCompile 'junit:junit'
     testCompile project(':baseline-refaster-testing')

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSize.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSize.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Collection;
+import java.util.Optional;
+
+public final class AssertjCollectionHasSize<T> {
+
+    @BeforeTemplate
+    void bad1(Collection<T> things, int size) {
+        assertThat(things.size() == size).isTrue();
+    }
+
+    @BeforeTemplate
+    void bad2(Collection<T> things, int size) {
+        assertThat(things.size()).isEqualTo(size);
+    }
+
+    @AfterTemplate
+    void after(Collection<T> things, int size) {
+        assertThat(things).hasSize(size);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSizeExactly.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSizeExactly.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.Collection;
-import java.util.Optional;
 
 public final class AssertjCollectionHasSizeExactly<T> {
 

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSizeExactly.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSizeExactly.java
@@ -23,7 +23,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.Collection;
 import java.util.Optional;
 
-public final class AssertjCollectionHasSize<T> {
+public final class AssertjCollectionHasSizeExactly<T> {
 
     @BeforeTemplate
     void bad1(Collection<T> things, int size) {

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSizeGreaterThan.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSizeGreaterThan.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Collection;
+
+public final class AssertjCollectionHasSizeGreaterThan<T> {
+
+    @BeforeTemplate
+    void before(Collection<T> things, int size) {
+        assertThat(things.size() > size).isTrue();
+    }
+
+    @AfterTemplate
+    void after(Collection<T> things, int size) {
+        assertThat(things).hasSizeGreaterThan(size);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
@@ -34,26 +34,31 @@ public final class AssertjCollectionIsEmpty<T> {
 
     @BeforeTemplate
     void bad2(Collection<T> things) {
-        assertThat(things.size()).isEqualTo(0);
+        assertThat(things.isEmpty()).isTrue();
     }
 
     @BeforeTemplate
     void bad3(Collection<T> things) {
-        assertThat(things).isEqualTo(Collections.emptyList());
+        assertThat(things.size() == 0).isTrue();
     }
 
     @BeforeTemplate
     void bad4(Collection<T> things) {
-        assertThat(things).isEqualTo(Collections.emptySet());
+        assertThat(things).isEqualTo(Collections.emptyList());
     }
 
     @BeforeTemplate
     void bad5(Collection<T> things) {
-        assertThat(things).isEqualTo(ImmutableList.of());
+        assertThat(things).isEqualTo(Collections.emptySet());
     }
 
     @BeforeTemplate
     void bad6(Collection<T> things) {
+        assertThat(things).isEqualTo(ImmutableList.of());
+    }
+
+    @BeforeTemplate
+    void bad7(Collection<T> things) {
         assertThat(things).isEqualTo(ImmutableSet.of());
     }
 

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
@@ -18,9 +18,12 @@ package com.palantir.baseline.refaster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.Collection;
+import java.util.Collections;
 
 public final class AssertjCollectionIsEmpty<T> {
 
@@ -32,6 +35,26 @@ public final class AssertjCollectionIsEmpty<T> {
     @BeforeTemplate
     void bad2(Collection<T> things) {
         assertThat(things.size()).isEqualTo(0);
+    }
+
+    @BeforeTemplate
+    void bad3(Collection<T> things) {
+        assertThat(things).isEqualTo(Collections.emptyList());
+    }
+
+    @BeforeTemplate
+    void bad4(Collection<T> things) {
+        assertThat(things).isEqualTo(Collections.emptySet());
+    }
+
+    @BeforeTemplate
+    void bad5(Collection<T> things) {
+        assertThat(things).isEqualTo(ImmutableList.of());
+    }
+
+    @BeforeTemplate
+    void bad6(Collection<T> things) {
+        assertThat(things).isEqualTo(ImmutableSet.of());
     }
 
     @AfterTemplate

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Collection;
+
+public final class AssertjCollectionIsEmpty<T> {
+
+    @BeforeTemplate
+    void bad1(Collection<T> things) {
+        assertThat(things.size() == 0).isTrue();
+    }
+
+    @BeforeTemplate
+    void bad2(Collection<T> things) {
+        assertThat(things.size()).isEqualTo(0);
+    }
+
+    @AfterTemplate
+    void after(Collection<T> things) {
+        assertThat(things).isEmpty();
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
@@ -62,6 +62,11 @@ public final class AssertjCollectionIsEmpty<T> {
         assertThat(things).isEqualTo(ImmutableSet.of());
     }
 
+    @BeforeTemplate
+    void bad8(Collection<T> things) {
+        assertThat(things).hasSize(0);
+    }
+
     @AfterTemplate
     void after(Collection<T> things) {
         assertThat(things).isEmpty();

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsNotEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsNotEmpty.java
@@ -18,9 +18,12 @@ package com.palantir.baseline.refaster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.Collection;
+import java.util.Collections;
 
 public final class AssertjCollectionIsNotEmpty<T> {
 
@@ -37,6 +40,36 @@ public final class AssertjCollectionIsNotEmpty<T> {
     @BeforeTemplate
     void bad3(Collection<T> things) {
         assertThat(things.size()).isNotEqualTo(0);
+    }
+
+    @BeforeTemplate
+    void bad4(Collection<T> things) {
+        assertThat(things.isEmpty()).isFalse();
+    }
+
+    @BeforeTemplate
+    void bad5(Collection<T> things) {
+        assertThat(!things.isEmpty()).isTrue();
+    }
+
+    @BeforeTemplate
+    void bad6(Collection<T> things) {
+        assertThat(things).isNotEqualTo(Collections.emptyList());
+    }
+
+    @BeforeTemplate
+    void bad7(Collection<T> things) {
+        assertThat(things).isNotEqualTo(Collections.emptySet());
+    }
+
+    @BeforeTemplate
+    void bad8(Collection<T> things) {
+        assertThat(things).isNotEqualTo(ImmutableList.of());
+    }
+
+    @BeforeTemplate
+    void bad9(Collection<T> things) {
+        assertThat(things).isNotEqualTo(ImmutableSet.of());
     }
 
     @AfterTemplate

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsNotEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsNotEmpty.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Collection;
+
+public final class AssertjCollectionIsNotEmpty<T> {
+
+    @BeforeTemplate
+    void bad1(Collection<T> things) {
+        assertThat(things.size() != 0).isTrue();
+    }
+
+    @BeforeTemplate
+    void bad2(Collection<T> things) {
+        assertThat(things.size() == 0).isFalse();
+    }
+
+    @BeforeTemplate
+    void bad3(Collection<T> things) {
+        assertThat(things.size()).isNotEqualTo(0);
+    }
+
+    @AfterTemplate
+    void after(Collection<T> things) {
+        assertThat(things).isNotEmpty();
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjFileContent.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjFileContent.java
@@ -33,6 +33,7 @@ public final class AssertjFileContent<T> {
     }
 
     @BeforeTemplate
+    @SuppressWarnings("deprecation") // we're migrating people off a deprecated method
     void before2(File file, String expected) throws IOException {
         assertThat(Files.toString(file, StandardCharsets.UTF_8)).isEqualTo(expected);
     }

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjFileContent.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjFileContent.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.Files;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+public final class AssertjFileContent<T> {
+
+    @BeforeTemplate
+    void before(File file, String expected) throws IOException {
+        assertThat(new String(Files.toByteArray(file), StandardCharsets.UTF_8)).isEqualTo(expected);
+    }
+
+    @BeforeTemplate
+    void before2(File file, String expected) throws IOException {
+        assertThat(Files.toString(file, StandardCharsets.UTF_8)).isEqualTo(expected);
+    }
+
+    @AfterTemplate
+    void after(File file, String expected) {
+        assertThat(file).hasContent(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjFileContent.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjFileContent.java
@@ -24,7 +24,6 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 
 public final class AssertjFileContent<T> {
 

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalIsPresent.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalIsPresent.java
@@ -19,9 +19,7 @@ package com.palantir.baseline.refaster;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
-import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import java.util.Collection;
 import java.util.Optional;
 
 public final class AssertjOptionalIsPresent<T> {

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalIsPresent.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalIsPresent.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.AlsoNegation;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Collection;
+import java.util.Optional;
+
+public final class AssertjOptionalIsPresent<T> {
+
+    @BeforeTemplate
+    void before(Optional<T> thing) {
+        assertThat(thing.isPresent()).isTrue();
+    }
+
+    @AfterTemplate
+    void after(Optional<T> thing) {
+        assertThat(thing).isPresent();
+    }
+}

--- a/changelog/@unreleased/pr-851.v2.yml
+++ b/changelog/@unreleased/pr-851.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Some AssertJ assertions can now be automatically replaced with more
+    idiomatic ones using refaster.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/851


### PR DESCRIPTION
## Before this PR

People can end up writing assertions that are _correct_, but don't give you as much debugging info as possible when they fail.

cc @carterkozak 

## After this PR
==COMMIT_MSG==
Some AssertJ assertions can now be automatically replaced with more idiomatic ones using refaster.
==COMMIT_MSG==

## Possible downsides?
- if nobody every actually makes these mistakes then we have some pointless code in the repo, and will spent excavator CPU cycles matching against them...

