### PR TITLE
Allow static imports of AssertJ and Mockito

### DIFF
--- a/changelog/@unreleased/pr-915.v2.yml
+++ b/changelog/@unreleased/pr-915.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Baseline now allows static imports of AssertJ and Mockito methods.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/915

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -84,11 +84,13 @@
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
             <property name="excludes" value="
+                com.google.common.base.Preconditions.*,
+                com.palantir.logsafe.Preconditions.*,
                 java.util.Collections.*,
                 java.util.stream.Collectors.*,
-                com.palantir.logsafe.Preconditions.*,
-                com.google.common.base.Preconditions.*,
-                org.apache.commons.lang3.Validate.*"/>
+                org.apache.commons.lang3.Validate.*,
+                org.assertj.core.api.Assertions.*,
+                org.mockito.Mockito.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>


### PR DESCRIPTION
## Before this PR
It's common to have a test utility project which is a test dependency in other projects. We currently allow static imports in tests (#240) but that does not apply to test utility projects since they are main sources.

This paper cut is aggravated by the `PreferAssertJ` check (#841) which static imports AssertJ methods. Doing this causes automated baseline upgrades to require manual intervention to successfully compile.

## After this PR
We allow static imports of AssertJ and Mockito methods.