### PR TITLE
Disable `UnusedVariable` in favour of `StrictUnusedVariable`

### DIFF
--- a/changelog/@unreleased/pr-888.v2.yml
+++ b/changelog/@unreleased/pr-888.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable `UnusedVariable` error prone rule by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/888

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -180,6 +180,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
         errorProneOptions.setExcludedPaths(
                 String.format("%s/(build|src/generated.*)/.*", project.getProjectDir().getPath()));
+        errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
         errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);


### PR DESCRIPTION
## Before this PR
We applied `UnusedVariable` and `StrictUnusedVariable` leading to duplicate suppressions

## After this PR
==COMMIT_MSG==
Disable `UnusedVariable` error prone rule by default
==COMMIT_MSG==

## Possible downsides?
N/A StrictUnusedVariable is better

