### PR TITLE
Fix error-prone suppressions with JUnit5 @TestTemplate

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
@@ -42,7 +42,10 @@ final class TestCheckUtils {
     }
 
     private static final Matcher<ClassTree> hasJUnit5TestCases =
-            Matchers.hasMethod(Matchers.hasAnnotationOnAnyOverriddenMethod("org.junit.jupiter.api.Test"));
+            Matchers.hasMethod(Matchers.anyOf(
+                    Matchers.hasAnnotationOnAnyOverriddenMethod("org.junit.jupiter.api.Test"),
+                    Matchers.hasAnnotationOnAnyOverriddenMethod("org.junit.jupiter.api.TestTemplate")));
+
     private static final Matcher<ClassTree> hasTestCases = Matchers
             .anyOf(JUnitMatchers.hasJUnit4TestCases, hasJUnit5TestCases);
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
@@ -138,9 +138,14 @@ public class PreferSafeLoggableExceptionsTest {
         compilationHelper.addSourceLines(
                 "FooTest.java",
                 "import org.junit.jupiter.api.Test;",
+                "import org.junit.jupiter.api.TestTemplate;",
                 "class FooTest {",
                 "  @Test",
                 "  public void run_junit5_test() {",
+                "    throw new IllegalStateException(\"constant\");",
+                "  }",
+                "  @TestTemplate",
+                "  public void junit5_test_template() {",
                 "    throw new IllegalStateException(\"constant\");",
                 "  }",
                 "}").doTest();

--- a/changelog/@unreleased/pr-892.v2.yml
+++ b/changelog/@unreleased/pr-892.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Certain error-prone checks are disabled in test code, and the presence
+    of JUnit5's `@TestTemplate` annotation is now used to detect whether a class is
+    test code.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/892


### PR DESCRIPTION
## Before this PR

Reported by @dtobin on https://internal-github/foundry/junit5-extensions/issues/38

## After this PR
==COMMIT_MSG==
Certain error-prone checks are disabled in test code, and the presence of JUnit5's `@TestTemplate` annotation is now used to detect whether a class is test code.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

