### PR TITLE
Continue when RefasterRuleBuilderScanner throws

### DIFF
--- a/baseline-refaster-javac-plugin/build.gradle
+++ b/baseline-refaster-javac-plugin/build.gradle
@@ -5,6 +5,7 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
     compile 'com.google.errorprone:error_prone_refaster'
+    compile 'org.slf4j:slf4j-api'
 
     annotationProcessor 'com.google.auto.service:auto-service'
     compileOnly 'com.google.auto.service:auto-service'

--- a/baseline-refaster-javac-plugin/src/main/java/com/palantir/baseline/refaster/BaselineRefasterCompilerAnalyzer.java
+++ b/baseline-refaster-javac-plugin/src/main/java/com/palantir/baseline/refaster/BaselineRefasterCompilerAnalyzer.java
@@ -32,6 +32,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * TaskListener that receives compilation of a Refaster rule class and outputs a combined serialized analyzer
@@ -41,6 +43,7 @@ import java.util.List;
  */
 public final class BaselineRefasterCompilerAnalyzer implements TaskListener {
 
+    private static final Logger log = LoggerFactory.getLogger(BaselineRefasterCompilerAnalyzer.class);
     private final Context context;
     private final Path destinationPath;
 
@@ -72,7 +75,11 @@ public final class BaselineRefasterCompilerAnalyzer implements TaskListener {
         new TreeScanner<Void, Context>() {
             @Override
             public Void visitClass(ClassTree node, Context classContext) {
-                rules.addAll(RefasterRuleBuilderScanner.extractRules(node, classContext));
+                try {
+                    rules.addAll(RefasterRuleBuilderScanner.extractRules(node, classContext));
+                } catch (RuntimeException | Error e) {
+                    log.warn("Failed to extract rules", e);
+                }
                 return super.visitClass(node, classContext);
             }
         }.scan(tree, context);

--- a/baseline-refaster-javac-plugin/src/main/java/com/palantir/baseline/refaster/BaselineRefasterCompilerAnalyzer.java
+++ b/baseline-refaster-javac-plugin/src/main/java/com/palantir/baseline/refaster/BaselineRefasterCompilerAnalyzer.java
@@ -32,8 +32,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * TaskListener that receives compilation of a Refaster rule class and outputs a combined serialized analyzer

--- a/changelog/@unreleased/pr-904.v2.yml
+++ b/changelog/@unreleased/pr-904.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Continue when RefasterRuleBuilderScanner throws
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/904


### PR DESCRIPTION
This seems to occur when builds apply a version-specific tools.jar
to the classpath, which is uncommon, but compilation should continue
to search for refaster rules.

## Before this PR
Builds failed with access problems despite compilation being successful.

## After this PR
==COMMIT_MSG==
Continue when RefasterRuleBuilderScanner throws
==COMMIT_MSG==

