### PR TITLE
Improve AssertjCollectionIsEmpty and add test cases

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty.java
@@ -20,8 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.refaster.ImportPolicy;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -39,36 +41,42 @@ public final class AssertjCollectionIsEmpty<T> {
 
     @BeforeTemplate
     void bad3(Collection<T> things) {
-        assertThat(things.size() == 0).isTrue();
+        assertThat(things.size()).isZero();
     }
 
     @BeforeTemplate
-    void bad4(Collection<T> things) {
+    void bad4(Iterable<T> things) {
         assertThat(things).isEqualTo(Collections.emptyList());
     }
 
     @BeforeTemplate
-    void bad5(Collection<T> things) {
+    void bad5(Iterable<T> things) {
         assertThat(things).isEqualTo(Collections.emptySet());
     }
 
     @BeforeTemplate
-    void bad6(Collection<T> things) {
+    void bad6(Iterable<T> things) {
         assertThat(things).isEqualTo(ImmutableList.of());
     }
 
     @BeforeTemplate
-    void bad7(Collection<T> things) {
+    void bad7(Iterable<T> things) {
         assertThat(things).isEqualTo(ImmutableSet.of());
     }
 
     @BeforeTemplate
-    void bad8(Collection<T> things) {
+    void bad8(Iterable<T> things) {
         assertThat(things).hasSize(0);
     }
 
+    @BeforeTemplate
+    void bad9(Collection<T> things) {
+        assertThat(things.size()).isEqualTo(0);
+    }
+
     @AfterTemplate
-    void after(Collection<T> things) {
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Iterable<T> things) {
         assertThat(things).isEmpty();
     }
 }

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjCollectionIsEmptyTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjCollectionIsEmptyTest.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjCollectionIsEmptyTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(AssertjCollectionIsEmpty.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.Collections;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in) {",
+                        "    assertThat(in.size() == 0).isTrue();",
+                        "    assertThat(in.isEmpty()).isTrue();",
+                        "    assertThat(in.size()).isEqualTo(0);",
+                        "    assertThat(in.size()).isZero();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.Collections;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in) {",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "  }",
+                        "}");
+    }
+
+}


### PR DESCRIPTION
the `isEqualTo(Collections.emptyList())` and `ImmutableList.of()` cases
do not appear to work.

## Before this PR
no tests. fewer fix cases.

## After this PR
==COMMIT_MSG==
Improve AssertjCollectionIsEmpty and add test cases
==COMMIT_MSG==

