### PR TITLE
StrictUnusedVariable maintains side effects

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -409,10 +409,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             return ImmutableList.of();
         }
         ElementKind varKind = varSymbol.getKind();
-        boolean encounteredSideEffects = false;
         SuggestedFix.Builder fix = SuggestedFix.builder().setShortDescription("remove unused variable");
-        SuggestedFix.Builder removeSideEffectsFix =
-                SuggestedFix.builder().setShortDescription("remove unused variable and any side effects");
         for (TreePath usagePath : usagePaths) {
             StatementTree statement = (StatementTree) usagePath.getLeaf();
             if (statement.getKind() == Tree.Kind.VARIABLE) {
@@ -422,17 +419,14 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                 VariableTree variableTree = (VariableTree) statement;
                 ExpressionTree initializer = variableTree.getInitializer();
                 if (hasSideEffect(initializer) && TOP_LEVEL_EXPRESSIONS.contains(initializer.getKind())) {
-                    encounteredSideEffects = true;
                     if (varKind == ElementKind.FIELD) {
                         String newContent =
                                 String.format(
                                         "%s{ %s; }",
                                         varSymbol.isStatic() ? "static " : "", state.getSourceForNode(initializer));
                         fix.merge(SuggestedFixes.replaceIncludingComments(usagePath, newContent, state));
-                        removeSideEffectsFix.replace(statement, "");
                     } else {
                         fix.replace(statement, String.format("%s;", state.getSourceForNode(initializer)));
-                        removeSideEffectsFix.replace(statement, "");
                     }
                 } else if (isEnhancedForLoopVar(usagePath)) {
                     String modifiers =
@@ -440,19 +434,14 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                                     variableTree.getModifiers() == null
                                             ? null
                                             : state.getSourceForNode(variableTree.getModifiers()));
-                    String newContent =
-                            String.format(
-                                    "%s%s unused",
-                                    modifiers.isEmpty() ? "" : (modifiers + " "), variableTree.getType());
+                    String newContent = String.format(
+                            "%s%s unused", modifiers.isEmpty() ? "" : (modifiers + " "), variableTree.getType());
                     // The new content for the second fix should be identical to the content for the first
                     // fix in this case because we can't just remove the enhanced for loop variable.
                     fix.replace(variableTree, newContent);
-                    removeSideEffectsFix.replace(variableTree, newContent);
                 } else {
                     String replacement = needsBlock(usagePath) ? "{}" : "";
                     fix.merge(SuggestedFixes.replaceIncludingComments(usagePath, replacement, state));
-                    removeSideEffectsFix.merge(
-                            SuggestedFixes.replaceIncludingComments(usagePath, replacement, state));
                 }
                 continue;
             } else if (statement.getKind() == Tree.Kind.EXPRESSION_STATEMENT) {
@@ -468,26 +457,20 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                                         ((JCTree.JCAssignOp) tree).getExpression().getStartPosition(),
                                         "");
                         fix.merge(replacement);
-                        removeSideEffectsFix.merge(replacement);
                         continue;
                     }
                 } else if (tree instanceof AssignmentTree) {
                     if (hasSideEffect(((AssignmentTree) tree).getExpression())) {
-                        encounteredSideEffects = true;
                         fix.replace(
                                 tree.getStartPosition(), ((JCTree.JCAssign) tree).getExpression().getStartPosition(), "");
-                        removeSideEffectsFix.replace(statement, "");
                         continue;
                     }
                 }
             }
             String replacement = needsBlock(usagePath) ? "{}" : "";
             fix.replace(statement, replacement);
-            removeSideEffectsFix.replace(statement, replacement);
         }
-        return encounteredSideEffects
-                ? ImmutableList.of(removeSideEffectsFix.build(), fix.build())
-                : ImmutableList.of(fix.build());
+        return ImmutableList.of(fix.build());
     }
 
     private static ImmutableList<SuggestedFix> buildUnusedParameterFixes(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -146,6 +146,31 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
+    public void side_effects_are_preserved() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  private static int _field = 1;",
+                        "  public static void privateMethod() {",
+                        "    Object foo = someMethod();",
+                        "  }",
+                        "  private static Object someMethod() { return null; }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  private static int field = 1;",
+                        "  public static void privateMethod() {",
+                        "    someMethod();",
+                        "  }",
+                        "  private static Object someMethod() { return null; }",
+                        "  }",
+                        "}"
+                ).doTest(TestMode.TEXT_MATCH);
+    }
+
+    @Test
     public void fixes_suppressed_but_used_variables() {
         refactoringTestHelper
                 .addInputLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -160,14 +160,13 @@ public class StrictUnusedVariableTest {
                 .addOutputLines(
                         "Test.java",
                         "class Test {",
-                        "  private static int field = 1;",
+                        "  private static int _field = 1;",
                         "  public static void privateMethod() {",
                         "    someMethod();",
                         "  }",
                         "  private static Object someMethod() { return null; }",
-                        "  }",
-                        "}"
-                ).doTest(TestMode.TEXT_MATCH);
+                        "}")
+                .doTest(TestMode.TEXT_MATCH);
     }
 
     @Test

--- a/changelog/@unreleased/pr-870.v2.yml
+++ b/changelog/@unreleased/pr-870.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: When removing unused variables, `StrictUnusedVariable` will preserve
+    side effects
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/870


### PR DESCRIPTION
## Before this PR
The original Error prone rule maintained two seperate suggested fixes for preserving side effects and removing them, but would always prefer removing side effects.

## After this PR
==COMMIT_MSG==
When removing unused variables, `StrictUnusedVariable` will no longer delete method calls as these may have side effects
==COMMIT_MSG==

## Possible downsides?
The way that side effects are detected is very conservative and this change may leave behind unnecessary initializers 

