### PR TITLE
strictUnusedVariable only support _ suppression prefix

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -115,7 +115,7 @@ import javax.lang.model.element.Name;
         severity = WARNING,
         documentSuppression = false)
 public final class StrictUnusedVariable extends BugChecker implements BugChecker.CompilationUnitTreeMatcher {
-    private static final ImmutableSet<String> EXEMPT_PREFIXES = ImmutableSet.of("unused", "_");
+    private static final ImmutableSet<String> EXEMPT_PREFIXES = ImmutableSet.of("_");
 
     /**
      * The set of annotation full names which exempt annotated element from being reported as unused.
@@ -578,7 +578,13 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                         // TODO(b/118437729): handle bogus source positions in enum declarations
                         return;
                     }
-                    fix.replace(startPos, endPos, "_" + tree.getName());
+                    if (tree.getName().toString().startsWith("unused")) {
+                        fix.replace(startPos, endPos, "_"  +
+                                CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL,
+                                        tree.getName().toString().substring("unused".length())));
+                    } else {
+                        fix.replace(startPos, endPos, "_" + tree.getName());
+                    }
                 }
             }.scan(state.getPath().getCompilationUnit(), null);
         }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -90,6 +90,24 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
+    public void renames_previous_suppression() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  public void publicMethod(String unusedValue, String unusedValue2) { }",
+                        "  public void varArgs(String unusedValue, String... unusedValue2) { }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  public void publicMethod(String _value, String _value2) { }",
+                        "  public void varArgs(String _value, String... _value2) { }",
+                        "}")
+                .doTest(TestMode.TEXT_MATCH);
+    }
+
+    @Test
     public void renames_unused_param() {
         refactoringTestHelper
                 .addInputLines(
@@ -134,11 +152,11 @@ public class StrictUnusedVariableTest {
                         "Test.java",
                         "class Test {",
                         "  private static int _field = 1;",
-                        "  public static void privateMethod(int _value, int unusedValue2) {",
+                        "  public static void privateMethod(int _value, int _value2) {",
                         "    int _value3 = 1;",
                         "    _value3 = 2;",
                         "    System.out.println(_value);",
-                        "    System.out.println(unusedValue2 + _value3 + _field);",
+                        "    System.out.println(_value2 + _value3 + _field);",
                         "  }",
                         "}")
                 .addOutputLines(

--- a/changelog/@unreleased/pr-854.v2.yml
+++ b/changelog/@unreleased/pr-854.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: StrictUnusedVariable can only be suppressed with `_` prefix
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/854


### PR DESCRIPTION
## Before this PR
We allowed users to suppress `StrictUnusedVariable` with `unused` or `_` prefix.

## After this PR
==COMMIT_MSG==
StrictUnusedVariable can only be suppressed with `_` prefix
==COMMIT_MSG==

We also will automatically migrate previous supressions with `unused` to `_`

## Possible downsides?
N/A

