### PR TITLE
Implement assertj map refactors for containsKey and containsEntry

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsEntry.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsEntry.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Map;
+
+public final class AssertjMapContainsEntry<K, V> {
+
+    @BeforeTemplate
+    void before(Map<K, V> things, K key, V expectedValue) {
+        assertThat(things.get(key)).isEqualTo(expectedValue);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Map<K, V> things, K key, V expectedValue) {
+        assertThat(things).containsEntry(key, expectedValue);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsEntryWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsEntryWithDescription.java
@@ -21,19 +21,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.errorprone.refaster.ImportPolicy;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Map;
 
 public final class AssertjMapContainsEntryWithDescription<K, V> {
 
     @BeforeTemplate
-    void before(Map<K, V> things, K key, V expectedValue, String description) {
-        assertThat(things.get(key)).describedAs(description).isEqualTo(expectedValue);
+    void before(Map<K, V> things, K key, V expectedValue, String description, @Repeated Object descriptionArgs) {
+        assertThat(things.get(key)).describedAs(description, descriptionArgs).isEqualTo(expectedValue);
     }
 
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
-    void after(Map<K, V> things, K key, V expectedValue, String description) {
-        assertThat(things).describedAs(description).containsEntry(key, expectedValue);
+    void after(Map<K, V> things, K key, V expectedValue, String description, @Repeated Object descriptionArgs) {
+        assertThat(things).describedAs(description, descriptionArgs).containsEntry(key, expectedValue);
     }
 }

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsEntryWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsEntryWithDescription.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Map;
+
+public final class AssertjMapContainsEntryWithDescription<K, V> {
+
+    @BeforeTemplate
+    void before(Map<K, V> things, K key, V expectedValue, String description) {
+        assertThat(things.get(key)).describedAs(description).isEqualTo(expectedValue);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Map<K, V> things, K key, V expectedValue, String description) {
+        assertThat(things).describedAs(description).containsEntry(key, expectedValue);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsKey.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsKey.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Map;
+
+public final class AssertjMapContainsKey<K, V> {
+
+    @BeforeTemplate
+    void before1(Map<K, V> things, K key) {
+        assertThat(things.containsKey(key)).isTrue();
+    }
+
+    @BeforeTemplate
+    @SuppressWarnings("RedundantCollectionOperation") // It's what we're fixing
+    void before2(Map<K, V> things, K key) {
+        assertThat(things.keySet().contains(key)).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Map<K, V> things, K key) {
+        assertThat(things).containsKey(key);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsKeyWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsKeyWithDescription.java
@@ -21,25 +21,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.errorprone.refaster.ImportPolicy;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Map;
 
 public final class AssertjMapContainsKeyWithDescription<K, V> {
 
     @BeforeTemplate
-    void before1(Map<K, V> things, K key, String description) {
-        assertThat(things.containsKey(key)).describedAs(description).isTrue();
+    void before1(Map<K, V> things, K key, String description, @Repeated Object descriptionArgs) {
+        assertThat(things.containsKey(key)).describedAs(description, descriptionArgs).isTrue();
     }
 
     @BeforeTemplate
     @SuppressWarnings("RedundantCollectionOperation") // It's what we're fixing
-    void before2(Map<K, V> things, K key, String description) {
-        assertThat(things.keySet().contains(key)).describedAs(description).isTrue();
+    void before2(Map<K, V> things, K key, String description, @Repeated Object descriptionArgs) {
+        assertThat(things.keySet().contains(key)).describedAs(description, descriptionArgs).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
-    void after(Map<K, V> things, K key, String description) {
-        assertThat(things).describedAs(description).containsKey(key);
+    void after(Map<K, V> things, K key, String description, @Repeated Object descriptionArgs) {
+        assertThat(things).describedAs(description, descriptionArgs).containsKey(key);
     }
 }

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsKeyWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjMapContainsKeyWithDescription.java
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Map;
+
+public final class AssertjMapContainsKeyWithDescription<K, V> {
+
+    @BeforeTemplate
+    void before1(Map<K, V> things, K key, String description) {
+        assertThat(things.containsKey(key)).describedAs(description).isTrue();
+    }
+
+    @BeforeTemplate
+    @SuppressWarnings("RedundantCollectionOperation") // It's what we're fixing
+    void before2(Map<K, V> things, K key, String description) {
+        assertThat(things.keySet().contains(key)).describedAs(description).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    void after(Map<K, V> things, K key, String description) {
+        assertThat(things).describedAs(description).containsKey(key);
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapContainsEntryTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapContainsEntryTest.java
@@ -16,12 +16,17 @@
 
 package com.palantir.baseline.refaster;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import org.junit.Test;
 
 public class AssertjMapContainsEntryTest {
 
     @Test
     public void simple() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
         RefasterTestHelper
                 .forRefactoring(AssertjMapContainsEntry.class)
                 .withInputLines(
@@ -45,6 +50,9 @@ public class AssertjMapContainsEntryTest {
 
     @Test
     public void description() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
         RefasterTestHelper
                 .forRefactoring(AssertjMapContainsEntryWithDescription.class)
                 .withInputLines(

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapContainsEntryTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapContainsEntryTest.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjMapContainsEntryTest {
+
+    @Test
+    public void simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjMapContainsEntry.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, Object> in, String key, Object expected) {",
+                        "    assertThat(in.get(key)).isEqualTo(expected);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, Object> in, String key, Object expected) {",
+                        "    assertThat(in).containsEntry(key, expected);",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjMapContainsEntryWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, Object> in, String key, Object expected) {",
+                        "    assertThat(in.get(key)).describedAs(\"desc\").isEqualTo(expected);",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, Object> in, String key, Object expected) {",
+                        "    assertThat(in).describedAs(\"desc\").containsEntry(key, expected);",
+                        "  }",
+                        "}");
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapContainsKeyTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjMapContainsKeyTest.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjMapContainsKeyTest {
+
+    @Test
+    public void simple() {
+        RefasterTestHelper
+                .forRefactoring(AssertjMapContainsKey.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in.keySet().contains(\"foo\")).isTrue();",
+                        "    assertThat(in.containsKey(\"foo\")).isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in).containsKey(\"foo\");",
+                        "    assertThat(in).containsKey(\"foo\");",
+                        "  }",
+                        "}");
+    }
+
+    @Test
+    public void description() {
+        RefasterTestHelper
+                .forRefactoring(AssertjMapContainsKeyWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in.keySet().contains(\"foo\")).describedAs(\"desc\").isTrue();",
+                        "    assertThat(in.containsKey(\"foo\")).describedAs(\"desc\").isTrue();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> in) {",
+                        "    assertThat(in).describedAs(\"desc\").containsKey(\"foo\");",
+                        "    assertThat(in).describedAs(\"desc\").containsKey(\"foo\");",
+                        "  }",
+                        "}");
+    }
+}

--- a/changelog/@unreleased/pr-925.v2.yml
+++ b/changelog/@unreleased/pr-925.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement assertj map refactors for containsKey and containsEntry
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/925


### PR DESCRIPTION
```diff
- assertThat(in.get(key)).isEqualTo(expected);
+ assertThat(in).containsEntry(key, expected);
```

```diff
- assertThat(in.containsKey("foo")).isTrue();
+ assertThat(in).containsKey("foo");
```

## After this PR
==COMMIT_MSG==
Implement assertj map refactors for containsKey and containsEntry
==COMMIT_MSG==

