### PR TITLE
Added Refaster Rule for Optional 'hasValue' Assert

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Optional;
+
+public class AssertjOptionalHasValue<T> {
+
+    @BeforeTemplate
+    void before(Optional<T> thing, T expected) {
+        assertThat(thing.get()).isEqualTo(expected);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Optional<T> thing, T expected) {
+        assertThat(thing).hasValue(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
@@ -24,7 +24,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Optional;
 
-public class AssertjOptionalHasValue<T> {
+public final class AssertjOptionalHasValue<T> {
 
     @BeforeTemplate
     void before(Optional<T> thing, T expected) {

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Optional;
+
+public class AssertjOptionalHasValueWithDescription<T> {
+
+    @BeforeTemplate
+    void before(Optional<T> thing, T expected, String description) {
+        assertThat(thing.get()).describedAs(description).isEqualTo(expected);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Optional<T> thing, T expected, String description) {
+        assertThat(thing).describedAs(description).hasValue(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
@@ -24,7 +24,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Optional;
 
-public class AssertjOptionalHasValueWithDescription<T> {
+public final class AssertjOptionalHasValueWithDescription<T> {
 
     @BeforeTemplate
     void before(Optional<T> thing, T expected, String description) {

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
@@ -42,4 +42,27 @@ public class AssertjOptionalHasValueTest {
                         "  }",
                         "}");
     }
+
+    @Test
+    public void testWithDescription() {
+        RefasterTestHelper
+                .forRefactoring(AssertjOptionalHasValueWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Optional;",
+                        "public class Test<T> {",
+                        "  void f(Optional<T> in, T out) {",
+                        "    assertThat(in.get()).describedAs(\"desc\").isEqualTo(out);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Optional;",
+                        "public class Test<T> {",
+                        "  void f(Optional<T> in, T out) {",
+                        "    assertThat(in).describedAs(\"desc\").hasValue(out);",
+                        "  }",
+                        "}");
+    }
 }

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
@@ -28,16 +28,16 @@ public final class AssertjOptionalHasValueTest {
                         "Test",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.Optional;",
-                        "public class Test<T> {",
-                        "  void f(Optional<T> in, T out) {",
+                        "public class Test<String> {",
+                        "  void f(Optional<String> in, String out) {",
                         "    assertThat(in.get()).isEqualTo(out);",
                         "  }",
                         "}")
                 .hasOutputLines(
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.Optional;",
-                        "public class Test<T> {",
-                        "  void f(Optional<T> in, T out) {",
+                        "public class Test<String> {",
+                        "  void f(Optional<String> in, String out) {",
                         "    assertThat(in).hasValue(out);",
                         "  }",
                         "}");
@@ -51,16 +51,16 @@ public final class AssertjOptionalHasValueTest {
                         "Test",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.Optional;",
-                        "public class Test<T> {",
-                        "  void f(Optional<T> in, T out) {",
+                        "public class Test<String> {",
+                        "  void f(Optional<String> in, String out) {",
                         "    assertThat(in.get()).describedAs(\"desc\").isEqualTo(out);",
                         "  }",
                         "}")
                 .hasOutputLines(
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.Optional;",
-                        "public class Test<T> {",
-                        "  void f(Optional<T> in, T out) {",
+                        "public class Test<String> {",
+                        "  void f(Optional<String> in, String out) {",
                         "    assertThat(in).describedAs(\"desc\").hasValue(out);",
                         "  }",
                         "}");

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjOptionalHasValueTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(AssertjOptionalHasValue.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Optional;",
+                        "public class Test<T> {",
+                        "  void f(Optional<T> in, T out) {",
+                        "    assertThat(in.get()).isEqualTo(out);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Optional;",
+                        "public class Test<T> {",
+                        "  void f(Optional<T> in, T out) {",
+                        "    assertThat(in).hasValue(out);",
+                        "  }",
+                        "}");
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
@@ -18,7 +18,7 @@ package com.palantir.baseline.refaster;
 
 import org.junit.Test;
 
-public class AssertjOptionalHasValueTest {
+public final class AssertjOptionalHasValueTest {
 
     @Test
     public void test() {

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
@@ -16,12 +16,17 @@
 
 package com.palantir.baseline.refaster;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import org.junit.Test;
 
 public final class AssertjOptionalHasValueTest {
 
     @Test
     public void test() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
         RefasterTestHelper
                 .forRefactoring(AssertjOptionalHasValue.class)
                 .withInputLines(
@@ -45,6 +50,9 @@ public final class AssertjOptionalHasValueTest {
 
     @Test
     public void testWithDescription() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
         RefasterTestHelper
                 .forRefactoring(AssertjOptionalHasValueWithDescription.class)
                 .withInputLines(

--- a/changelog/@unreleased/refaster-rule-optional-hasvalue.v2.yml
+++ b/changelog/@unreleased/refaster-rule-optional-hasvalue.v2.yml
@@ -1,0 +1,4 @@
+type: improvement
+improvement:
+  description: |
+    Added a Refaster rule to change `isEqualTo` checks into `hasValue` checks


### PR DESCRIPTION
// cc @carterkozak 

## After this PR
Added refaster rule for optionals `hasValue` assert, replaces `isEqualsTo` with `hasValue`
