### PR TITLE
Refaster for AssertJ isZero/isNotZero/isOne and collections

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty2.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmpty2.java
@@ -16,39 +16,34 @@
 
 package com.palantir.baseline.refaster;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.google.errorprone.refaster.ImportPolicy;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import com.google.errorprone.refaster.annotation.UseImportPolicy;
-import java.util.Collection;
+import java.util.Collections;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractIterableAssert;
 
-public final class AssertjCollectionIsEmpty<T> {
+public final class AssertjCollectionIsEmpty2<A extends AbstractIterableAssert<A, I, T, E>,
+        I extends Iterable<? extends T>, T, E extends AbstractAssert<E, T>> {
 
     @BeforeTemplate
-    void bad1(Collection<T> things) {
-        assertThat(things.size() == 0).isTrue();
+    void before1(A in) {
+        in.hasSize(0);
     }
 
     @BeforeTemplate
-    void bad2(Collection<T> things) {
-        assertThat(things.isEmpty()).isTrue();
-    }
-
-    @BeforeTemplate
-    void bad3(Collection<T> things) {
-        assertThat(things.size()).isZero();
-    }
-
-    @BeforeTemplate
-    void bad4(Collection<T> things) {
-        assertThat(things.size()).isEqualTo(0);
+    void before2(A in) {
+        in.isEqualTo(Refaster.anyOf(
+                ImmutableList.of(),
+                ImmutableSet.of(),
+                Collections.emptySet(),
+                Collections.emptyList()));
     }
 
     @AfterTemplate
-    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
-    void after(Iterable<T> things) {
-        assertThat(things).isEmpty();
+    void after(A in) {
+        in.isEmpty();
     }
 }

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmptyWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionIsEmptyWithDescription.java
@@ -18,14 +18,11 @@ package com.palantir.baseline.refaster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.refaster.ImportPolicy;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Collection;
-import java.util.Collections;
 
 public final class AssertjCollectionIsEmptyWithDescription<T> {
 
@@ -45,32 +42,7 @@ public final class AssertjCollectionIsEmptyWithDescription<T> {
     }
 
     @BeforeTemplate
-    void bad4(Iterable<T> things, String description) {
-        assertThat(things).describedAs(description).isEqualTo(Collections.emptyList());
-    }
-
-    @BeforeTemplate
-    void bad5(Iterable<T> things, String description) {
-        assertThat(things).describedAs(description).isEqualTo(Collections.emptySet());
-    }
-
-    @BeforeTemplate
-    void bad6(Iterable<T> things, String description) {
-        assertThat(things).describedAs(description).isEqualTo(ImmutableList.of());
-    }
-
-    @BeforeTemplate
-    void bad7(Iterable<T> things, String description) {
-        assertThat(things).describedAs(description).isEqualTo(ImmutableSet.of());
-    }
-
-    @BeforeTemplate
-    void bad8(Iterable<T> things, String description) {
-        assertThat(things).describedAs(description).hasSize(0);
-    }
-
-    @BeforeTemplate
-    void bad9(Collection<T> things, String description) {
+    void bad4(Collection<T> things, String description) {
         assertThat(things.size()).describedAs(description).isEqualTo(0);
     }
 

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjIsNotZero.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjIsNotZero.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractFloatAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.NumberAssert;
+
+public final class AssertjIsNotZero {
+
+    @BeforeTemplate
+    public AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> input) {
+        return input.isNotEqualTo(0);
+    }
+
+    @BeforeTemplate
+    public AbstractLongAssert<?> before(AbstractLongAssert<?> input) {
+        return input.isNotEqualTo(0L);
+    }
+
+    @BeforeTemplate
+    public AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> input) {
+        return input.isNotEqualTo(0D);
+    }
+
+    @BeforeTemplate
+    public AbstractFloatAssert<?> before(AbstractFloatAssert<?> input) {
+        return input.isNotEqualTo(0f);
+    }
+
+    @BeforeTemplate
+    public AbstractDoubleAssert<?> beforeWithDecimal(AbstractDoubleAssert<?> input) {
+        return input.isNotEqualTo(0.0D);
+    }
+
+    @BeforeTemplate
+    public AbstractFloatAssert<?> beforeWithDecimal(AbstractFloatAssert<?> input) {
+        return input.isNotEqualTo(0.0);
+    }
+
+    @AfterTemplate
+    public NumberAssert<?, ?> after(NumberAssert<?, ?> input) {
+        return input.isNotZero();
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjIsOne.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjIsOne.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractFloatAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.NumberAssert;
+
+public final class AssertjIsOne {
+
+    @BeforeTemplate
+    public AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> input) {
+        return input.isEqualTo(1);
+    }
+
+    @BeforeTemplate
+    public AbstractLongAssert<?> before(AbstractLongAssert<?> input) {
+        return input.isEqualTo(1L);
+    }
+
+    @BeforeTemplate
+    public AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> input) {
+        return input.isEqualTo(1D);
+    }
+
+    @BeforeTemplate
+    public AbstractFloatAssert<?> before(AbstractFloatAssert<?> input) {
+        return input.isEqualTo(1f);
+    }
+
+    @BeforeTemplate
+    public AbstractDoubleAssert<?> beforeWithDecimal(AbstractDoubleAssert<?> input) {
+        return input.isEqualTo(1.0D);
+    }
+
+    @BeforeTemplate
+    public AbstractFloatAssert<?> beforeWithDecimal(AbstractFloatAssert<?> input) {
+        return input.isEqualTo(1.0);
+    }
+
+    @AfterTemplate
+    public NumberAssert<?, ?> after(NumberAssert<?, ?> input) {
+        return input.isOne();
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjIsZero.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjIsZero.java
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractFloatAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.NumberAssert;
+
+public final class AssertjIsZero {
+
+    @BeforeTemplate
+    public AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> input) {
+        return input.isEqualTo(0);
+    }
+
+    @BeforeTemplate
+    public AbstractLongAssert<?> before(AbstractLongAssert<?> input) {
+        return input.isEqualTo(0L);
+    }
+
+    @BeforeTemplate
+    public AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> input) {
+        return input.isEqualTo(0D);
+    }
+
+    @BeforeTemplate
+    public AbstractFloatAssert<?> before(AbstractFloatAssert<?> input) {
+        return input.isEqualTo(0f);
+    }
+
+    @BeforeTemplate
+    public AbstractDoubleAssert<?> beforeWithDecimal(AbstractDoubleAssert<?> input) {
+        return input.isEqualTo(0.0D);
+    }
+
+    @BeforeTemplate
+    public AbstractFloatAssert<?> beforeWithDecimal(AbstractFloatAssert<?> input) {
+        return input.isEqualTo(0.0);
+    }
+
+    @AfterTemplate
+    public NumberAssert<?, ?> after(NumberAssert<?, ?> input) {
+        return input.isZero();
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjCollectionIsEmptyTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjCollectionIsEmptyTest.java
@@ -16,6 +16,8 @@
 
 package com.palantir.baseline.refaster;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import org.junit.Test;
 
 public class AssertjCollectionIsEmptyTest {
@@ -80,6 +82,9 @@ public class AssertjCollectionIsEmptyTest {
 
     @Test
     public void test2() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
         RefasterTestHelper
                 .forRefactoring(AssertjCollectionIsEmpty2.class)
                 .withInputLines(

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjCollectionIsEmptyTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjCollectionIsEmptyTest.java
@@ -78,4 +78,41 @@ public class AssertjCollectionIsEmptyTest {
                         "}");
     }
 
+    @Test
+    public void test2() {
+        RefasterTestHelper
+                .forRefactoring(AssertjCollectionIsEmpty2.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.Collections;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in) {",
+                        "    assertThat(in).hasSize(0);",
+                        "    assertThat(in).isEqualTo(ImmutableList.of());",
+                        "    assertThat(in).isEqualTo(Collections.emptyList());",
+                        "    assertThat(in).describedAs(\"desc\").hasSize(0);",
+                        "    assertThat(in).describedAs(\"desc\").isEqualTo(ImmutableList.of());",
+                        "    assertThat(in).describedAs(\"desc\").isEqualTo(Collections.emptyList());",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.Collections;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in) {",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "  }",
+                        "}");
+    }
+
 }

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsNotZeroTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsNotZeroTest.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjIsNotZeroTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(AssertjIsNotZero.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, int i, double d, float f, long l) {",
+                        "    assertThat(in.size()).isNotEqualTo(0);",
+                        "    assertThat(i).isNotEqualTo(0);",
+                        "    assertThat(d).isNotEqualTo(0);",
+                        "    assertThat(d).isNotEqualTo(0D);",
+                        "    assertThat(d).isNotEqualTo(0.0D);",
+                        "    assertThat(f).isNotEqualTo(0);",
+                        "    assertThat(f).isNotEqualTo(0.0);",
+                        "    assertThat(l).isNotEqualTo(0);",
+                        "    assertThat(l).isNotEqualTo(0L);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, int i, double d, float f, long l) {",
+                        "    assertThat(in.size()).isNotZero();",
+                        "    assertThat(i).isNotZero();",
+                        "    assertThat(d).isNotZero();",
+                        "    assertThat(d).isNotZero();",
+                        "    assertThat(d).isNotZero();",
+                        "    assertThat(f).isNotZero();",
+                        "    assertThat(f).isNotZero();",
+                        "    assertThat(l).isNotZero();",
+                        "    assertThat(l).isNotZero();",
+                        "  }",
+                        "}");
+    }
+
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsNotZeroTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsNotZeroTest.java
@@ -16,12 +16,17 @@
 
 package com.palantir.baseline.refaster;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import org.junit.Test;
 
 public class AssertjIsNotZeroTest {
 
     @Test
     public void test() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
         RefasterTestHelper
                 .forRefactoring(AssertjIsNotZero.class)
                 .withInputLines(

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsOneTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsOneTest.java
@@ -16,12 +16,17 @@
 
 package com.palantir.baseline.refaster;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import org.junit.Test;
 
 public class AssertjIsOneTest {
 
     @Test
     public void test() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
         RefasterTestHelper
                 .forRefactoring(AssertjIsOne.class)
                 .withInputLines(

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsOneTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsOneTest.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjIsOneTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(AssertjIsOne.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, int i, double d, float f, long l) {",
+                        "    assertThat(in.size()).isEqualTo(1);",
+                        "    assertThat(i).isEqualTo(1);",
+                        "    assertThat(d).isEqualTo(1);",
+                        "    assertThat(d).isEqualTo(1D);",
+                        "    assertThat(d).isEqualTo(1.0D);",
+                        "    assertThat(f).isEqualTo(1);",
+                        "    assertThat(f).isEqualTo(1.0);",
+                        "    assertThat(l).isEqualTo(1);",
+                        "    assertThat(l).isEqualTo(1L);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, int i, double d, float f, long l) {",
+                        "    assertThat(in.size()).isOne();",
+                        "    assertThat(i).isOne();",
+                        "    assertThat(d).isOne();",
+                        "    assertThat(d).isOne();",
+                        "    assertThat(d).isOne();",
+                        "    assertThat(f).isOne();",
+                        "    assertThat(f).isOne();",
+                        "    assertThat(l).isOne();",
+                        "    assertThat(l).isOne();",
+                        "  }",
+                        "}");
+    }
+
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsZeroTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsZeroTest.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjIsZeroTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(AssertjIsZero.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, int i, double d, float f, long l) {",
+                        "    assertThat(in.size()).isEqualTo(0);",
+                        "    assertThat(i).isEqualTo(0);",
+                        "    assertThat(d).isEqualTo(0);",
+                        "    assertThat(d).isEqualTo(0D);",
+                        "    assertThat(d).isEqualTo(0.0D);",
+                        "    assertThat(f).isEqualTo(0);",
+                        "    assertThat(f).isEqualTo(0.0);",
+                        "    assertThat(l).isEqualTo(0);",
+                        "    assertThat(l).isEqualTo(0L);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, int i, double d, float f, long l) {",
+                        "    assertThat(in.size()).isZero();",
+                        "    assertThat(i).isZero();",
+                        "    assertThat(d).isZero();",
+                        "    assertThat(d).isZero();",
+                        "    assertThat(d).isZero();",
+                        "    assertThat(f).isZero();",
+                        "    assertThat(f).isZero();",
+                        "    assertThat(l).isZero();",
+                        "    assertThat(l).isZero();",
+                        "  }",
+                        "}");
+    }
+
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsZeroTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjIsZeroTest.java
@@ -16,12 +16,17 @@
 
 package com.palantir.baseline.refaster;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import org.junit.Test;
 
 public class AssertjIsZeroTest {
 
     @Test
     public void test() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
         RefasterTestHelper
                 .forRefactoring(AssertjIsZero.class)
                 .withInputLines(

--- a/changelog/@unreleased/pr-881.v2.yml
+++ b/changelog/@unreleased/pr-881.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refaster for AssertJ isZero/isNotZero/isOne and collections
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/881


### PR DESCRIPTION
Examples using specific AssertJ asserts without `assertThat`.

## After this PR
==COMMIT_MSG==
Refaster for AssertJ isZero/isNotZer/isOne and collections
==COMMIT_MSG==

