### PR TITLE
One more assertj refaster

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSameSizeAs.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSameSizeAs.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.List;
+import org.assertj.core.api.IterableAssert;
+
+public final class AssertjCollectionHasSameSizeAs<T,U> {
+
+    @BeforeTemplate
+    IterableAssert<T> before(IterableAssert<T> assertInProgress, List<U> expected) {
+        return assertInProgress.hasSize(expected.size());
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    IterableAssert<T> after(IterableAssert<T> assertInProgress, List<U> expected) {
+        return assertInProgress.hasSameSizeAs(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSameSizeAs.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjCollectionHasSameSizeAs.java
@@ -20,19 +20,19 @@ import com.google.errorprone.refaster.ImportPolicy;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
-import java.util.List;
+import java.util.Collection;
 import org.assertj.core.api.IterableAssert;
 
-public final class AssertjCollectionHasSameSizeAs<T,U> {
+public final class AssertjCollectionHasSameSizeAs<T, U> {
 
     @BeforeTemplate
-    IterableAssert<T> before(IterableAssert<T> assertInProgress, List<U> expected) {
+    IterableAssert<T> before(IterableAssert<T> assertInProgress, Collection<U> expected) {
         return assertInProgress.hasSize(expected.size());
     }
 
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
-    IterableAssert<T> after(IterableAssert<T> assertInProgress, List<U> expected) {
+    IterableAssert<T> after(IterableAssert<T> assertInProgress, Collection<U> expected) {
         return assertInProgress.hasSameSizeAs(expected);
     }
 }

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjCollectionHasSameSizeAsTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjCollectionHasSameSizeAsTest.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjCollectionHasSameSizeAsTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(AssertjCollectionHasSameSizeAs.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> a, List<String> b) {",
+                        "    assertThat(a).hasSize(b.size());",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> a, List<String> b) {",
+                        "    assertThat(a).hasSameSizeAs(b);",
+                        "  }",
+                        "}");
+    }
+}

--- a/baseline-refaster-testing/src/main/java/com/palantir/baseline/refaster/RefasterTestHelper.java
+++ b/baseline-refaster-testing/src/main/java/com/palantir/baseline/refaster/RefasterTestHelper.java
@@ -87,7 +87,9 @@ public final class RefasterTestHelper {
                     .orElseThrow(() -> new IllegalArgumentException("Failed to compile input lines"));
 
             DescriptionBasedDiff diff = DescriptionBasedDiff.create(tree, ImportOrganizer.STATIC_FIRST_ORGANIZER);
-            transformers.forEach(transformer -> transformer.apply(new TreePath(tree), result.context(), diff));
+            for (CodeTransformer transformer : transformers) {
+                transformer.apply(new TreePath(tree), result.context(), diff);
+            }
 
             SourceFile inputSourceFile = sourceFile(input);
             diff.applyDifferences(inputSourceFile);


### PR DESCRIPTION
## Before this PR
I saw a codebase with exactly this before state, which can easily be replaced with a version that produces a nicer error message!


## After this PR
==COMMIT_MSG==
refaster replacement for assertj hasSize(foo.size) -> hasSameSizeAs
==COMMIT_MSG==

## Possible downsides?
n/a

