### PR TITLE
Refaster rules for AssertJ tests

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjEquals.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjEquals.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Objects;
+
+/**
+ * We have to guess as to which value is expected and which is the actual result, but either way failures will
+ * produce significantly more helpful output.
+ */
+public final class AssertjEquals<T> {
+
+    @BeforeTemplate
+    void before1(T expected, T actual) {
+        assertThat(actual.equals(expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(T expected, T actual) {
+        assertThat(Objects.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void before3(T expected, T actual) {
+        assertThat(!actual.equals(expected)).isFalse();
+    }
+
+    @BeforeTemplate
+    void before4(T expected, T actual) {
+        assertThat(!Objects.equals(actual, expected)).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(T expected, T actual) {
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjEqualsWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjEqualsWithDescription.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Objects;
+
+/**
+ * We have to guess as to which value is expected and which is the actual result, but either way failures will
+ * produce significantly more helpful output.
+ */
+public final class AssertjEqualsWithDescription<T> {
+
+    @BeforeTemplate
+    void before1(T expected, T actual, String description) {
+        assertThat(actual.equals(expected)).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(T expected, T actual, String description) {
+        assertThat(Objects.equals(actual, expected)).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    void before3(T expected, T actual, String description) {
+        assertThat(!actual.equals(expected)).describedAs(description).isFalse();
+    }
+
+    @BeforeTemplate
+    void before4(T expected, T actual, String description) {
+        assertThat(!Objects.equals(actual, expected)).describedAs(description).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(T expected, T actual, String description) {
+        assertThat(actual).describedAs(description).isEqualTo(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjInstanceOf.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjInstanceOf.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+/**
+ * We have to guess as to which value is expected and which is the actual result, but either way failures will
+ * produce significantly more helpful output.
+ */
+public final class AssertjInstanceOf<T, E> {
+
+    @BeforeTemplate
+    void before(T input) {
+        assertThat(Refaster.<E>isInstance(input)).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(T input) {
+        assertThat(input).isInstanceOf(Refaster.<E>clazz());
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjInstanceOfWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjInstanceOfWithDescription.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjInstanceOfWithDescription<T, E> {
+
+    @BeforeTemplate
+    void before(T input, String description) {
+        assertThat(Refaster.<E>isInstance(input)).describedAs(description).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(T input, String description) {
+        assertThat(input).describedAs(description).isInstanceOf(Refaster.<E>clazz());
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjNotEquals.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjNotEquals.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Objects;
+
+/**
+ * We have to guess as to which value is expected and which is the actual result, but either way failures will
+ * produce significantly more helpful output.
+ */
+public final class AssertjNotEquals<T> {
+
+    @BeforeTemplate
+    void before1(T expected, T actual) {
+        assertThat(!actual.equals(expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(T expected, T actual) {
+        assertThat(!Objects.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void before3(T expected, T actual) {
+        assertThat(actual.equals(expected)).isFalse();
+    }
+
+    @BeforeTemplate
+    void before4(T expected, T actual) {
+        assertThat(Objects.equals(actual, expected)).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(T expected, T actual) {
+        assertThat(actual).isNotEqualTo(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjNotEqualsWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjNotEqualsWithDescription.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Objects;
+
+/**
+ * We have to guess as to which value is expected and which is the actual result, but either way failures will
+ * produce significantly more helpful output.
+ */
+public final class AssertjNotEqualsWithDescription<T> {
+
+    @BeforeTemplate
+    void before1(T expected, T actual, String description) {
+        assertThat(!actual.equals(expected)).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(T expected, T actual, String description) {
+        assertThat(!Objects.equals(actual, expected)).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    void before3(T expected, T actual, String description) {
+        assertThat(actual.equals(expected)).describedAs(description).isFalse();
+    }
+
+    @BeforeTemplate
+    void before4(T expected, T actual, String description) {
+        assertThat(Objects.equals(actual, expected)).describedAs(description).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(T expected, T actual, String description) {
+        assertThat(actual).describedAs(description).isNotEqualTo(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjStringContains.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjStringContains.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjStringContains {
+
+    @BeforeTemplate
+    void before1(String input, CharSequence contains) {
+        assertThat(input.contains(contains)).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(String input, CharSequence contains) {
+        assertThat(!input.contains(contains)).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(String input, CharSequence contains) {
+        assertThat(input).contains(contains);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjStringContainsWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjStringContainsWithDescription.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjStringContainsWithDescription {
+
+    @BeforeTemplate
+    void before1(String input, CharSequence contains, String description) {
+        assertThat(input.contains(contains)).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(String input, CharSequence contains, String description) {
+        assertThat(!input.contains(contains)).describedAs(description).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(String input, CharSequence contains, String description) {
+        assertThat(input).describedAs(description).contains(contains);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjStringDoesNotContain.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjStringDoesNotContain.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjStringDoesNotContain {
+
+    @BeforeTemplate
+    void before1(String input, CharSequence contains) {
+        assertThat(input.contains(contains)).isFalse();
+    }
+
+    @BeforeTemplate
+    void before2(String input, CharSequence contains) {
+        assertThat(!input.contains(contains)).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(String input, CharSequence contains) {
+        assertThat(input).doesNotContain(contains);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjStringDoesNotContainWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjStringDoesNotContainWithDescription.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjStringDoesNotContainWithDescription<T> {
+
+    @BeforeTemplate
+    void before1(String input, CharSequence contains, String description) {
+        assertThat(input.contains(contains)).describedAs(description).isFalse();
+    }
+
+    @BeforeTemplate
+    void before2(String input, CharSequence contains, String description) {
+        assertThat(!input.contains(contains)).describedAs(description).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(String input, CharSequence contains, String description) {
+        assertThat(input).describedAs(description).doesNotContain(contains);
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjEqualityTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjEqualityTest.java
@@ -1,0 +1,134 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjEqualityTest {
+
+    @Test
+    public void equals_simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Objects;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj.equals(\"foo\")).isTrue();",
+                        "    assertThat(!obj.equals(\"foo\")).isFalse();",
+                        "    assertThat(Objects.equals(obj, \"foo\")).isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Objects;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj).isEqualTo(\"foo\");",
+                        "    assertThat(obj).isEqualTo(\"foo\");",
+                        "    assertThat(obj).isEqualTo(\"foo\");",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void equals_description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Objects;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj.equals(\"foo\")).describedAs(\"desc\").isTrue();",
+                        "    assertThat(!obj.equals(\"foo\")).describedAs(\"desc\").isFalse();",
+                        "    assertThat(Objects.equals(obj, \"foo\")).describedAs(\"desc\").isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Objects;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj).describedAs(\"desc\").isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc\").isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc\").isEqualTo(\"foo\");",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void notEquals_simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjNotEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Objects;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj.equals(\"foo\")).isFalse();",
+                        "    assertThat(!obj.equals(\"foo\")).isTrue();",
+                        "    assertThat(Objects.equals(obj, \"foo\")).isFalse();",
+                        "    assertThat(!Objects.equals(obj, \"foo\")).isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Objects;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj).isNotEqualTo(\"foo\");",
+                        "    assertThat(obj).isNotEqualTo(\"foo\");",
+                        "    assertThat(obj).isNotEqualTo(\"foo\");",
+                        "    assertThat(obj).isNotEqualTo(\"foo\");",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void notEquals_description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjNotEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Objects;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj.equals(\"foo\")).describedAs(\"desc\").isFalse();",
+                        "    assertThat(!obj.equals(\"foo\")).describedAs(\"desc\").isTrue();",
+                        "    assertThat(Objects.equals(obj, \"foo\")).describedAs(\"desc\").isFalse();",
+                        "    assertThat(!Objects.equals(obj, \"foo\")).describedAs(\"desc\").isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Objects;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj).describedAs(\"desc\").isNotEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc\").isNotEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc\").isNotEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc\").isNotEqualTo(\"foo\");",
+                        "  }",
+                        "}");
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInstanceOfTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInstanceOfTest.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjInstanceOfTest {
+
+    @Test
+    public void simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjInstanceOf.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, Object obj) {",
+                        "    assertThat(in instanceof ImmutableList).isTrue();",
+                        "    assertThat(obj instanceof String).isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, Object obj) {",
+                        "    assertThat(in).isInstanceOf(ImmutableList.class);",
+                        "    assertThat(obj).isInstanceOf(String.class);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjInstanceOfWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, Object obj) {",
+                        "    assertThat(in instanceof ImmutableList).describedAs(\"desc\").isTrue();",
+                        "    assertThat(obj instanceof String).describedAs(\"desc\").isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> in, Object obj) {",
+                        "    assertThat(in).describedAs(\"desc\").isInstanceOf(ImmutableList.class);",
+                        "    assertThat(obj).describedAs(\"desc\").isInstanceOf(String.class);",
+                        "  }",
+                        "}");
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjStringContentTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjStringContentTest.java
@@ -1,0 +1,114 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjStringContentTest {
+
+    @Test
+    public void contains_simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjStringContains.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str.contains(\"foo\")).isTrue();",
+                        "    assertThat(!str.contains(\"foo\")).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str).contains(\"foo\");",
+                        "    assertThat(str).contains(\"foo\");",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void contains_description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjStringContainsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str.contains(\"foo\")).describedAs(\"desc\").isTrue();",
+                        "    assertThat(!str.contains(\"foo\")).describedAs(\"desc\").isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str).describedAs(\"desc\").contains(\"foo\");",
+                        "    assertThat(str).describedAs(\"desc\").contains(\"foo\");",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void notContain_simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjStringDoesNotContain.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str.contains(\"foo\")).isFalse();",
+                        "    assertThat(!str.contains(\"foo\")).isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str).doesNotContain(\"foo\");",
+                        "    assertThat(str).doesNotContain(\"foo\");",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void notContain_description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjStringDoesNotContainWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str.contains(\"foo\")).describedAs(\"desc\").isFalse();",
+                        "    assertThat(!str.contains(\"foo\")).describedAs(\"desc\").isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str).describedAs(\"desc\").doesNotContain(\"foo\");",
+                        "    assertThat(str).describedAs(\"desc\").doesNotContain(\"foo\");",
+                        "  }",
+                        "}");
+    }
+}

--- a/changelog/@unreleased/pr-898.v2.yml
+++ b/changelog/@unreleased/pr-898.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refaster rules for AssertJ tests
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/898


### PR DESCRIPTION
```diff
- assertThat(str.contains("val")).isTrue();
+ assertThat(str).contains("val");
```

```diff
- assertThat(a instanceof B).isTrue();
+ assertThat(a)isInstanceOf(B.class);
```

```diff
- assertThat(a.equals(b)).isTrue();
+ assertThat(a).isEqualTo(b);
```

## After this PR
==COMMIT_MSG==
Refaster rules for AssertJ tests
==COMMIT_MSG==

## Possible downsides?
I've added a lot of these, they might be worth splitting into a separate library. For the most part these are a one-time migration in a large internal codebase, it's not terribly important to me that these are merged and rolled out with baseline, but they are worth keeping around somewhere.
These provide the most utility after `PreferAssertj` is applied because AssertJ is more expressive than `org.junit.Assert`.

