### PR TITLE
Less strict junit dependency check

### DIFF
--- a/changelog/@unreleased/pr-880.v2.yml
+++ b/changelog/@unreleased/pr-880.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Allow junit4 dependencies to exist without junit4 tests
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/880

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -76,14 +77,17 @@ public final class BaselineTesting implements Plugin<Project> {
     public static Optional<Test> getTestTaskForSourceSet(Project proj, SourceSet ss) {
         String testTaskName = ss.getTaskName(null, "test");
 
-        Test task1 = (Test) proj.getTasks().findByName(testTaskName);
-        if (task1 != null) {
-            return Optional.of(task1);
+        Task task1 =  proj.getTasks().findByName(testTaskName);
+        if (task1 instanceof Test) {
+            return Optional.of((Test) task1);
         }
 
         // unbroken dome does this
-        Test task2 = (Test) proj.getTasks().findByName(ss.getName());
-        return Optional.ofNullable(task2);
+        Task task2 =  proj.getTasks().findByName(ss.getName());
+        if (task2 instanceof Test) {
+            return Optional.of((Test) task2);
+        }
+        return Optional.empty();
     }
 
     private static boolean hasCompileDependenciesMatching(Project project, SourceSet sourceSet, Spec<Dependency> spec) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -109,16 +109,7 @@ public class CheckJUnitDependencies extends DefaultTask {
                                 + "'org.junit.jupiter:junit-jupiter' dependency "
                                 + "because tests use JUnit4 and useJUnitPlatform() is not enabled.");
             }
-        } else {
-            String compileClasspath = ss.getCompileClasspathConfigurationName();
-            boolean compilingAgainstOldJunit = hasDep(compileClasspath, CheckJUnitDependencies::isJunit4);
-            Preconditions.checkState(
-                    !compilingAgainstOldJunit,
-                    "Extraneous dependency on JUnit4 (no test mentions JUnit4 classes). Please exclude "
-                            + "this from compilation to ensure developers don't accidentally re-introduce it, e.g.\n\n"
-                            + "    configurations." + compileClasspath + ".exclude module: 'junit'\n\n");
         }
-
         // sourcesets might also contain Spock classes, but we don't have any special validation for these.
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -109,7 +109,17 @@ public class CheckJUnitDependencies extends DefaultTask {
                                 + "'org.junit.jupiter:junit-jupiter' dependency "
                                 + "because tests use JUnit4 and useJUnitPlatform() is not enabled.");
             }
+        } else {
+            String compileClasspath = ss.getCompileClasspathConfigurationName();
+            boolean compilingAgainstOldJunit = hasDep(compileClasspath, CheckJUnitDependencies::isJunit4);
+            if (compilingAgainstOldJunit) {
+                getProject().getLogger().info(
+                        "Extraneous dependency on JUnit4 (no test mentions JUnit4 classes). Please exclude "
+                                + "this from compilation to ensure developers don't accidentally re-introduce it, "
+                                + "e.g.\n\n    configurations." + compileClasspath + ".exclude module: 'junit'\n\n");
+            }
         }
+
         // sourcesets might also contain Spock classes, but we don't have any special validation for these.
     }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -145,22 +145,4 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         BuildResult result = with('checkJUnitDependencies', '--write-locks').buildAndFail()
         result.output.contains 'Some tests mention JUnit5, but the \'test\' task does not have useJUnitPlatform() enabled'
     }
-
-    def 'checkJUnitDependencies detects extraneous old junit'() {
-        when:
-        buildFile << standardBuildFile
-        buildFile << '''
-        dependencies {
-            testCompile "junit:junit:4.12"
-        }
-        test {
-          useJUnitPlatform()
-        }
-        '''.stripIndent()
-        file('src/test/java/test/TestClass5.java') << junit5Test
-
-        then:
-        BuildResult result = with('checkJUnitDependencies', '--write-locks').buildAndFail()
-        result.output.contains 'Extraneous dependency on JUnit4 (no test mentions JUnit4 classes)'
-    }
 }


### PR DESCRIPTION
## Before this PR
We would fail builds if we found junit dependencies on the testCompileClasspath without any corresponding tests. This was a little aggressive and blocked roll out of baseline.

We also ran into some issues with how we found test task and JMH since JMH creates a task named after the source set

## After this PR
==COMMIT_MSG==
Allow junit4 dependencies to exist without junit4 tests
==COMMIT_MSG==

## Possible downsides?
Some users could continue to write junit4. However this would only pass CI if the project still had the vintage engine, so the test would still be executed

