### PR TITLE
checkJunitDependencies only checks Java source

### DIFF
--- a/changelog/@unreleased/pr-885.v2.yml
+++ b/changelog/@unreleased/pr-885.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: checkJunitDependencies only checks Java source
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/885

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -134,7 +134,7 @@ public class CheckJUnitDependencies extends DefaultTask {
     }
 
     private boolean sourceSetMentionsJUnit4(SourceSet ss) {
-        return !ss.getAllSource()
+        return !ss.getAllJava()
                 .filter(file -> fileContainsSubstring(file, l ->
                         l.contains("org.junit.Test")
                                 || l.contains("org.junit.runner")
@@ -143,7 +143,7 @@ public class CheckJUnitDependencies extends DefaultTask {
     }
 
     private boolean sourceSetMentionsJUnit5Api(SourceSet ss) {
-        return !ss.getAllSource()
+        return !ss.getAllJava()
                 .filter(file -> fileContainsSubstring(file, l -> l.contains("org.junit.jupiter.api.")))
                 .isEmpty();
     }


### PR DESCRIPTION
Closes #884 
## Before this PR
We would try to read all files within a source set which includes resources. This was problematic if there were binary files like a `.jks` in the resources

## After this PR
==COMMIT_MSG==
checkJunitDependencies only checks Java source
==COMMIT_MSG==

## Possible downsides?
N/A

