### PR TITLE
Correctly fix previous suppressed params

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -144,6 +144,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                     "serialVersionUID",
                     // TAG fields are used by convention in Android apps.
                     "TAG");
+    private static final String UNUSED = "unused";
 
     @Override
     public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
@@ -578,10 +579,12 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                         // TODO(b/118437729): handle bogus source positions in enum declarations
                         return;
                     }
-                    if (tree.getName().toString().startsWith("unused")) {
-                        fix.replace(startPos, endPos, "_"  +
-                                CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL,
-                                        tree.getName().toString().substring("unused".length())));
+                    String name = tree.getName().toString();
+                    if (name.startsWith(UNUSED)) {
+                        fix.replace(startPos, endPos, "_"  + (name.equals(UNUSED)
+                                        ? "value"
+                                        : CaseFormat.UPPER_CAMEL.to(
+                                                CaseFormat.LOWER_CAMEL, name.substring(UNUSED.length()))));
                     } else {
                         fix.replace(startPos, endPos, "_" + tree.getName());
                     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -172,4 +172,22 @@ public class StrictUnusedVariableTest {
                         "}"
                 ).doTest(TestMode.TEXT_MATCH);
     }
+
+    @Test
+    public void fixes_previously_suppressed_variables() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  public static void privateMethod(int unused) {",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  public static void privateMethod(int _value) {",
+                        "  }",
+                        "}"
+                ).doTest(TestMode.TEXT_MATCH);
+    }
 }

--- a/changelog/@unreleased/pr-865.v2.yml
+++ b/changelog/@unreleased/pr-865.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure that `StrictUnusedVariable` correctly converts previously suppressed variables `unused` to `_`
+  links:
+    - https://github.com/palantir/gradle-baseline/pull/865


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Ensure that `StrictUnusedVariable` correctly converts previously suppressed variables `unused` to `_`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

