### PR TITLE
Errorprone ignores all generated code

### DIFF
--- a/changelog/@unreleased/pr-864.v2.yml
+++ b/changelog/@unreleased/pr-864.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Error prone will correctly ignore all source files in the build directory and in any generated source directory
+  links:
+    - https://github.com/palantir/gradle-baseline/pull/864

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -178,7 +178,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
 
         errorProneOptions.setEnabled(true);
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
-        errorProneOptions.setExcludedPaths(project.getBuildDir().getAbsolutePath() + "/.*");
+        errorProneOptions.setExcludedPaths(
+                String.format("%s/(build|src/generated.*)/.*", project.getProjectDir().getAbsolutePath()));
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
         errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -179,7 +179,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.setEnabled(true);
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
         errorProneOptions.setExcludedPaths(
-                String.format("%s/(build|src/generated.*)/.*", project.getProjectDir().getAbsolutePath()));
+                String.format("%s/(build|src/generated.*)/.*", project.getProjectDir().getPath()));
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
         errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);


### PR DESCRIPTION
## Before this PR
We only ignored code generated in the build directory. This caused issues when interacting with conjure and other code generators

## After this PR
==COMMIT_MSG==
Error prone will correctly ignore all source files in the build directory and in any generated source directory
==COMMIT_MSG==

## Possible downsides?
N/A

