### PR TITLE
AssertJ refasters for some integer inequalities

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjGreaterThan.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjGreaterThan.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjGreaterThan {
+
+    @BeforeTemplate
+    public void before1(int left, int right) {
+        assertThat(left > right).isTrue();
+    }
+
+    @BeforeTemplate
+    public void before2(int left, int right) {
+        assertThat(left <= right).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    public void after(int left, int right) {
+        assertThat(left).isGreaterThan(right);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjGreaterThanOrEqualTo.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjGreaterThanOrEqualTo.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjGreaterThanOrEqualTo {
+
+    @BeforeTemplate
+    public void before1(int left, int right) {
+        assertThat(left >= right).isTrue();
+    }
+
+    @BeforeTemplate
+    public void before2(int left, int right) {
+        assertThat(left < right).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    public void after(int left, int right) {
+        assertThat(left).isGreaterThanOrEqualTo(right);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjGreaterThanOrEqualToWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjGreaterThanOrEqualToWithDescription.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjGreaterThanOrEqualToWithDescription {
+
+    @BeforeTemplate
+    public void before1(int left, int right, String desc) {
+        assertThat(left >= right).describedAs(desc).isTrue();
+    }
+
+    @BeforeTemplate
+    public void before2(int left, int right, String desc) {
+        assertThat(left < right).describedAs(desc).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    public void after(int left, int right, String desc) {
+        assertThat(left).describedAs(desc).isGreaterThanOrEqualTo(right);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjGreaterThanWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjGreaterThanWithDescription.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjGreaterThanWithDescription {
+
+    @BeforeTemplate
+    public void before1(int left, int right, String desc) {
+        assertThat(left > right).describedAs(desc).isTrue();
+    }
+
+    @BeforeTemplate
+    public void before2(int left, int right, String desc) {
+        assertThat(left <= right).describedAs(desc).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    public void after(int left, int right, String desc) {
+        assertThat(left).describedAs(desc).isGreaterThan(right);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThan.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThan.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractFloatAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.NumberAssert;
+
+public final class AssertjLessThan {
+
+    @BeforeTemplate
+    public void before1(int left, int right) {
+        assertThat(left < right).isTrue();
+    }
+
+    @BeforeTemplate
+    public void before2(int left, int right) {
+        assertThat(left >= right).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    public void after(int left, int right) {
+        assertThat(left).isLessThan(right);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThan.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThan.java
@@ -19,15 +19,9 @@ package com.palantir.baseline.refaster;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.errorprone.refaster.ImportPolicy;
-import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
-import org.assertj.core.api.AbstractDoubleAssert;
-import org.assertj.core.api.AbstractFloatAssert;
-import org.assertj.core.api.AbstractIntegerAssert;
-import org.assertj.core.api.AbstractLongAssert;
-import org.assertj.core.api.NumberAssert;
 
 public final class AssertjLessThan {
 

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThanOrEqualTo.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThanOrEqualTo.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjLessThanOrEqualTo {
+
+    @BeforeTemplate
+    public void before1(int left, int right) {
+        assertThat(left <= right).isTrue();
+    }
+
+    @BeforeTemplate
+    public void before2(int left, int right) {
+        assertThat(left > right).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    public void after(int left, int right) {
+        assertThat(left).isLessThanOrEqualTo(right);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThanOrEqualToWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThanOrEqualToWithDescription.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjLessThanOrEqualToWithDescription {
+
+    @BeforeTemplate
+    public void before1(int left, int right, String desc) {
+        assertThat(left <= right).describedAs(desc).isTrue();
+    }
+
+    @BeforeTemplate
+    public void before2(int left, int right, String desc) {
+        assertThat(left > right).describedAs(desc).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    public void after(int left, int right, String desc) {
+        assertThat(left).describedAs(desc).isLessThanOrEqualTo(right);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThanWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjLessThanWithDescription.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjLessThanWithDescription {
+
+    @BeforeTemplate
+    public void before1(int left, int right, String desc) {
+        assertThat(left < right).describedAs(desc).isTrue();
+    }
+
+    @BeforeTemplate
+    public void before2(int left, int right, String desc) {
+        assertThat(left >= right).describedAs(desc).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    public void after(int left, int right, String desc) {
+        assertThat(left).describedAs(desc).isLessThan(right);
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInequalitiesTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInequalitiesTest.java
@@ -34,7 +34,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b) {",
+                        "  void test(int a, int b) {",
                         "    assertThat(a < b).isTrue();",
                         "    assertThat(a >= b).isFalse();",
                         "  }",
@@ -43,7 +43,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b) {",
+                        "  void test(int a, int b) {",
                         "    assertThat(a).isLessThan(b);",
                         "    assertThat(a).isLessThan(b);",
                         "  }",
@@ -62,7 +62,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b, String desc) {",
+                        "  void test(int a, int b, String desc) {",
                         "    assertThat(a < b).describedAs(desc).isTrue();",
                         "    assertThat(a >= b).describedAs(desc).isFalse();",
                         "  }",
@@ -71,7 +71,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b, String desc) {",
+                        "  void test(int a, int b, String desc) {",
                         "    assertThat(a).describedAs(desc).isLessThan(b);",
                         "    assertThat(a).describedAs(desc).isLessThan(b);",
                         "  }",
@@ -90,7 +90,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b) {",
+                        "  void test(int a, int b) {",
                         "    assertThat(a > b).isTrue();",
                         "    assertThat(a <= b).isFalse();",
                         "  }",
@@ -99,7 +99,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b) {",
+                        "  void test(int a, int b) {",
                         "    assertThat(a).isGreaterThan(b);",
                         "    assertThat(a).isGreaterThan(b);",
                         "  }",
@@ -118,7 +118,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b, String desc) {",
+                        "  void test(int a, int b, String desc) {",
                         "    assertThat(a > b).describedAs(desc).isTrue();",
                         "    assertThat(a <= b).describedAs(desc).isFalse();",
                         "  }",
@@ -127,7 +127,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b, String desc) {",
+                        "  void test(int a, int b, String desc) {",
                         "    assertThat(a).describedAs(desc).isGreaterThan(b);",
                         "    assertThat(a).describedAs(desc).isGreaterThan(b);",
                         "  }",
@@ -146,7 +146,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b) {",
+                        "  void test(int a, int b) {",
                         "    assertThat(a <= b).isTrue();",
                         "    assertThat(a > b).isFalse();",
                         "  }",
@@ -155,7 +155,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b) {",
+                        "  void test(int a, int b) {",
                         "    assertThat(a).isLessThanOrEqualTo(b);",
                         "    assertThat(a).isLessThanOrEqualTo(b);",
                         "  }",
@@ -174,7 +174,7 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b, String desc) {",
+                        "  void test(int a, int b, String desc) {",
                         "    assertThat(a <= b).describedAs(desc).isTrue();",
                         "    assertThat(a > b).describedAs(desc).isFalse();",
                         "  }",
@@ -183,9 +183,65 @@ public class AssertjInequalitiesTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.List;",
                         "public class Test {",
-                        "  void int_istrue(int a, int b, String desc) {",
+                        "  void test(int a, int b, String desc) {",
                         "    assertThat(a).describedAs(desc).isLessThanOrEqualTo(b);",
                         "    assertThat(a).describedAs(desc).isLessThanOrEqualTo(b);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void greater_than_or_equal_to() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjGreaterThanOrEqualTo.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void test(int a, int b) {",
+                        "    assertThat(a >= b).isTrue();",
+                        "    assertThat(a < b).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void test(int a, int b) {",
+                        "    assertThat(a).isGreaterThanOrEqualTo(b);",
+                        "    assertThat(a).isGreaterThanOrEqualTo(b);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void greater_than_or_equal_to_with_description() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjGreaterThanOrEqualToWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void test(int a, int b, String desc) {",
+                        "    assertThat(a >= b).describedAs(desc).isTrue();",
+                        "    assertThat(a < b).describedAs(desc).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void test(int a, int b, String desc) {",
+                        "    assertThat(a).describedAs(desc).isGreaterThanOrEqualTo(b);",
+                        "    assertThat(a).describedAs(desc).isGreaterThanOrEqualTo(b);",
                         "  }",
                         "}");
     }

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInequalitiesTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInequalitiesTest.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.junit.Test;
+
+public class AssertjInequalitiesTest {
+
+    @Test
+    public void less_than() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjLessThan.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b) {",
+                        "    assertThat(a < b).isTrue();",
+                        "    assertThat(a >= b).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b) {",
+                        "    assertThat(a).isLessThan(b);",
+                        "    assertThat(a).isLessThan(b);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void less_than_with_description() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjLessThanWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b, String desc) {",
+                        "    assertThat(a < b).describedAs(desc).isTrue();",
+                        "    assertThat(a >= b).describedAs(desc).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b, String desc) {",
+                        "    assertThat(a).describedAs(desc).isLessThan(b);",
+                        "    assertThat(a).describedAs(desc).isLessThan(b);",
+                        "  }",
+                        "}");
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInequalitiesTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInequalitiesTest.java
@@ -77,4 +77,60 @@ public class AssertjInequalitiesTest {
                         "  }",
                         "}");
     }
+
+    @Test
+    public void less_than_or_equal_to() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjLessThanOrEqualTo.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b) {",
+                        "    assertThat(a <= b).isTrue();",
+                        "    assertThat(a > b).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b) {",
+                        "    assertThat(a).isLessThanOrEqualTo(b);",
+                        "    assertThat(a).isLessThanOrEqualTo(b);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void less_than_or_equal_to_with_description() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjLessThanOrEqualToWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b, String desc) {",
+                        "    assertThat(a <= b).describedAs(desc).isTrue();",
+                        "    assertThat(a > b).describedAs(desc).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b, String desc) {",
+                        "    assertThat(a).describedAs(desc).isLessThanOrEqualTo(b);",
+                        "    assertThat(a).describedAs(desc).isLessThanOrEqualTo(b);",
+                        "  }",
+                        "}");
+    }
 }

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInequalitiesTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjInequalitiesTest.java
@@ -79,6 +79,62 @@ public class AssertjInequalitiesTest {
     }
 
     @Test
+    public void greater_than() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjGreaterThan.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b) {",
+                        "    assertThat(a > b).isTrue();",
+                        "    assertThat(a <= b).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b) {",
+                        "    assertThat(a).isGreaterThan(b);",
+                        "    assertThat(a).isGreaterThan(b);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void greater_than_with_description() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjGreaterThanWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b, String desc) {",
+                        "    assertThat(a > b).describedAs(desc).isTrue();",
+                        "    assertThat(a <= b).describedAs(desc).isFalse();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void int_istrue(int a, int b, String desc) {",
+                        "    assertThat(a).describedAs(desc).isGreaterThan(b);",
+                        "    assertThat(a).describedAs(desc).isGreaterThan(b);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
     public void less_than_or_equal_to() {
         assumeThat(System.getProperty("java.specification.version"))
                 .describedAs("Refaster does not currently support fluent refactors on java 11")


### PR DESCRIPTION
## Before this PR

Excavator did this to the timelock repo:

<img width="1405" alt="Screenshot 2019-09-30 at 19 30 29" src="https://user-images.githubusercontent.com/3473798/65905642-d8112280-e3b8-11e9-98df-0ccf2ee88275.png">

## After this PR
==COMMIT_MSG==
Refaster rules will automatically convert inequalities like `assertThat(a < b).isTrue()` to the easier to debug form: `assertThat(a).isLessThan(b)`
==COMMIT_MSG==

## Possible downsides?

- there is a lot of code and it still doesn't cover longs, floats, doubles. starting to feel like refaster might not be the right tool for the job here.

