### PR TITLE
Promote StrictUnusedVariable to error by default

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -23,7 +23,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
-import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
@@ -112,7 +112,7 @@ import javax.lang.model.element.Name;
         linkType = BugPattern.LinkType.CUSTOM,
         summary = "Unused.",
         providesFix = REQUIRES_HUMAN_ATTENTION,
-        severity = WARNING,
+        severity = ERROR,
         documentSuppression = false)
 public final class StrictUnusedVariable extends BugChecker implements BugChecker.CompilationUnitTreeMatcher {
     private static final ImmutableSet<String> EXEMPT_PREFIXES = ImmutableSet.of("unused", "_");

--- a/changelog/@unreleased/pr-855.v2.yml
+++ b/changelog/@unreleased/pr-855.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: StrictUnusedVariable is now an error by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/855


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
StrictUnusedVariable is now an error by default
==COMMIT_MSG==

## Possible downsides?
We have a bunch of automation around this rule, so turning it into an error should just prevent people from shooting themselves in the foot

