### PR TITLE
extra AssertjOptionalHasValue case

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
@@ -36,6 +36,12 @@ public final class AssertjOptionalHasValue<T> {
         assertThat(optional.isPresent() && optional.get().equals(innerValue)).isTrue();
     }
 
+    @BeforeTemplate
+    void before3(Optional<T> optional, T innerValue) {
+        assertThat(optional.isPresent()).isTrue();
+        assertThat(optional.get().equals(innerValue)).isTrue();
+    }
+
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(Optional<T> optional, T innerValue) {

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
@@ -42,6 +42,18 @@ public final class AssertjOptionalHasValue<T> {
         assertThat(optional.get().equals(innerValue)).isTrue();
     }
 
+    @BeforeTemplate
+    void before4(Optional<T> optional, T innerValue) {
+        assertThat(optional.isPresent()).isTrue();
+        assertThat(optional.get()).isEqualTo(innerValue);
+    }
+
+    @BeforeTemplate
+    void before5(Optional<T> optional, T innerValue) {
+        assertThat(optional.isPresent()).isTrue();
+        assertThat(optional).hasValue(innerValue);
+    }
+
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(Optional<T> optional, T innerValue) {

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValue.java
@@ -37,20 +37,8 @@ public final class AssertjOptionalHasValue<T> {
     }
 
     @BeforeTemplate
-    void before3(Optional<T> optional, T innerValue) {
-        assertThat(optional.isPresent()).isTrue();
-        assertThat(optional.get().equals(innerValue)).isTrue();
-    }
-
-    @BeforeTemplate
-    void before4(Optional<T> optional, T innerValue) {
-        assertThat(optional.isPresent()).isTrue();
-        assertThat(optional.get()).isEqualTo(innerValue);
-    }
-
-    @BeforeTemplate
-    void before5(Optional<T> optional, T innerValue) {
-        assertThat(optional.isPresent()).isTrue();
+    void redundantAssertion(Optional<T> optional, T innerValue) {
+        assertThat(optional).isPresent();
         assertThat(optional).hasValue(innerValue);
     }
 

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
@@ -37,20 +37,8 @@ public final class AssertjOptionalHasValueWithDescription<T> {
     }
 
     @BeforeTemplate
-    void before3(Optional<T> optional, T innerValue, String description) {
-        assertThat(optional.isPresent()).describedAs(description).isTrue();
-        assertThat(optional.get().equals(innerValue)).describedAs(description).isTrue();
-    }
-
-    @BeforeTemplate
-    void before4(Optional<T> optional, T innerValue, String description) {
-        assertThat(optional.isPresent()).describedAs(description).isTrue();
-        assertThat(optional.get()).describedAs(description).isEqualTo(innerValue);
-    }
-
-    @BeforeTemplate
-    void before5(Optional<T> optional, T innerValue, String description) {
-        assertThat(optional.isPresent()).describedAs(description).isTrue();
+    void redundantAssertion(Optional<T> optional, T innerValue, String description) {
+        assertThat(optional).describedAs(description).isPresent();
         assertThat(optional).describedAs(description).hasValue(innerValue);
     }
 

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
@@ -36,6 +36,12 @@ public final class AssertjOptionalHasValueWithDescription<T> {
         assertThat(optional.isPresent() && optional.get().equals(innerValue)).describedAs(description).isTrue();
     }
 
+    @BeforeTemplate
+    void before3(Optional<T> optional, T innerValue, String description) {
+        assertThat(optional.isPresent()).describedAs(description).isTrue();
+        assertThat(optional.get().equals(innerValue)).describedAs(description).isTrue();
+    }
+
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(Optional<T> optional, T innerValue, String description) {

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjOptionalHasValueWithDescription.java
@@ -42,6 +42,18 @@ public final class AssertjOptionalHasValueWithDescription<T> {
         assertThat(optional.get().equals(innerValue)).describedAs(description).isTrue();
     }
 
+    @BeforeTemplate
+    void before4(Optional<T> optional, T innerValue, String description) {
+        assertThat(optional.isPresent()).describedAs(description).isTrue();
+        assertThat(optional.get()).describedAs(description).isEqualTo(innerValue);
+    }
+
+    @BeforeTemplate
+    void before5(Optional<T> optional, T innerValue, String description) {
+        assertThat(optional.isPresent()).describedAs(description).isTrue();
+        assertThat(optional).describedAs(description).hasValue(innerValue);
+    }
+
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(Optional<T> optional, T innerValue, String description) {

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
@@ -37,6 +37,8 @@ public final class AssertjOptionalHasValueTest {
                         "  void f(Optional<String> in, String out) {",
                         "    assertThat(in.get()).isEqualTo(out);",
                         "    assertThat(in.isPresent() && in.get().equals(out)).isTrue();",
+                        "    assertThat(in.isPresent()).isTrue();",
+                        "    assertThat(in.get().equals(out)).isTrue();",
                         "  }",
                         "}")
                 .hasOutputLines(
@@ -44,6 +46,7 @@ public final class AssertjOptionalHasValueTest {
                         "import java.util.Optional;",
                         "public class Test<String> {",
                         "  void f(Optional<String> in, String out) {",
+                        "    assertThat(in).hasValue(out);",
                         "    assertThat(in).hasValue(out);",
                         "    assertThat(in).hasValue(out);",
                         "  }",
@@ -65,6 +68,8 @@ public final class AssertjOptionalHasValueTest {
                         "  void f(Optional<String> in, String out) {",
                         "    assertThat(in.get()).describedAs(\"desc\").isEqualTo(out);",
                         "    assertThat(in.isPresent() && in.get().equals(out)).describedAs(\"desc\").isTrue();",
+                        "    assertThat(in.isPresent()).describedAs(\"desc\").isTrue();",
+                        "    assertThat(in.get().equals(out)).describedAs(\"desc\").isTrue();",
                         "  }",
                         "}")
                 .hasOutputLines(
@@ -72,6 +77,7 @@ public final class AssertjOptionalHasValueTest {
                         "import java.util.Optional;",
                         "public class Test<String> {",
                         "  void f(Optional<String> in, String out) {",
+                        "    assertThat(in).describedAs(\"desc\").hasValue(out);",
                         "    assertThat(in).describedAs(\"desc\").hasValue(out);",
                         "    assertThat(in).describedAs(\"desc\").hasValue(out);",
                         "  }",

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjOptionalHasValueTest.java
@@ -37,8 +37,10 @@ public final class AssertjOptionalHasValueTest {
                         "  void f(Optional<String> in, String out) {",
                         "    assertThat(in.get()).isEqualTo(out);",
                         "    assertThat(in.isPresent() && in.get().equals(out)).isTrue();",
-                        "    assertThat(in.isPresent()).isTrue();",
-                        "    assertThat(in.get().equals(out)).isTrue();",
+                        "  }",
+                        "  void g(Optional<String> in, String out) {",
+                        "    assertThat(in).isPresent();",
+                        "    assertThat(in).hasValue(out);",
                         "  }",
                         "}")
                 .hasOutputLines(
@@ -48,7 +50,10 @@ public final class AssertjOptionalHasValueTest {
                         "  void f(Optional<String> in, String out) {",
                         "    assertThat(in).hasValue(out);",
                         "    assertThat(in).hasValue(out);",
+                        "  }",
+                        "  void g(Optional<String> in, String out) {",
                         "    assertThat(in).hasValue(out);",
+                        "    ",
                         "  }",
                         "}");
     }
@@ -68,8 +73,10 @@ public final class AssertjOptionalHasValueTest {
                         "  void f(Optional<String> in, String out) {",
                         "    assertThat(in.get()).describedAs(\"desc\").isEqualTo(out);",
                         "    assertThat(in.isPresent() && in.get().equals(out)).describedAs(\"desc\").isTrue();",
-                        "    assertThat(in.isPresent()).describedAs(\"desc\").isTrue();",
-                        "    assertThat(in.get().equals(out)).describedAs(\"desc\").isTrue();",
+                        "  }",
+                        "  void g(Optional<String> in, String out) {",
+                        "    assertThat(in).describedAs(\"desc\").isPresent();",
+                        "    assertThat(in).describedAs(\"desc\").hasValue(out);",
                         "  }",
                         "}")
                 .hasOutputLines(
@@ -79,7 +86,10 @@ public final class AssertjOptionalHasValueTest {
                         "  void f(Optional<String> in, String out) {",
                         "    assertThat(in).describedAs(\"desc\").hasValue(out);",
                         "    assertThat(in).describedAs(\"desc\").hasValue(out);",
+                        "  }",
+                        "  void g(Optional<String> in, String out) {",
                         "    assertThat(in).describedAs(\"desc\").hasValue(out);",
+                        "    ",
                         "  }",
                         "}");
     }


### PR DESCRIPTION
I saw some of our internal repos actually do this two-stage assert on optionals. Taking it down to one line gives you better error messages (and I think is more readable).