### PR TITLE
Improve performannce of error prone PreferAssertj check

### DIFF
--- a/changelog/@unreleased/pr-875.v2.yml
+++ b/changelog/@unreleased/pr-875.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve performannce of error prone PreferAssertj check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/875


### PR DESCRIPTION
I most cases it checks a single MethodMatcher, down from twenty.

==COMMIT_MSG==
Improve performannce of error prone PreferAssertj check
==COMMIT_MSG==

