### PR TITLE
Don't apply com.palantir.baseline-versions automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,17 +229,23 @@ Also, the plugin:
 
 ## com.palantir.baseline-versions (deprecated)
 
-_Deprecated in favour of [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions)_
+_Deprecated in favour of [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions)._ Configures nebula dependency recommender to source version numbers from a root level `versions.props` file.  This plugin should be applied in an `allprojects` block.
 
-Uses nebula dependency recommender to source version numbers from a root level `versions.props` file.  This plugin should be applied in an `allprojects` block. It is effectively a shorthand for the following:
+```diff
+ buildscript {
+     dependencies {
++        classpath 'com.netflix.nebula:nebula-dependency-recommender:8.2.0'
+     }
+ }
+
+ allprojects {
++    apply plugin: 'com.palantir.baseline-versions'
+ }
+ ```
+
+It is effectively a shorthand for the following:
 
 ```gradle
-buildscript {
-    dependencies {
-        classpath 'com.netflix.nebula:nebula-dependency-recommender:x.y.z'
-    }
-}
-
 allprojects {
     apply plugin: 'nebula.dependency-recommender'
     dependencyRecommendations {

--- a/README.md
+++ b/README.md
@@ -227,8 +227,11 @@ Also, the plugin:
 3. stores the HTML output of tests in `$CIRCLE_ARTIFACTS/junit`
 
 
-## com.palantir.baseline-versions
-Sources version numbers from a root level `versions.props` file.  This plugin should be applied in an `allprojects` block. It is effectively a shorthand for the following:
+## com.palantir.baseline-versions (deprecated)
+
+_Deprecated in favour of [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions)_
+
+Uses nebula dependency recommender to source version numbers from a root level `versions.props` file.  This plugin should be applied in an `allprojects` block. It is effectively a shorthand for the following:
 
 ```gradle
 buildscript {

--- a/changelog/@unreleased/pr-899.v2.yml
+++ b/changelog/@unreleased/pr-899.v2.yml
@@ -1,0 +1,7 @@
+type: break
+break:
+  description: 'nebula-dependency-recommender is no longer applied by default. If
+    you have not yet migrated to GCV, you need to explicitly depend on `com.netflix.nebula:nebula-dependency-recommender`
+    and `apply plugin: ''com.palantir.baseline-versions''`.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/899

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile 'com.diffplug.spotless:spotless-plugin-gradle'
     compile 'com.google.errorprone:error_prone_refaster'
     compile 'com.google.guava:guava'
-    compile 'com.netflix.nebula:nebula-dependency-recommender'
+    compileOnly 'com.netflix.nebula:nebula-dependency-recommender'
     compile 'com.palantir.configurationresolver:gradle-configuration-resolver-plugin'
     compile 'net.ltgt.gradle:gradle-errorprone-plugin'
     compile 'org.apache.maven.shared:maven-dependency-analyzer'

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testCompile 'junit:junit'
     testCompile 'net.lingala.zip4j:zip4j'
     testCompile 'org.assertj:assertj-core'
+    testCompile 'com.netflix.nebula:nebula-dependency-recommender'
 
     annotationProcessor 'org.inferred:freebuilder'
     compileOnly 'org.inferred:freebuilder'

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -42,7 +42,6 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineEclipse.class);
             proj.getPluginManager().apply(BaselineIdea.class);
             proj.getPluginManager().apply(BaselineErrorProne.class);
-            proj.getPluginManager().apply(BaselineVersions.class);
             proj.getPluginManager().apply(BaselineFormat.class);
             proj.getPluginManager().apply(BaselineReproducibility.class);
             proj.getPluginManager().apply(BaselineExactDependencies.class);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -16,7 +16,6 @@
 
 package com.palantir.baseline.plugins;
 
-import com.palantir.baseline.plugins.versions.BaselineVersions;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import groovy.util.Node;
 import groovy.xml.QName;
 import java.nio.file.Paths;
-import netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.github.ngbinh.scalastyle.ScalaStylePlugin;
 import org.github.ngbinh.scalastyle.ScalaStyleTask;
@@ -104,14 +103,5 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                             .orElseGet(() -> parametersNode.appendNode("parameter"));
                     parameter.attributes().put("value", targetJvmVersion);
                 });
-    }
-
-    // separate class just so that the main plugin can still be loaded even if the nebula jar isn't on the classpath
-    private static class ExcludeZinc {
-        static void apply(Project project) {
-            project.getExtensions().configure(
-                    RecommendationProviderContainer.class,
-                    recommendations -> recommendations.excludeConfigurations("zinc"));
-        }
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
@@ -39,9 +39,8 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
     public void apply(Project project) {
         this.project = project;
         project.getPluginManager().withPlugin("scala", plugin -> {
-            project.getPluginManager().withPlugin("nebula.dependency-recommender", nebulaPlugin ->
-                    project.getExtensions().configure(RecommendationProviderContainer.class,
-                            recommendations -> recommendations.excludeConfigurations("zinc")));
+            project.getPluginManager()
+                    .withPlugin("nebula.dependency-recommender", nebulaPlugin -> ExcludeZinc.apply(project));
             JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
             project.getTasks().withType(ScalaCompile.class)
                     .configureEach(scalaCompile ->
@@ -107,4 +106,12 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                 });
     }
 
+    // separate class just so that the main plugin can still be loaded even if the nebula jar isn't on the classpath
+    private static class ExcludeZinc {
+        static void apply(Project project) {
+            project.getExtensions().configure(
+                    RecommendationProviderContainer.class,
+                    recommendations -> recommendations.excludeConfigurations("zinc"));
+        }
+    }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/ExcludeZinc.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/ExcludeZinc.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer;
+import org.gradle.api.Project;
+
+// separate class just so that the main plugin can still be loaded even if the nebula jar isn't on the classpath
+final class ExcludeZinc {
+    static void apply(Project project) {
+        project.getExtensions().configure(
+                RecommendationProviderContainer.class,
+                recommendations -> recommendations.excludeConfigurations("zinc"));
+    }
+
+    private ExcludeZinc() {}
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -60,7 +60,10 @@ import org.gradle.api.tasks.TaskProvider;
  *     }
  * }
  * </pre>
+ *
+ * @deprecated use GCV instead
  */
+@Deprecated
 public final class BaselineVersions implements Plugin<Project> {
 
     private static final Logger log = Logging.getLogger(BaselineVersions.class);

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
@@ -134,6 +134,7 @@ class BaselineVersionsIntegrationTest extends AbstractPluginTest {
             plugins {
                 id 'java'
                 id 'com.palantir.baseline-versions'
+                id 'nebula.dependency-recommender' version '8.2.0'
             }
         
             repositories {
@@ -168,6 +169,7 @@ class BaselineVersionsIntegrationTest extends AbstractPluginTest {
         buildFile << """
             plugins {
                 id 'com.palantir.baseline-versions'
+                id 'nebula.dependency-recommender' version '8.2.0'
             }
             allprojects {
                 apply plugin: 'com.palantir.baseline-versions'
@@ -269,6 +271,7 @@ class BaselineVersionsIntegrationTest extends AbstractPluginTest {
         plugins {
             id 'java'
             id 'com.palantir.baseline-versions'
+            id 'nebula.dependency-recommender' version '8.2.0'
         }
 
         repositories {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineVersionsIntegrationTest.groovy
@@ -32,6 +32,7 @@ class BaselineVersionsIntegrationTest extends AbstractPluginTest {
         plugins {
             id 'java'
             id 'com.palantir.baseline-versions'
+            id 'nebula.dependency-recommender' version '8.2.0'
         }
     
         repositories {


### PR DESCRIPTION
## Before this PR

We have been discouraging people from using nebula-dependency recommender in favour of GCV for a long time. Most repos now have a `com.palantir.baseline-versions.disable=true` line in their versions.props, and occasionally people still have trouble with this.

## After this PR
==COMMIT_MSG==
nebula-dependency-recommender is no longer applied by default. If you have not yet migrated to GCV, you need to explicitly depend on `com.netflix.nebula:nebula-dependency-recommender` and `apply plugin: 'com.palantir.baseline-versions'`.
==COMMIT_MSG==

## Possible downsides?

- anyone who was relying on nebula-dependency-recommender for some other purpose might stop taking baseline upgrades until they manually pull it in. Seems like that's about 60 repos:

![image](https://user-images.githubusercontent.com/3473798/65772487-32e51880-e132-11e9-9724-91502e4f5a7d.png)

