### PR TITLE
Revert gradle upgrade until we can fix the `compileRefaster` task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,11 @@ jobs:
 
   unit-test:
     docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
-    resource_class: large
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
       CIRCLE_ARTIFACTS: /home/circleci/artifacts
-      GRADLE_OPTS: -Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=256m' -Dorg.gradle.workers.max=4
-      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1382m -XX:MaxMetaspaceSize=256m -XX:ActiveProcessorCount=2 -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xms3072m -Xmx3072m'
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=2 -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
       - attach_workspace: { at: /home/circleci }
       - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
@@ -102,8 +101,8 @@ jobs:
     environment:
       CIRCLE_TEST_REPORTS: /home/circleci/junit
       CIRCLE_ARTIFACTS: /home/circleci/artifacts
-      GRADLE_OPTS: -Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=256m' -Dorg.gradle.workers.max=4
-      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1382m -XX:MaxMetaspaceSize=256m -XX:ActiveProcessorCount=2 -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xms6144m -Xmx6144m'
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
       - checkout
       - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }

--- a/changelog/@unreleased/refaster-gradle-6.v2.yml
+++ b/changelog/@unreleased/refaster-gradle-6.v2.yml
@@ -1,6 +1,0 @@
-type: break
-break:
-  description: |
-    Refaster now works on repos using Gradle 6.0. This raises the minimum supported version of Gradle from 5.0 -> 5.4
-  links:
-  - https://github.com/palantir/gradle-baseline/pull/804

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -20,7 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.palantir.baseline.extensions.BaselineErrorProneExtension;
-import com.palantir.baseline.tasks.CompileRefasterTask;
+import com.palantir.baseline.tasks.RefasterCompileTask;
 import java.io.File;
 import java.util.AbstractList;
 import java.util.Collections;
@@ -91,8 +91,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 .file("refaster/rules.refaster")
                 .map(RegularFile::getAsFile);
 
-        CompileRefasterTask compileRefaster =
-                project.getTasks().create("compileRefaster", CompileRefasterTask.class, task -> {
+        RefasterCompileTask compileRefaster =
+                project.getTasks().create("compileRefaster", RefasterCompileTask.class, task -> {
                     task.setSource(refasterConfiguration);
                     task.getRefasterSources().set(refasterConfiguration);
                     task.setClasspath(refasterCompilerConfiguration);
@@ -170,7 +170,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
     private static void configureErrorProneOptions(
             Project project,
             Provider<File> refasterRulesFile,
-            CompileRefasterTask compileRefaster,
+            RefasterCompileTask compileRefaster,
             BaselineErrorProneExtension errorProneExtension,
             JavaCompile javaCompile,
             ErrorProneOptions errorProneOptions) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckVersionsPropsTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/CheckVersionsPropsTask.java
@@ -19,7 +19,6 @@ package com.palantir.baseline.plugins.versions;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.options.Option;
 
 public class CheckVersionsPropsTask extends DefaultTask {
@@ -36,7 +35,6 @@ public class CheckVersionsPropsTask extends DefaultTask {
         this.shouldFix.set(shouldFix);
     }
 
-    @Input
     final Provider<Boolean> getShouldFix() {
         return shouldFix;
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessTask.java
@@ -29,7 +29,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.tasks.CacheableTask;
-import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
@@ -43,7 +43,7 @@ public class CheckClassUniquenessTask extends DefaultTask {
         setDescription("Checks that the given configuration contains no identically named classes.");
     }
 
-    @Classpath
+    @InputFiles
     public final Configuration getConfiguration() {
         return configuration;
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/RefasterCompileTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/RefasterCompileTask.java
@@ -27,14 +27,13 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.work.InputChanges;
 
-public class CompileRefasterTask extends JavaCompile {
+public class RefasterCompileTask extends JavaCompile {
 
     private final Property<Configuration> refasterSources = getProject().getObjects().property(Configuration.class);
     private final Property<File> refasterRulesFile = getProject().getObjects().property(File.class);
 
-    public CompileRefasterTask() {
+    public RefasterCompileTask() {
         // Don't care about .class files
         setDestinationDir(getTemporaryDir());
 
@@ -43,7 +42,7 @@ public class CompileRefasterTask extends JavaCompile {
     }
 
     @Override
-    protected final void compile(InputChanges inputs) {
+    protected final void compile() {
         // Clear out the default error-prone providers
         getOptions().getCompilerArgumentProviders().clear();
         getOptions().setCompilerArgs(ImmutableList.of(
@@ -70,12 +69,11 @@ public class CompileRefasterTask extends JavaCompile {
 
         if (!javaSources.isEmpty()) {
             setSource(javaSources);
-            super.compile(inputs);
+            super.compile();
         } else {
             setDidWork(false);
         }
     }
-
 
     @InputFiles
     public final Property<Configuration> getRefasterSources() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -30,13 +30,11 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         plugins {
             id 'java'
             id 'com.palantir.baseline-error-prone'
-            id 'org.inferred.processors' version '3.1.0'
+            id 'org.inferred.processors' version '1.3.0'
         }
         repositories {
             mavenLocal()
             jcenter()
-            // TODO(forozco): figure out why pTML no longer works
-            maven { url  "http://palantir.bintray.com/releases" }
         }
     '''.stripIndent()
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneRefasterIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneRefasterIntegrationTest.groovy
@@ -19,6 +19,7 @@ package com.palantir.baseline
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+
 /**
  * This test depends on ./gradlew :baseline-error-prone:publishToMavenLocal
  */
@@ -28,13 +29,11 @@ class BaselineErrorProneRefasterIntegrationTest extends AbstractPluginTest {
         plugins {
             id 'java'
             id 'com.palantir.baseline-error-prone'
-            id 'org.inferred.processors' version '3.1.0'
+            id 'org.inferred.processors' version '1.3.0'
         }
         repositories {
             mavenLocal()
             jcenter()
-            // TODO(forozco): figure out why pTML no longer works
-            maven { url  "http://palantir.bintray.com/releases" }
         }
         tasks.withType(JavaCompile) {
             options.compilerArgs += ['-Werror', '-Xlint:deprecation']
@@ -55,7 +54,6 @@ class BaselineErrorProneRefasterIntegrationTest extends AbstractPluginTest {
         then:
         BuildResult result = with('compileJava', '-i', '-PrefasterApply').build()
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
-        file('build/refaster/rules.refaster').exists()
         file('src/main/java/test/Test.java').text == '''
         package test;
         import java.util.ArrayList;
@@ -119,11 +117,6 @@ class BaselineErrorProneRefasterIntegrationTest extends AbstractPluginTest {
     def 'compileJava with refaster fixes Utf8Length with deprecated method'() {
         when:
         buildFile << standardBuildFile
-        buildFile << '''
-            dependencies {
-                compile 'com.google.guava:guava:27.1-jre'
-            }
-        '''
         file('src/main/java/test/Test.java') << '''
         package test;
         import com.google.common.base.CharMatcher;

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIntegrationTest.groovy
@@ -43,6 +43,6 @@ class BaselineIntegrationTest extends AbstractPluginTest {
         with().withArguments('-s').withGradleVersion(gradleVersion).build()
 
         where:
-        gradleVersion << ['5.4', '6.0-20190904072820+0000']
+        gradleVersion << ['5.0', '6.0-20190904072820+0000']
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -24,6 +24,7 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         plugins {
             id 'java'
             id 'com.palantir.baseline-testing'
+            id 'com.palantir.consistent-versions' version '1.9.2'
         }
         
         repositories {
@@ -72,7 +73,7 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         file('src/test/java/test/TestClass5.java') << junit5Test
 
         then:
-        BuildResult result = with('test').build()
+        BuildResult result = with('test', '--write-locks').build()
         result.task(':test').outcome == TaskOutcome.SUCCESS
         new File(projectDir, "build/reports/tests/test/classes/test.TestClass4.html").exists()
         new File(projectDir, "build/reports/tests/test/classes/test.TestClass5.html").exists()
@@ -99,7 +100,7 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         file('src/integrationTest/java/test/TestClass5.java') << junit5Test
 
         then:
-        BuildResult result = with('integrationTest').build()
+        BuildResult result = with('integrationTest', '--write-locks').build()
         result.task(':integrationTest').outcome == TaskOutcome.SUCCESS
         new File(projectDir, "build/reports/tests/integrationTest/classes/test.TestClass5.html").exists()
     }
@@ -125,7 +126,7 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         file('src/integrationTest/java/test/TestClass5.java') << junit5Test
 
         then:
-        BuildResult result = with('checkJUnitDependencies').buildAndFail()
+        BuildResult result = with('checkJUnitDependencies', '--write-locks').buildAndFail()
         result.output.contains 'Some tests still use JUnit4, but Gradle has been set to use JUnit Platform'
     }
 
@@ -141,7 +142,7 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         file('src/test/java/test/TestClass5.java') << junit5Test
 
         then:
-        BuildResult result = with('checkJUnitDependencies').buildAndFail()
+        BuildResult result = with('checkJUnitDependencies', '--write-locks').buildAndFail()
         result.output.contains 'Some tests mention JUnit5, but the \'test\' task does not have useJUnitPlatform() enabled'
     }
 }

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/subproject.gradle
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/subproject.gradle
@@ -17,6 +17,7 @@
 plugins {
     id 'java'
     id 'checkstyle'
+    id 'findbugs'
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.0-20190925220032+0000-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = "gradle-baseline"
+enableFeaturePreview("STABLE_PUBLISHING")
 
 include "baseline-error-prone"
 include "baseline-refaster-javac-plugin"


### PR DESCRIPTION
Revert "Excavator: Upgrades gradle wrapper to the latest version (#804)"

This reverts commit 831e40d67482467fb75e137637d55af5ecfb3be9.

## Before this PR
```
1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':module:compileRefaster'.
> no source files
```

## After this PR
==COMMIT_MSG==
Revert gradle upgrade until we can fix the `compileRefaster` task
==COMMIT_MSG==

