### PR TITLE
Fix refaster compilation on gradle 5.x

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CompileRefasterTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CompileRefasterTask.java
@@ -27,7 +27,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.work.InputChanges;
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 
 public class CompileRefasterTask extends JavaCompile {
 
@@ -38,12 +38,15 @@ public class CompileRefasterTask extends JavaCompile {
         // Don't care about .class files
         setDestinationDir(getTemporaryDir());
 
-        // Ensure we hit the non-incremental code-path since we override it
-        getOptions().setIncremental(false);
+        // Ensure we hit the incremental code-path since we override it
+        getOptions().setIncremental(true);
     }
 
     @Override
-    protected final void compile(InputChanges inputs) {
+    // TODO(forozco): override compile(InputChanges inputs) once we can raise our minimum version 6.0
+    @SuppressWarnings("deprecated")
+    protected final void compile(IncrementalTaskInputs inputs) {
+        getProject().getLogger().warn("Doing compilation - Felipe");
         // Clear out the default error-prone providers
         getOptions().getCompilerArgumentProviders().clear();
         getOptions().setCompilerArgs(ImmutableList.of(


### PR DESCRIPTION
## Before this PR
We were overriding a compilation method that only exists in gradle 6.0, causing usage from gradle 5.x to not work 

## After this PR
Correctly override a compilation method available in 5.0 and 6.0.

This actually means we don't need to raise our minimum version of gradle

## Possible downsides?
N/A

