### PR TITLE
Assertj refasters for array equality

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjArrayEquals.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjArrayEquals.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Arrays;
+
+public final class AssertjArrayEquals {
+
+    @BeforeTemplate
+    void before(byte[] actual, byte[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(byte[] actual, byte[] expected) {
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjArrayEquals.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjArrayEquals.java
@@ -27,13 +27,48 @@ import java.util.Arrays;
 public final class AssertjArrayEquals {
 
     @BeforeTemplate
-    void before(byte[] actual, byte[] expected) {
+    void bytes(byte[] actual, byte[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void shorts(short[] actual, short[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void ints(int[] actual, int[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void longs(long[] actual, long[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void floats(float[] actual, float[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void doubles(double[] actual, double[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void chars(char[] actual, char[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
+    @BeforeTemplate
+    void booleans(boolean[] actual, boolean[] expected) {
         assertThat(Arrays.equals(actual, expected)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
-    void after(byte[] actual, byte[] expected) {
+    <T> void after(T[] actual, T[] expected) {
         assertThat(actual).isEqualTo(expected);
     }
 }

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjArrayEquals.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjArrayEquals.java
@@ -66,6 +66,11 @@ public final class AssertjArrayEquals {
         assertThat(Arrays.equals(actual, expected)).isTrue();
     }
 
+    @BeforeTemplate
+    <T> void arbitraryObjects(T[] actual, T[] expected) {
+        assertThat(Arrays.equals(actual, expected)).isTrue();
+    }
+
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     <T> void after(T[] actual, T[] expected) {

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjArrayEqualsTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjArrayEqualsTest.java
@@ -180,4 +180,23 @@ public class AssertjArrayEqualsTest {
                         "  void f(boolean[] a, boolean[] b) { assertThat(a).isEqualTo(b); }",
                         "}");
     }
+
+    @Test
+    public void strings() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(String[] a, String[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(String[] a, String[] b) { assertThat(a).isEqualTo(b); }",
+                        "}");
+    }
 }

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjArrayEqualsTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjArrayEqualsTest.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class AssertjArrayEqualsTest {
+    @Test
+    public void sanity_check() {
+        byte[] bytes = {1, 2, 3};
+        // both of these work, but I think isEqualTo reads a bit more nicely
+        assertThat(bytes).isEqualTo(new byte[]{1, 2, 3});
+        assertThat(bytes).containsExactly(new byte[]{1, 2, 3});
+    }
+
+    @Test
+    public void array_of_bytes() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(byte[] a, byte[] b) {",
+                        "    assertThat(Arrays.equals(a,b)).isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(byte[] a, byte[] b) {",
+                        "    assertThat(a).isEqualTo(b);",
+                        "  }",
+                        "}");
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjArrayEqualsTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjArrayEqualsTest.java
@@ -30,7 +30,7 @@ public class AssertjArrayEqualsTest {
     }
 
     @Test
-    public void array_of_bytes() {
+    public void bytes() {
         RefasterTestHelper
                 .forRefactoring(AssertjArrayEquals.class)
                 .withInputLines(
@@ -38,17 +38,146 @@ public class AssertjArrayEqualsTest {
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.Arrays;",
                         "public class Test {",
-                        "  void f(byte[] a, byte[] b) {",
-                        "    assertThat(Arrays.equals(a,b)).isTrue();",
-                        "  }",
+                        "  void f(byte[] a, byte[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
                         "}")
                 .hasOutputLines(
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.Arrays;",
                         "public class Test {",
-                        "  void f(byte[] a, byte[] b) {",
-                        "    assertThat(a).isEqualTo(b);",
-                        "  }",
+                        "  void f(byte[] a, byte[] b) { assertThat(a).isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void shorts() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(short[] a, short[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(short[] a, short[] b) { assertThat(a).isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void ints() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(int[] a, int[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(int[] a, int[] b) { assertThat(a).isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void longs() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(long[] a, long[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(long[] a, long[] b) { assertThat(a).isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void floats() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(float[] a, float[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(float[] a, float[] b) { assertThat(a).isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void doubles() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(double[] a, double[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(double[] a, double[] b) { assertThat(a).isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void chars() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(char[] a, char[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(char[] a, char[] b) { assertThat(a).isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void booleans() {
+        RefasterTestHelper
+                .forRefactoring(AssertjArrayEquals.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(boolean[] a, boolean[] b) { assertThat(Arrays.equals(a,b)).isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Arrays;",
+                        "public class Test {",
+                        "  void f(boolean[] a, boolean[] b) { assertThat(a).isEqualTo(b); }",
                         "}");
     }
 }


### PR DESCRIPTION
## Before this PR

Excavator did this to timelock:

![image](https://user-images.githubusercontent.com/3473798/65907959-4c4dc500-e3bd-11e9-8309-1330353d5e45.png)

## After this PR
==COMMIT_MSG==
AssertJ refasters for array equality
==COMMIT_MSG==

## Possible downsides?
N/A

