### PR TITLE
Add assertj refaster rules for map size asserts

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapHasSizeExactly.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapHasSizeExactly.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Map;
+
+public final class AssertjMapHasSizeExactly<K, V> {
+
+    @BeforeTemplate
+    void before1(Map<K, V> things, int size) {
+        assertThat(things.size() == size).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(Map<K, V> things, int size) {
+        assertThat(things.size()).isEqualTo(size);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Map<K, V> things, int size) {
+        assertThat(things).hasSize(size);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapHasSizeExactlyWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapHasSizeExactlyWithDescription.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Map;
+
+public final class AssertjMapHasSizeExactlyWithDescription<K, V> {
+
+    @BeforeTemplate
+    void before1(Map<K, V> things, int size, String description) {
+        assertThat(things.size() == size).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(Map<K, V> things, int size, String description) {
+        assertThat(things.size()).describedAs(description).isEqualTo(size);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Map<K, V> things, int size, String description) {
+        assertThat(things).describedAs(description).hasSize(size);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapIsEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapIsEmpty.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Map;
+
+public final class AssertjMapIsEmpty<K, V> {
+
+    @BeforeTemplate
+    void before1(Map<K, V> things) {
+        assertThat(things.size() == 0).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(Map<K, V> things) {
+        assertThat(things.isEmpty()).isTrue();
+    }
+
+    @BeforeTemplate
+    void before3(Map<K, V> things) {
+        assertThat(things.size()).isZero();
+    }
+
+    @BeforeTemplate
+    void before4(Map<K, V> things) {
+        assertThat(things.size()).isEqualTo(0);
+    }
+
+    @BeforeTemplate
+    void before5(Map<K, V> things) {
+        assertThat(things).hasSize(0);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Map<K, V> things) {
+        assertThat(things).isEmpty();
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapIsEmpty2.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapIsEmpty2.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Collections;
+import org.assertj.core.api.MapAssert;
+
+public final class AssertjMapIsEmpty2<A extends MapAssert<K, V>, K, V> {
+
+    @BeforeTemplate
+    void before1(A in) {
+        in.hasSize(0);
+    }
+
+    @BeforeTemplate
+    void before2(A in) {
+        in.isEqualTo(Refaster.anyOf(
+                ImmutableMap.of(),
+                Collections.emptyMap()));
+    }
+
+    @AfterTemplate
+    void after(A in) {
+        in.isEmpty();
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapIsEmptyWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapIsEmptyWithDescription.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Map;
+
+public final class AssertjMapIsEmptyWithDescription<K, V> {
+
+    @BeforeTemplate
+    void before1(Map<K, V> things, String description) {
+        assertThat(things.size() == 0).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(Map<K, V> things, String description) {
+        assertThat(things.isEmpty()).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    void before3(Map<K, V> things, String description) {
+        assertThat(things.size()).describedAs(description).isZero();
+    }
+
+    @BeforeTemplate
+    void before4(Map<K, V> things, String description) {
+        assertThat(things.size()).describedAs(description).isEqualTo(0);
+    }
+
+    @BeforeTemplate
+    void before5(Map<K, V> things, String description) {
+        assertThat(things).describedAs(description).hasSize(0);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Map<K, V> things, String description) {
+        assertThat(things).describedAs(description).isEmpty();
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapHasSizeTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapHasSizeTest.java
@@ -1,0 +1,76 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjMapHasSizeTest {
+
+    @Test
+    public void exactSize_simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjMapHasSizeExactly.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in.size() == 2).isTrue();",
+                        "    assertThat(in.size()).isEqualTo(2);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in).hasSize(2);",
+                        "    assertThat(in).hasSize(2);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void exactSize_description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjMapHasSizeExactlyWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.Collections;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in.size() == 2).describedAs(\"desc\").isTrue();",
+                        "    assertThat(in.size()).describedAs(\"desc\").isEqualTo(2);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.Collections;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in).describedAs(\"desc\").hasSize(2);",
+                        "    assertThat(in).describedAs(\"desc\").hasSize(2);",
+                        "  }",
+                        "}");
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapIsEmptyTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapIsEmptyTest.java
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.junit.Test;
+
+public class AssertjMapIsEmptyTest {
+
+    @Test
+    public void simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjMapIsEmpty.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in.size() == 0).isTrue();",
+                        "    assertThat(in.isEmpty()).isTrue();",
+                        "    assertThat(in.size()).isEqualTo(0);",
+                        "    assertThat(in.size()).isZero();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjMapIsEmptyWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in.size() == 0).describedAs(\"desc\").isTrue();",
+                        "    assertThat(in.isEmpty()).describedAs(\"desc\").isTrue();",
+                        "    assertThat(in.size()).describedAs(\"desc\").isEqualTo(0);",
+                        "    assertThat(in.size()).describedAs(\"desc\").isZero();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void test2() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjMapIsEmpty2.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableMap;",
+                        "import java.util.Collections;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in).hasSize(0);",
+                        "    assertThat(in).isEqualTo(ImmutableMap.of());",
+                        "    assertThat(in).isEqualTo(Collections.emptyMap());",
+                        "    assertThat(in).describedAs(\"desc\").hasSize(0);",
+                        "    assertThat(in).describedAs(\"desc\").isEqualTo(ImmutableMap.of());",
+                        "    assertThat(in).describedAs(\"desc\").isEqualTo(Collections.emptyMap());",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableMap;",
+                        "import java.util.Collections;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "  }",
+                        "}");
+    }
+
+}

--- a/changelog/@unreleased/pr-919.v2.yml
+++ b/changelog/@unreleased/pr-919.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add assertj refaster rules for map size asserts
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/919


### PR DESCRIPTION
Rules are based on the collection and iterable variants.

==COMMIT_MSG==
Add assertj refaster rules for map size asserts
==COMMIT_MSG==

