### PR TITLE
Improve checkUnusedDependencies message

### DIFF
--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -167,6 +167,16 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.task(':sub-project-no-deps:checkImplicitDependencies').getOutcome() == TaskOutcome.SUCCESS
     }
 
+    def 'checkUnusedDependencies fails when a redundant project dep is present'() {
+        when:
+        setupMultiProject()
+
+        then:
+        BuildResult result = with(':checkUnusedDependencies', '--stacktrace').withDebug(true).buildAndFail()
+        result.output.contains "project(':sub-project-with-deps') (sub-project-with-deps.jar (project :sub-project-with-deps))"
+        result.output.contains "implementation project(':sub-project-no-deps')"
+    }
+
     /**
      * Sets up a multi-module project with 2 sub projects.  The root project has a transitive dependency on sub-project-no-deps
      * and so checkImplicitDependencies should fail on it.


### PR DESCRIPTION
## Before this PR
The `checkUnusedDependencies` error message has two deficiencies:
1. When an unused dependency has a classifier, it is not possible to distinguish between that dependency and a dependency without the classifier.
1. When depending on a project whose `default` configuration contains multiple sources sets and only some are unused, it is not possible to determine which source set is unused.

## After this PR
When displaying unused dependencies
1. Display the classifier in the resolved artifact string.
1. Display the `ModuleVersionIdentifier#getDisplayName` of the resolved artifact. The implementation isn't ideal because it appears as the following, but it's the only way to show the source set name without using internal classes.
    ```
    project(':my-other-project') (mySourceSet (project :my-other-project))
    ```

This PR also improves the display strings of project dependencies (both when unused and in suggestions) to appear as the following rather than artifact coordinates:
```
project(':my-other-project')
```

## Possible downsides?
The display of the source sets is verbose and can be confusing. If we find it too confusing I'm happy to remove that bit from this PR. But it was a real issue I ran into so I just wanted to put this up as a proposal.