### PR TITLE
Use Mockito verifyNoInteractions over deprecated verifyZeroInteractions

### DIFF
--- a/baseline-refaster-rules/build.gradle
+++ b/baseline-refaster-rules/build.gradle
@@ -6,6 +6,7 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 dependencies {
     implementation 'com.google.errorprone:error_prone_refaster'
     implementation 'org.assertj:assertj-core'
+    implementation 'org.mockito:mockito-core'
 
     testCompile 'junit:junit'
     testCompile project(':baseline-refaster-testing')

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/MockitoVerifyNoInteractions.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/MockitoVerifyNoInteractions.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Repeated;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class MockitoVerifyNoInteractions {
+
+    @BeforeTemplate
+    @SuppressWarnings("deprecation")
+    // must use @Repeated for varargs per https://github.com/google/error-prone/issues/568
+    void before(@Repeated Object varargs) {
+        verifyZeroInteractions(varargs);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(@Repeated Object varargs) {
+        verifyNoInteractions(varargs);
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/MockitoVerifyNoInteractionsTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/MockitoVerifyNoInteractionsTest.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class MockitoVerifyNoInteractionsTest {
+
+    @Test
+    public void testSingleArg() {
+        RefasterTestHelper
+                .forRefactoring(MockitoVerifyNoInteractions.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.mockito.Mockito.verifyZeroInteractions;",
+                        "public class Test {",
+                        "  void test(Object mock) {",
+                        "    verifyZeroInteractions(mock);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.mockito.Mockito.verifyNoInteractions;",
+                        "import static org.mockito.Mockito.verifyZeroInteractions;",
+                        "public class Test {",
+                        "  void test(Object mock) {",
+                        "    verifyNoInteractions(mock);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void testMultipleArgs() {
+        RefasterTestHelper
+                .forRefactoring(MockitoVerifyNoInteractions.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.mockito.Mockito.verifyZeroInteractions;",
+                        "public class Test {",
+                        "  void test(Object mock1, Object mock2) {",
+                        "    verifyZeroInteractions(mock1, mock2);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.mockito.Mockito.verifyNoInteractions;",
+                        "import static org.mockito.Mockito.verifyZeroInteractions;",
+                        "public class Test {",
+                        "  void test(Object mock1, Object mock2) {",
+                        "    verifyNoInteractions(mock1, mock2);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void testVarArgs() {
+        RefasterTestHelper
+                .forRefactoring(MockitoVerifyNoInteractions.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.mockito.Mockito.verifyZeroInteractions;",
+                        "public class Test {",
+                        "  void test(Object... mocks) {",
+                        "    verifyZeroInteractions(mocks);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.mockito.Mockito.verifyNoInteractions;",
+                        "import static org.mockito.Mockito.verifyZeroInteractions;",
+                        "public class Test {",
+                        "  void test(Object... mocks) {",
+                        "    verifyNoInteractions(mocks);",
+                        "  }",
+                        "}");
+    }
+}

--- a/changelog/@unreleased/pr-924.v2.yml
+++ b/changelog/@unreleased/pr-924.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use Mockito verifyNoInteractions over deprecated verifyZeroInteractions
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/924


### PR DESCRIPTION
## Before this PR
Mockito deprecated `verifyZeroInteractions` in favor of `verifyNoInteractions` in Mockito 3.0.1 via https://github.com/mockito/mockito/pull/1733

## After this PR
==COMMIT_MSG==
Use Mockito verifyNoInteractions over deprecated verifyZeroInteractions
==COMMIT_MSG==

## Possible downsides?
The after refactor requires Mockito 3.0.1+ to succeed

