### PR TITLE
StringBuilderConstantParameters suggested fix doesn't remove comments

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StringBuilderConstantParameters.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StringBuilderConstantParameters.java
@@ -75,6 +75,12 @@ public final class StringBuilderConstantParameters
         if (!result.isPresent()) {
             return Description.NO_MATCH;
         }
+        // Avoid rewriting code that removes comments.
+        if (ASTHelpers.containsComments(tree, state)) {
+            return buildDescription(tree)
+                    .setMessage(MESSAGE)
+                    .build();
+        }
         List<ExpressionTree> arguments = result.get();
         Stream<String> prefixStream = arguments.stream().findFirst()
                 .map(ASTHelpers::getType)

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StringBuilderConstantParametersTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StringBuilderConstantParametersTests.java
@@ -196,6 +196,49 @@ public class StringBuilderConstantParametersTests {
     }
 
     @Test
+    public void shouldWarnWhenCommentsArePresent() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "class Test {",
+                "   String f() {",
+                "       return new StringBuilder()",
+                "           .append(\"foo\") // comment",
+                "           .append(\"bar\")",
+                "           // BUG: Diagnostic contains: StringBuilder with a constant number of parameters",
+                "           .toString();",
+                "   }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    public void doesNotRemoveComments() {
+        BugCheckerRefactoringTestHelper.newInstance(new StringBuilderConstantParameters(), getClass())
+                .addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "   String f() {",
+                        // Fails validation, but the tool prefers not to remove existing comments
+                        "       return new StringBuilder()",
+                        "           .append(\"foo\") // comment",
+                        "           .append(\"bar\")",
+                        "           .toString();",
+                        "   }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "class Test {",
+                        "   String f() {",
+                        "       return new StringBuilder()",
+                        "           .append(\"foo\") // comment",
+                        "           .append(\"bar\")",
+                        "           .toString();",
+                        "   }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
     public void shouldWarnOnNoParams_fix() {
         BugCheckerRefactoringTestHelper.newInstance(new StringBuilderConstantParameters(), getClass())
                 .addInputLines(

--- a/changelog/@unreleased/pr-877.v2.yml
+++ b/changelog/@unreleased/pr-877.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: StringBuilderConstantParameters suggested fix doesn't remove comments
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/877


### PR DESCRIPTION
Updated to avoid suggesting a fix if there are comments present.

## Before this PR
Comments could be removed.

## After this PR
==COMMIT_MSG==
StringBuilderConstantParameters suggested fix doesn't remove comments
==COMMIT_MSG==
