### PR TITLE
Avoid ambiguity in assertions on iterable maps

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -223,61 +223,51 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
     @SuppressWarnings({"CyclomaticComplexity", "MethodLength"})
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (ASSERT_TRUE.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ").isTrue()"));
+            return withAssertThat(tree, state, 0, (assertThat, fix) -> fix.replace(tree, assertThat + ".isTrue()"));
         }
         if (ASSERT_TRUE_DESCRIPTION.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + ").describedAs(" + argSource(tree, state, 0) + ").isTrue()"));
+            return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + ".describedAs(" + argSource(tree, state, 0) + ").isTrue()"));
         }
         if (ASSERT_FALSE.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ").isFalse()"));
+            return withAssertThat(tree, state, 0, (assertThat, fix) -> fix.replace(tree, assertThat + ".isFalse()"));
         }
         if (ASSERT_FALSE_DESCRIPTION.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + ").describedAs(" + argSource(tree, state, 0) + ").isFalse()"));
+            return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + ".describedAs(" + argSource(tree, state, 0) + ").isFalse()"));
         }
         if (ASSERT_NULL.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ").isNull()"));
+            return withAssertThat(tree, state, 0, (assertThat, fix) -> fix.replace(tree, assertThat+ ".isNull()"));
         }
         if (ASSERT_NULL_DESCRIPTION.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + ").describedAs(" + argSource(tree, state, 0) + ").isNull()"));
+            return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + ".describedAs(" + argSource(tree, state, 0) + ").isNull()"));
         }
         if (ASSERT_NOT_NULL.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ").isNotNull()"));
+            return withAssertThat(tree, state, 0, (assertThat, fix) -> fix.replace(tree, assertThat + ".isNotNull()"));
         }
         if (ASSERT_NOT_NULL_DESCRIPTION.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + ").describedAs(" + argSource(tree, state, 0) + ").isNotNull()"));
+            return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + ".describedAs(" + argSource(tree, state, 0) + ").isNotNull()"));
         }
         if (ASSERT_SAME.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + ").isSameAs(" + argSource(tree, state, 0) + ")"));
+            return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + ".isSameAs(" + argSource(tree, state, 0) + ")"));
         }
         if (ASSERT_SAME_DESCRIPTION.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 2)
-                            + ").describedAs(" + argSource(tree, state, 0) + ").isSameAs("
+            return withAssertThat(tree, state, 2, (assertThat, fix) ->
+                    fix.replace(tree, assertThat
+                            + ".describedAs(" + argSource(tree, state, 0) + ").isSameAs("
                             + argSource(tree, state, 1) + ")"));
         }
         if (ASSERT_NOT_SAME.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + ").isNotSameAs(" + argSource(tree, state, 0) + ")"));
+            return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                    fix.replace(tree, assertThat + ".isNotSameAs(" + argSource(tree, state, 0) + ")"));
         }
         if (ASSERT_NOT_SAME_DESCRIPTION.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 2)
-                            + ").describedAs(" + argSource(tree, state, 0) + ").isNotSameAs("
+            return withAssertThat(tree, state, 2, (assertThat, fix) ->
+                    fix.replace(tree, assertThat
+                            + ".describedAs(" + argSource(tree, state, 0) + ").isNotSameAs("
                             + argSource(tree, state, 1) + ")"));
         }
         if (FAIL_DESCRIPTION.matches(tree, state) || FAIL.matches(tree, state)) {
@@ -293,22 +283,20 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
 
         }
         if (ASSERT_EQUALS_FLOATING.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) -> fix
+            return withAssertThat(tree, state, 1, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, String.format("%s(%s)%s",
+                    .replace(tree, String.format("%s%s",
                             assertThat,
-                            argSource(tree, state, 1),
                             isConstantZero(tree.getArguments().get(2))
                                     ? String.format(".isEqualTo(%s)", argSource(tree, state, 0))
                                     : String.format(".isCloseTo(%s, within(%s))",
                                     argSource(tree, state, 0), argSource(tree, state, 2)))));
         }
         if (ASSERT_EQUALS_FLOATING_DESCRIPTION.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) -> fix
+            return withAssertThat(tree, state, 2, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, String.format("%s(%s).describedAs(%s)%s",
+                    .replace(tree, String.format("%s.describedAs(%s)%s",
                             assertThat,
-                            argSource(tree, state, 2),
                             argSource(tree, state, 0),
                             isConstantZero(tree.getArguments().get(3))
                                     ? String.format(".isEqualTo(%s)", argSource(tree, state, 1))
@@ -316,22 +304,20 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
                                     argSource(tree, state, 1), argSource(tree, state, 3)))));
         }
         if (ASSERT_NOT_EQUALS_FLOATING.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) -> fix
+            return withAssertThat(tree, state, 1, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, String.format("%s(%s)%s",
+                    .replace(tree, String.format("%s%s",
                             assertThat,
-                            argSource(tree, state, 1),
                             isConstantZero(tree.getArguments().get(2))
                                     ? String.format(".isNotEqualTo(%s)", argSource(tree, state, 0))
                                     : String.format(".isNotCloseTo(%s, within(%s))",
                                     argSource(tree, state, 0), argSource(tree, state, 2)))));
         }
         if (ASSERT_NOT_EQUALS_FLOATING_DESCRIPTION.matches(tree, state)) {
-            return withAssertThat(tree, state, (assertThat, fix) -> fix
+            return withAssertThat(tree, state, 2, (assertThat, fix) -> fix
                     .addStaticImport("org.assertj.core.api.Assertions.within")
-                    .replace(tree, String.format("%s(%s).describedAs(%s)%s",
+                    .replace(tree, String.format("%s.describedAs(%s)%s",
                             assertThat,
-                            argSource(tree, state, 2),
                             argSource(tree, state, 0),
                             isConstantZero(tree.getArguments().get(3))
                                     ? String.format(".isNotEqualTo(%s)", argSource(tree, state, 1))
@@ -341,8 +327,8 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         if (ASSERT_THAT.matches(tree, state)) {
             Optional<String> replacement = tree.getArguments().get(1)
                     .accept(HamcrestVisitor.INSTANCE, state);
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 0) + ")"
+            return withAssertThat(tree, state, 0, (assertThat, fix) ->
+                    fix.replace(tree, assertThat
                             + replacement.orElseGet(() ->
                             ".is(new "
                             + SuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.HamcrestCondition")
@@ -352,9 +338,9 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         if (ASSERT_THAT_DESCRIPTION.matches(tree, state)) {
             Optional<String> replacement = tree.getArguments().get(2)
                     .accept(HamcrestVisitor.INSTANCE, state);
-            return withAssertThat(tree, state, (assertThat, fix) ->
-                    fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                            + ").describedAs(" + argSource(tree, state, 0) + ")"
+            return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                    fix.replace(tree, assertThat
+                            + ".describedAs(" + argSource(tree, state, 0) + ")"
                             + replacement.orElseGet(() -> ".is(new "
                             + SuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.HamcrestCondition")
                             + "<>(" + argSource(tree, state, 2) + "))")));
@@ -362,16 +348,16 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         if (ASSERT_EQUALS_CATCHALL.matches(tree, state)) {
             int parameters = tree.getArguments().size();
             if (parameters == 2) {
-                return withAssertThat(tree, state, (assertThat, fix) ->
-                        fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                                + ").isEqualTo(" + argSource(tree, state, 0) + ")"));
+                return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                        fix.replace(tree, assertThat
+                                + ".isEqualTo(" + argSource(tree, state, 0) + ")"));
             } else if (parameters == 3 && ASTHelpers.isSameType(
                     ASTHelpers.getType(tree.getArguments().get(0)),
                     state.getTypeFromString(String.class.getName()),
                     state)) {
-                return withAssertThat(tree, state, (assertThat, fix) ->
-                        fix.replace(tree, assertThat + "(" + argSource(tree, state, 2)
-                                + ").describedAs(" + argSource(tree, state, 0) + ").isEqualTo("
+                return withAssertThat(tree, state, 2, (assertThat, fix) ->
+                        fix.replace(tree, assertThat
+                                + ".describedAs(" + argSource(tree, state, 0) + ").isEqualTo("
                                 + argSource(tree, state, 1) + ")"));
             } else {
                 // Does not fix assertArrayEquals(double[], double[], double)
@@ -382,16 +368,16 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         if (ASSERT_NOT_EQUALS_CATCHALL.matches(tree, state)) {
             int parameters = tree.getArguments().size();
             if (parameters == 2) {
-                return withAssertThat(tree, state, (assertThat, fix) ->
-                        fix.replace(tree, assertThat + "(" + argSource(tree, state, 1)
-                                + ").isNotEqualTo(" + argSource(tree, state, 0) + ")"));
+                return withAssertThat(tree, state, 1, (assertThat, fix) ->
+                        fix.replace(tree, assertThat
+                                + ".isNotEqualTo(" + argSource(tree, state, 0) + ")"));
             } else if (parameters == 3 && ASTHelpers.isSameType(
                     ASTHelpers.getType(tree.getArguments().get(0)),
                     state.getTypeFromString(String.class.getName()),
                     state)) {
-                return withAssertThat(tree, state, (assertThat, fix) ->
-                        fix.replace(tree, assertThat + "(" + argSource(tree, state, 2)
-                                + ").describedAs(" + argSource(tree, state, 0) + ").isNotEqualTo("
+                return withAssertThat(tree, state, 2, (assertThat, fix) ->
+                        fix.replace(tree, assertThat
+                                + ".describedAs(" + argSource(tree, state, 0) + ").isNotEqualTo("
                                 + argSource(tree, state, 1) + ")"));
             } else {
                 // I'm not aware of anything that should hit this.
@@ -408,6 +394,7 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
     private Description withAssertThat(
             MethodInvocationTree tree,
             VisitorState state,
+            int actualIndex,
             BiConsumer<String, SuggestedFix.Builder> assertThat) {
         SuggestedFix.Builder fix = SuggestedFix.builder();
         String qualified;
@@ -419,10 +406,30 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
         } else {
             qualified = SuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.Assertions.assertThat");
         }
-        assertThat.accept(qualified, fix);
+
+        String actualArgumentString = argSource(tree, state, actualIndex);
+        ExpressionTree actualArgument = tree.getArguments().get(actualIndex);
+        if (isIterableMap(actualArgument, state)) {
+            actualArgumentString = String.format("(%s<?, ?>) %s",
+                    SuggestedFixes.qualifyType(state, fix, "java.util.Map"),
+                    actualArgumentString);
+        }
+        assertThat.accept(qualified + '(' + actualArgumentString + ')', fix);
         return buildDescription(tree)
                 .addFix(fix.build())
                 .build();
+    }
+
+    private static boolean isIterableMap(ExpressionTree value, VisitorState state) {
+        return isSubtype(value, "java.lang.Iterable", state)
+                && isSubtype(value, "java.util.Map", state);
+    }
+
+    private static boolean isSubtype(ExpressionTree value, String castableTo, VisitorState state) {
+        return ASTHelpers.isSubtype(
+                ASTHelpers.getType(value),
+                state.getTypeFromString(castableTo),
+                state);
     }
 
     private static boolean useStaticAssertjImport(VisitorState state) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -237,7 +237,7 @@ public final class PreferAssertj extends BugChecker implements BugChecker.Method
                     fix.replace(tree, assertThat + ".describedAs(" + argSource(tree, state, 0) + ").isFalse()"));
         }
         if (ASSERT_NULL.matches(tree, state)) {
-            return withAssertThat(tree, state, 0, (assertThat, fix) -> fix.replace(tree, assertThat+ ".isNull()"));
+            return withAssertThat(tree, state, 0, (assertThat, fix) -> fix.replace(tree, assertThat + ".isNull()"));
         }
         if (ASSERT_NULL_DESCRIPTION.matches(tree, state)) {
             return withAssertThat(tree, state, 1, (assertThat, fix) ->

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -24,14 +24,20 @@ import org.junit.Test;
 public class PreferAssertjTests {
 
     @Test
-    public void fix_assertFalse() {
+    public void fix_booleanAsserts() {
         test()
                 .addInputLines(
                         "Test.java",
+                        "import static org.hamcrest.MatcherAssert.assertThat;",
+                        "",
                         "import org.junit.Assert;",
                         "class Test {",
                         "  void foo(boolean b) {",
                         "    Assert.assertFalse(b);",
+                        "    Assert.assertFalse(\"desc\", b);",
+                        "    Assert.assertTrue(b);",
+                        "    Assert.assertTrue(\"desc\", b);",
+                        "    assertThat(\"desc\", b);",
                         "  }",
                         "}")
                 .addOutputLines(
@@ -42,99 +48,9 @@ public class PreferAssertjTests {
                         "class Test {",
                         "  void foo(boolean b) {",
                         "    assertThat(b).isFalse();",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertFalseDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import org.junit.Assert;",
-                        "class Test {",
-                        "  void foo(boolean b) {",
-                        "    Assert.assertFalse(\"desc\", b);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "",
-                        "import org.junit.Assert;",
-                        "class Test {",
-                        "  void foo(boolean b) {",
                         "    assertThat(b).describedAs(\"desc\").isFalse();",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertTrue() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import org.junit.Assert;",
-                        "class Test {",
-                        "  void foo(boolean b) {",
-                        "    Assert.assertTrue(b);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "",
-                        "import org.junit.Assert;",
-                        "class Test {",
-                        "  void foo(boolean b) {",
                         "    assertThat(b).isTrue();",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertTrueDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import org.junit.Assert;",
-                        "class Test {",
-                        "  void foo(boolean b) {",
-                        "    Assert.assertTrue(\"desc\", b);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "",
-                        "import org.junit.Assert;",
-                        "class Test {",
-                        "  void foo(boolean b) {",
                         "    assertThat(b).describedAs(\"desc\").isTrue();",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertThat_matcherAssert() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.hamcrest.MatcherAssert.assertThat;",
-                        "class Test {",
-                        "  void foo(boolean b) {",
-                        "    assertThat(\"desc\", b);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "class Test {",
-                        "  void foo(boolean b) {",
                         "    assertThat(b).describedAs(\"desc\").isTrue();",
                         "  }",
                         "}")
@@ -175,77 +91,12 @@ public class PreferAssertjTests {
                 .addInputLines(
                         "Test.java",
                         "import static org.junit.Assert.assertNull;",
+                        "import static org.junit.Assert.assertNotNull;",
                         "class Test {",
                         "  void foo(String s) {",
                         "    assertNull(s);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertNull;",
-                        "class Test {",
-                        "  void foo(String s) {",
-                        "    assertThat(s).isNull();",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNullDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNull;",
-                        "class Test {",
-                        "  void foo(String s) {",
                         "    assertNull(\"desc\", s);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertNull;",
-                        "class Test {",
-                        "  void foo(String s) {",
-                        "    assertThat(s).describedAs(\"desc\").isNull();",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotNull() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNotNull;",
-                        "class Test {",
-                        "  void foo(String s) {",
                         "    assertNotNull(s);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertNotNull;",
-                        "class Test {",
-                        "  void foo(String s) {",
-                        "    assertThat(s).isNotNull();",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotNullDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNotNull;",
-                        "class Test {",
-                        "  void foo(String s) {",
                         "    assertNotNull(\"desc\", s);",
                         "  }",
                         "}")
@@ -253,8 +104,12 @@ public class PreferAssertjTests {
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import static org.junit.Assert.assertNotNull;",
+                        "import static org.junit.Assert.assertNull;",
                         "class Test {",
                         "  void foo(String s) {",
+                        "    assertThat(s).isNull();",
+                        "    assertThat(s).describedAs(\"desc\").isNull();",
+                        "    assertThat(s).isNotNull();",
                         "    assertThat(s).describedAs(\"desc\").isNotNull();",
                         "  }",
                         "}")
@@ -267,77 +122,12 @@ public class PreferAssertjTests {
                 .addInputLines(
                         "Test.java",
                         "import static org.junit.Assert.assertSame;",
-                        "class Test {",
-                        "  void foo(String a, String b) {",
-                        "    assertSame(a, b);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertSame;",
-                        "class Test {",
-                        "  void foo(String a, String b) {",
-                        "    assertThat(b).isSameAs(a);",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertSameDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertSame;",
-                        "class Test {",
-                        "  void foo(String a, String b) {",
-                        "    assertSame(\"desc\", a, b);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertSame;",
-                        "class Test {",
-                        "  void foo(String a, String b) {",
-                        "    assertThat(b).describedAs(\"desc\").isSameAs(a);",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotSame() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertSame;",
-                        "class Test {",
-                        "  void foo(String a, String b) {",
-                        "    assertSame(a, b);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertSame;",
-                        "class Test {",
-                        "  void foo(String a, String b) {",
-                        "    assertThat(b).isSameAs(a);",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotSameDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
                         "import static org.junit.Assert.assertNotSame;",
                         "class Test {",
                         "  void foo(String a, String b) {",
+                        "    assertSame(a, b);",
+                        "    assertSame(\"desc\", a, b);",
+                        "    assertNotSame(a, b);",
                         "    assertNotSame(\"desc\", a, b);",
                         "  }",
                         "}")
@@ -345,8 +135,12 @@ public class PreferAssertjTests {
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import static org.junit.Assert.assertNotSame;",
+                        "import static org.junit.Assert.assertSame;",
                         "class Test {",
                         "  void foo(String a, String b) {",
+                        "    assertThat(b).isSameAs(a);",
+                        "    assertThat(b).describedAs(\"desc\").isSameAs(a);",
+                        "    assertThat(b).isNotSameAs(a);",
                         "    assertThat(b).describedAs(\"desc\").isNotSameAs(a);",
                         "  }",
                         "}")
@@ -359,52 +153,12 @@ public class PreferAssertjTests {
                 .addInputLines(
                         "Test.java",
                         "import static org.junit.Assert.fail;",
-                        "class Test {",
-                        "  void foo() {",
-                        "    fail();",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.fail;",
-                        "class Test {",
-                        "  void foo() {",
-                        "    fail(\"fail\");",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_failDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.fail;",
-                        "class Test {",
-                        "  void foo() {",
-                        "    fail(\"desc\");",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.fail;",
-                        "class Test {",
-                        "  void foo() {",
-                        "    fail(\"desc\");",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_failDescriptionNonStaticImport() {
-        test()
-                .addInputLines(
-                        "Test.java",
+                        "",
                         "import org.junit.Assert;",
                         "class Test {",
                         "  void foo() {",
+                        "    fail();",
+                        "    fail(\"desc\");",
                         "    Assert.fail(\"desc\");",
                         "  }",
                         "}")
@@ -415,6 +169,8 @@ public class PreferAssertjTests {
                         "import org.junit.Assert;",
                         "class Test {",
                         "  void foo() {",
+                        "    fail(\"fail\");",
+                        "    fail(\"desc\");",
                         "    fail(\"desc\");",
                         "  }",
                         "}")
@@ -498,18 +254,26 @@ public class PreferAssertjTests {
                 .addInputLines(
                         "Test.java",
                         "import static org.junit.Assert.assertEquals;",
+                        "import static org.junit.Assert.assertNotEquals;",
                         "class Test {",
                         "  void foo(String value) {",
                         "    assertEquals(\"1\", value);",
+                        "    assertEquals(\"desc\", \"1\", value);",
+                        "    assertNotEquals(\"1\", value);",
+                        "    assertNotEquals(\"desc\", \"1\", value);",
                         "  }",
                         "}")
                 .addOutputLines(
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import static org.junit.Assert.assertEquals;",
+                        "import static org.junit.Assert.assertNotEquals;",
                         "class Test {",
                         "  void foo(String value) {",
                         "    assertThat(value).isEqualTo(\"1\");",
+                        "    assertThat(value).describedAs(\"desc\").isEqualTo(\"1\");",
+                        "    assertThat(value).isNotEqualTo(\"1\");",
+                        "    assertThat(value).describedAs(\"desc\").isNotEqualTo(\"1\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -579,29 +343,6 @@ public class PreferAssertjTests {
                         "class Test {",
                         "  void foo(int value) {",
                         "    assertThat(value).describedAs(\"desc\").isEqualTo(1);",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertEqualsStringDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(String value) {",
-                        "    assertEquals(\"desc\", \"1\", value);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertEquals;",
-                        "class Test {",
-                        "  void foo(String value) {",
-                        "    assertThat(value).describedAs(\"desc\").isEqualTo(\"1\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -718,51 +459,6 @@ public class PreferAssertjTests {
                         "class Test {",
                         "  void foo(int value) {",
                         "    assertNotEquals(1, value);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(int value) {",
-                        "    assertThat(value).isNotEqualTo(1);",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotEqualsString() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(String value) {",
-                        "    assertNotEquals(\"1\", value);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(String value) {",
-                        "    assertThat(value).isNotEqualTo(\"1\");",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotEqualsIntDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(int value) {",
                         "    assertNotEquals(\"desc\", 1, value);",
                         "  }",
                         "}")
@@ -772,30 +468,8 @@ public class PreferAssertjTests {
                         "import static org.junit.Assert.assertNotEquals;",
                         "class Test {",
                         "  void foo(int value) {",
+                        "    assertThat(value).isNotEqualTo(1);",
                         "    assertThat(value).describedAs(\"desc\").isNotEqualTo(1);",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertNotEqualsStringDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(String value) {",
-                        "    assertNotEquals(\"desc\", \"1\", value);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.junit.Assert.assertNotEquals;",
-                        "class Test {",
-                        "  void foo(String value) {",
-                        "    assertThat(value).describedAs(\"desc\").isNotEqualTo(\"1\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -811,29 +485,6 @@ public class PreferAssertjTests {
                         "class Test {",
                         "  void foo(int value) {",
                         "    assertThat(value, is(1));",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.hamcrest.Matchers.is;",
-                        "class Test {",
-                        "  void foo(int value) {",
-                        "    assertThat(value).isEqualTo(1);",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertThatIntDescription() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.junit.Assert.assertThat;",
-                        "import static org.hamcrest.Matchers.is;",
-                        "class Test {",
-                        "  void foo(int value) {",
                         "    assertThat(\"desc\", value, is(1));",
                         "  }",
                         "}")
@@ -843,6 +494,7 @@ public class PreferAssertjTests {
                         "import static org.hamcrest.Matchers.is;",
                         "class Test {",
                         "  void foo(int value) {",
+                        "    assertThat(value).isEqualTo(1);",
                         "    assertThat(value).describedAs(\"desc\").isEqualTo(1);",
                         "  }",
                         "}")
@@ -850,12 +502,12 @@ public class PreferAssertjTests {
     }
 
     @Test
-    public void fix_matcherAssertThatString_startsWith() {
+    public void fix_matcherAssertThatString_fallback() {
         test()
                 .addInputLines(
                         "Test.java",
                         "import static org.hamcrest.MatcherAssert.assertThat;",
-                        "import static org.hamcrest.Matchers.hasToString;",
+                        "import static org.hamcrest.Matchers.*;",
                         "class Test {",
                         "  void foo(String value) {",
                         "    assertThat(value, hasToString(\"str\"));",
@@ -864,36 +516,12 @@ public class PreferAssertjTests {
                 .addOutputLines(
                         "Test.java",
                         "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.hamcrest.Matchers.hasToString;",
+                        "import static org.hamcrest.Matchers.*;",
                         "",
                         "import org.assertj.core.api.HamcrestCondition;",
                         "class Test {",
                         "  void foo(String value) {",
                         "    assertThat(value).is(new HamcrestCondition<>(hasToString(\"str\")));",
-                        "  }",
-                        "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    public void fix_assertThat_instanceOf() {
-        test()
-                .addInputLines(
-                        "Test.java",
-                        "import static org.hamcrest.MatcherAssert.assertThat;",
-                        "import static org.hamcrest.Matchers.*;",
-                        "class Test {",
-                        "  void foo(String value) {",
-                        "    assertThat(value, instanceOf(String.class));",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import static org.assertj.core.api.Assertions.assertThat;",
-                        "import static org.hamcrest.Matchers.*;",
-                        "class Test {",
-                        "  void foo(String value) {",
-                        "    assertThat(value).isInstanceOf(String.class);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -198,6 +198,12 @@ public class PreferAssertjTests {
                         "    assertNotEquals(\"desc\", .1D, db, .01D);",
                         "    assertNotEquals(\"desc\", .1D, db, 0.0);",
                         "    assertNotEquals(.1D, db, 0D);",
+                        "    assertEquals(1D, db, 1);",
+                        "    assertEquals(1, db, 1D);",
+                        "    assertEquals(1D, db, 1f);",
+                        "    assertNotEquals(\"desc\", 1f, db, 1D);",
+                        "    assertEquals(1f, fl, 1);",
+                        "    assertNotEquals(1, fl, 1f);",
                         "  }",
                         "}")
                 .addOutputLines(
@@ -220,6 +226,12 @@ public class PreferAssertjTests {
                         "    assertThat(db).describedAs(\"desc\").isNotCloseTo(.1D, within(.01D));",
                         "    assertThat(db).describedAs(\"desc\").isNotEqualTo(.1D);",
                         "    assertThat(db).isNotEqualTo(.1D);",
+                        "    assertThat(db).isCloseTo(1D, within((double) 1));",
+                        "    assertThat(db).isCloseTo((double) 1, within(1D));",
+                        "    assertThat(db).isCloseTo(1D, within((double) 1f));",
+                        "    assertThat(db).describedAs(\"desc\").isNotCloseTo((double) 1f, within(1D));",
+                        "    assertThat(fl).isCloseTo(1f, within((float) 1));",
+                        "    assertThat(fl).isNotCloseTo((float) 1, within(1f));",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/changelog/@unreleased/pr-874.v2.yml
+++ b/changelog/@unreleased/pr-874.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid ambiguity in assertions on iterable maps
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/874

--- a/changelog/@unreleased/pr-874.v2.yml
+++ b/changelog/@unreleased/pr-874.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: PreferAssertj check avoids ambiguity in assertions on iterable maps
+  description: PreferAssertj check avoids ambiguity in assertThat invocations
   links:
   - https://github.com/palantir/gradle-baseline/pull/874

--- a/changelog/@unreleased/pr-874.v2.yml
+++ b/changelog/@unreleased/pr-874.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Avoid ambiguity in assertions on iterable maps
+  description: PreferAssertj check avoids ambiguity in assertions on iterable maps
   links:
   - https://github.com/palantir/gradle-baseline/pull/874


### PR DESCRIPTION
==COMMIT_MSG==
Avoid ambiguity in assertions on iterable maps
==COMMIT_MSG==

