### PR TITLE
Errorprone ignores code in build directory

### DIFF
--- a/changelog/@unreleased/pr-853.v2.yml
+++ b/changelog/@unreleased/pr-853.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Do not run error prone on any code in the build directory
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/853

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -178,6 +178,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
 
         errorProneOptions.setEnabled(true);
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
+        errorProneOptions.setExcludedPaths(project.getBuildDir().getAbsolutePath() + "/.*");
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
         errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);


### PR DESCRIPTION
## Before this PR
Errorprone checks would be applied to all code in a source set included code generated by annotation processors in to `build/.*`. This typically was not an issue since we most annotation processors annotate their generated classes with `@Generated` and we disable warnings in generated code. However some generators like derive4j do not do this leading to compilation failure.

Furthermore, relying on disable warning in generated prevented us from making certain checks (ex: `StrictUnusedVariable`) errors by default

## After this PR
==COMMIT_MSG==
Do not run error prone on any code in the build directory
==COMMIT_MSG==

## Possible downsides?
N/A

