### PR TITLE
People have to opt-in to PreferAssertj patching

### DIFF
--- a/changelog/@unreleased/pr-861.v2.yml
+++ b/changelog/@unreleased/pr-861.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The PreferAssertj refactoring will only be applied if you have explicitly
+    opted in (e.g. using `baselineErrorProne { patchChecks += 'PreferAssertj' }`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/861

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -26,7 +26,6 @@ public class BaselineErrorProneExtension {
             // Baseline checks
             "LambdaMethodReference",
             "OptionalOrElseMethodInvocation",
-            "PreferAssertj",
             "PreferBuiltInConcurrentKeySet",
             "PreferCollectionTransform",
             "PreferListsPartition",


### PR DESCRIPTION
## Before this PR

Some repos are failing to merge 'latest baseline' refactoring PRs because it has huge assertj changes (like +2500lines or so).

I've pulled this out to a separate excavator PR that explicitly opts-in to the PreferAssertj check, so I think we can flip this to be opt-in.

## After this PR
==COMMIT_MSG==
The PreferAssertj refactoring will only be applied if you have explicitly opted in (e.g. using `baselineErrorProne { patchChecks += 'PreferAssertj' }`
==COMMIT_MSG==

## Possible downsides?
- more PRs to people's repos?

