### PR TITLE
keep spotless from eagerly configuring all tasks.

### DIFF
--- a/changelog/@unreleased/pr-902.v2.yml
+++ b/changelog/@unreleased/pr-902.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "Keep spotless plugin from eagerly configuring all tasks"
+  links:
+    - https://github.com/diffplug/spotless/issues/444

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -23,7 +23,9 @@ import java.nio.file.Path;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
 
 class BaselineFormat extends AbstractBaselinePlugin {
@@ -40,7 +42,8 @@ class BaselineFormat extends AbstractBaselinePlugin {
             project.getPluginManager().apply("com.diffplug.gradle.spotless");
             Path eclipseXml = eclipseConfigFile(project);
 
-            project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
+            SpotlessExtension spotlessExtension = project.getExtensions().getByType(SpotlessExtension.class);
+            spotlessExtension.java(java -> {
                 // Configure a lazy FileCollection then pass it as the target
                 ConfigurableFileCollection allJavaFiles = project.files();
                 project
@@ -62,16 +65,26 @@ class BaselineFormat extends AbstractBaselinePlugin {
                 java.trimTrailingWhitespace();
             });
 
+            // Keep spotless from eagerly configuring all other tasks.  We do the same thing as the enforceCheck
+            // property below by making the check task depend on spotlessCheck.
+            // See  https://github.com/diffplug/spotless/issues/444
+            spotlessExtension.setEnforceCheck(false);
+
             // necessary because SpotlessPlugin creates tasks in an afterEvaluate block
-            Task formatTask = project.task("format");
+            TaskProvider<Task> formatTask = project.getTasks().register("format");
             project.afterEvaluate(p -> {
                 Task spotlessJava = project.getTasks().getByName("spotlessJava");
                 Task spotlessApply = project.getTasks().getByName("spotlessApply");
                 if (eclipseFormattingEnabled(project) && !Files.exists(eclipseXml)) {
                     spotlessJava.dependsOn(":baselineUpdateConfig");
                 }
-                formatTask.dependsOn(spotlessApply);
+                formatTask.configure(t -> {t.dependsOn(spotlessApply);});
                 project.getTasks().withType(JavaCompile.class).configureEach(spotlessJava::mustRunAfter);
+
+                //re-enable spotless checking, but lazily so it doesn't eagerly configure everything else
+                project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(t -> {
+                    t.dependsOn(project.getTasks().named("spotlessCheck"));
+                });
             });
         });
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -78,7 +78,9 @@ class BaselineFormat extends AbstractBaselinePlugin {
                 if (eclipseFormattingEnabled(project) && !Files.exists(eclipseXml)) {
                     spotlessJava.dependsOn(":baselineUpdateConfig");
                 }
-                formatTask.configure(t -> {t.dependsOn(spotlessApply);});
+                formatTask.configure(t -> {
+                    t.dependsOn(spotlessApply);
+                });
                 project.getTasks().withType(JavaCompile.class).configureEach(spotlessJava::mustRunAfter);
 
                 //re-enable spotless checking, but lazily so it doesn't eagerly configure everything else

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatTest.groovy
@@ -47,4 +47,24 @@ class BaselineFormatTest extends Specification {
         expect:
         project.tasks.format
     }
+
+    def spotlessPluginEagerCreationIssue() {
+        when:
+        project.buildscript {
+            repositories {
+                mavenCentral()
+            }
+
+            project.tasks.register("foo") {
+                throw new SpotlessEagerConfigException("See https://github.com/diffplug/spotless/issues/444")
+            }
+        }
+
+        then:
+        notThrown(SpotlessEagerConfigException)
+    }
+
+    static final class SpotlessEagerConfigException extends RuntimeException {
+
+    }
 }


### PR DESCRIPTION
## Before this PR
Including the baseline-format plugin would trigger eager configuration of tons of tasks due to a problem with spotless (https://github.com/diffplug/spotless/issues/444)

## After this PR
This applies the recommended fix until such time as the spotless plugin fixes the source issue.

## Possible downsides?
 

