### PR TITLE
Formatter preserves NLS comments in multiline string constants

### DIFF
--- a/gradle-baseline-java-config/resources/spotless/eclipse.xml
+++ b/gradle-baseline-java-config/resources/spotless/eclipse.xml
@@ -92,6 +92,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/formatter-expected/MultilineStringConstant.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/formatter-expected/MultilineStringConstant.java
@@ -1,0 +1,26 @@
+package test;
+
+class MultilineStringConstant {
+
+    // NON-NLS comments are required for i18n, it's important they are kept with their strings.
+    private static final String MULTIPLE_LINE_NON_NLS =
+            "field_0," + //$NON-NLS-1$
+                    "field_1," //$NON-NLS-1$
+                    +
+                    "field_2,"
+                    +
+                    "field_3,"
+                    +
+                    "field_4";
+
+    private static final String MULTIPLE_LINE_NO_COMMENT =
+            "field_0," +
+                    "field_1,"
+                    +
+                    "field_2,"
+                    +
+                    "field_3,"
+                    +
+                    "field_4";
+
+}

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/formatter-expected/MultilineStringConstant.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/formatter-expected/MultilineStringConstant.java
@@ -5,22 +5,16 @@ class MultilineStringConstant {
     // NON-NLS comments are required for i18n, it's important they are kept with their strings.
     private static final String MULTIPLE_LINE_NON_NLS =
             "field_0," + //$NON-NLS-1$
-                    "field_1," //$NON-NLS-1$
-                    +
-                    "field_2,"
-                    +
-                    "field_3,"
-                    +
-                    "field_4";
+                    "field_1," + //$NON-NLS-1$
+                    "field_2," + //$NON-NLS-1$
+                    "field_3," + //$NON-NLS-1$
+                    "field_4"; //$NON-NLS-1$
 
     private static final String MULTIPLE_LINE_NO_COMMENT =
             "field_0," +
-                    "field_1,"
-                    +
-                    "field_2,"
-                    +
-                    "field_3,"
-                    +
+                    "field_1," +
+                    "field_2," +
+                    "field_3," +
                     "field_4";
 
 }

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/formatter-in/MultilineStringConstant.java
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/formatter-in/MultilineStringConstant.java
@@ -1,0 +1,20 @@
+package test;
+
+class MultilineStringConstant {
+
+    // NON-NLS comments are required for i18n, it's important they are kept with their strings.
+    private static final String MULTIPLE_LINE_NON_NLS =
+                    "field_0," + //$NON-NLS-1$
+                    "field_1," + //$NON-NLS-1$
+                    "field_2," + //$NON-NLS-1$
+                    "field_3," + //$NON-NLS-1$
+                    "field_4"; //$NON-NLS-1$
+
+    private static final String MULTIPLE_LINE_NO_COMMENT =
+                    "field_0," +
+                    "field_1," +
+                    "field_2," +
+                    "field_3," +
+                    "field_4";
+
+}


### PR DESCRIPTION
==COMMIT_MSG==
Failing test for multiline string constant with NLS comments
==COMMIT_MSG==

