### PR TITLE
Skip checking binary files for possible JUnit dependencies

### DIFF
--- a/changelog/@unreleased/pr-886.v2.yml
+++ b/changelog/@unreleased/pr-886.v2.yml
@@ -1,0 +1,11 @@
+type: fix
+fix:
+  description: |-
+    Treat MalformedInputException as binary files that are not necessary to
+    scan for old JUnit dependencies.
+
+    Rethrow any non-IOExeception (such as UncheckedIOException wrapping
+    MalformedInputException) with more useful error message indicating a
+    file could not be scanned (e.g. ).
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/886


### PR DESCRIPTION
## Before this PR
The `checkJUnitDependencies` task would attempt to scan all files in a source set, including binary files such as `src/test/resources/server_keystore.jks`, which would lead to a `java.io.UncheckedIOException: java.nio.charset.MalformedInputException: Input length = 1` (see 
https://circleci.com/gh/palantir/tritium/4234 & https://github.com/palantir/tritium/pull/439 ):

```
java.io.UncheckedIOException: java.nio.charset.MalformedInputException: Input length = 1
    at java.base/java.nio.file.FileChannelLinesSpliterator.readLine(FileChannelLinesSpliterator.java:173)
    at java.base/java.nio.file.FileChannelLinesSpliterator.tryAdvance(FileChannelLinesSpliterator.java:101)
    at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:127)
    at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:502)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:488)
    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
    at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
    at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
    at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:528)
    at com.palantir.baseline.tasks.CheckJUnitDependencies.fileContainsSubstring(CheckJUnitDependencies.java:153)
    at com.palantir.baseline.tasks.CheckJUnitDependencies.lambda$sourceSetMentionsJUnit5Api$5(CheckJUnitDependencies.java:147)
    at org.gradle.util.CollectionUtils.filter(CollectionUtils.java:154)
    at org.gradle.api.internal.file.AbstractFileCollection$5.getFiles(AbstractFileCollection.java:245)
    at org.gradle.api.internal.file.AbstractFileCollection.isEmpty(AbstractFileCollection.java:194)
    at org.gradle.api.internal.file.CompositeFileCollection.isEmpty(CompositeFileCollection.java:99)
    at com.palantir.baseline.tasks.CheckJUnitDependencies.sourceSetMentionsJUnit5Api(CheckJUnitDependencies.java:148)
    at com.palantir.baseline.tasks.CheckJUnitDependencies.validateSourceSet(CheckJUnitDependencies.java:72)
    at com.palantir.baseline.tasks.CheckJUnitDependencies.lambda$validateDependencies$0(CheckJUnitDependencies.java:61)
    at java.base/java.lang.Iterable.forEach(Iterable.java:75)
    at com.palantir.baseline.tasks.CheckJUnitDependencies.validateDependencies(CheckJUnitDependencies.java:46)
    ...snip gradle stuff...
Caused by: java.nio.charset.MalformedInputException: Input length = 1
    at java.base/java.nio.charset.CoderResult.throwException(CoderResult.java:274)
    at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:339)
    at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
    at java.base/java.io.BufferedReader.fill(BufferedReader.java:161)
    at java.base/java.io.BufferedReader.readLine(BufferedReader.java:326)
    at java.base/java.io.BufferedReader.readLine(BufferedReader.java:392)
    at java.base/java.nio.file.FileChannelLinesSpliterator.readLine(FileChannelLinesSpliterator.java:171)
    ... 117 more
```

## After this PR
==COMMIT_MSG==
Treat MalformedInputException as binary files that are not necessary to
scan for old JUnit dependencies.

Rethrow any non-IOExeception (such as UncheckedIOException wrapping
MalformedInputException) with more useful error message indicating a
file could not be scanned (e.g. src/test/resources/server_keystore.jks).
==COMMIT_MSG==

## Possible downsides?
This method of attempting to exclude non-source files may potentially have false-negatives of not flagging old JUnit dependencies in a source file if it were to trigger a `MalformedInputException` while reading (e.g. if the source file was not `UTF-8` but instead `UTF-16` or `UCS-2` per https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.1)
