### PR TITLE
Rule to refacter out String.format from describedAs

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjDescribedAsFormat.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjDescribedAsFormat.java
@@ -1,3 +1,19 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.palantir.baseline.refaster;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjDescribedAsFormat.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjDescribedAsFormat.java
@@ -1,0 +1,19 @@
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Repeated;
+import org.assertj.core.api.Descriptable;
+
+public final class AssertjDescribedAsFormat<T extends Descriptable<T>> {
+
+    @BeforeTemplate
+    public T before(T assertion, String format, @Repeated Object formatArgs) {
+        return assertion.describedAs(String.format(format, formatArgs));
+    }
+
+    @AfterTemplate
+    public T after(T assertion, String format, @Repeated Object formatArgs) {
+        return assertion.describedAs(format, formatArgs);
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjDescribedAsFormatTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjDescribedAsFormatTest.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.junit.Test;
+
+public class AssertjDescribedAsFormatTest {
+
+    @Test
+    public void test() {
+        assumeThat(System.getProperty("java.specification.version"))
+                .describedAs("Refaster does not currently support fluent refactors on java 11")
+                .isEqualTo("1.8");
+        RefasterTestHelper
+                .forRefactoring(AssertjDescribedAsFormat.class)
+                .withInputLines(
+                        "Test",
+                        "import static java.lang.String.format;",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj).isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc\").isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc %s\", \"arg\").isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(String.format(\"desc %s\", \"arg\")).isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(format(\"desc %s\", \"arg\")).isEqualTo(\"foo\");",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import static java.lang.String.format;",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(Object obj) {",
+                        "    assertThat(obj).isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc\").isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc %s\", \"arg\").isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc %s\", \"arg\").isEqualTo(\"foo\");",
+                        "    assertThat(obj).describedAs(\"desc %s\", \"arg\").isEqualTo(\"foo\");",
+                        "  }",
+                        "}");
+    }
+}

--- a/changelog/@unreleased/pr-927.v2.yml
+++ b/changelog/@unreleased/pr-927.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refaster out String.format from describedAs
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/927


### PR DESCRIPTION
AssertjDescribedAsFormat
```
- assertThat(obj).describedAs(String.format("desc %s", "arg")).isEqualTo("foo");
+ assertThat(obj).describedAs("desc %s", "arg").isEqualTo("foo");
```

==COMMIT_MSG==
Rule to refacter out String.format from describedAs
==COMMIT_MSG==

