### PR TITLE
checkJUnitDependencies also detects spock (via nebula-test)

### DIFF
--- a/changelog/@unreleased/pr-951.v2.yml
+++ b/changelog/@unreleased/pr-951.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: checkJUnitDependencies detects a possible misconfiguration with spock
+    and JUnit5 which could lead to tests silently not running.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/951

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -73,7 +73,7 @@ public class CheckJUnitDependencies extends DefaultTask {
         boolean junitJupiterIsPresent = hasDep(deps, CheckJUnitDependencies::isJunitJupiter);
         boolean vintageEngineExists = hasDep(deps, CheckJUnitDependencies::isVintageEngine);
         boolean spockDependency = hasDep(deps, CheckJUnitDependencies::isSpock);
-        String testRuntimeOnly = ss.getRuntimeConfigurationName() + "Only";
+        String testRuntimeOnly = ss.getRuntimeOnlyConfigurationName();
         boolean junitPlatformEnabled = BaselineTesting.useJUnitPlatformEnabled(task);
 
         // If some testing library happens to provide the junit-jupiter-api, then users might start using the

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -16,7 +16,6 @@
 
 package com.palantir.baseline.tasks;
 
-
 import com.google.common.base.Preconditions;
 import com.palantir.baseline.plugins.BaselineTesting;
 import java.io.File;
@@ -166,9 +165,6 @@ public class CheckJUnitDependencies extends DefaultTask {
         return "org.junit.vintage".equals(dep.getGroup()) && "junit-vintage-engine".equals(dep.getName());
     }
 
-    private static boolean isJunit4(ModuleVersionIdentifier dep) {
-        return "junit".equals(dep.getGroup()) && "junit".equals(dep.getName());
-    }
     private static boolean isSpock(ModuleVersionIdentifier dep) {
         return "org.spockframework".equals(dep.getGroup()) && "spock-core".equals(dep.getName());
     }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -144,4 +144,20 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         BuildResult result = with('checkJUnitDependencies').buildAndFail()
         result.output.contains 'Some tests mention JUnit5, but the \'test\' task does not have useJUnitPlatform() enabled'
     }
+
+    def 'checkJUnitDependencies ensures nebula test => vintage must be present'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+        apply plugin: 'groovy'
+        dependencies {
+            testImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
+            testImplementation 'com.netflix.nebula:nebula-test:7.3.0'
+        }
+        '''.stripIndent()
+
+        then:
+        BuildResult result = with('checkJUnitDependencies').buildAndFail()
+        result.output.contains 'Tests may be silently not running! Spock dependency detected'
+    }
 }


### PR DESCRIPTION
## Before this PR

We had the scary realization recently that no tests were running on develop for one of our gradle plugins because it used spock and junit5 without the vintage engine (see [fix PR](https://github.com/palantir/gradle-revapi/pull/48/files#diff-c197962302397baf3a4cc36463dce5eaR60))

## After this PR
==COMMIT_MSG==
checkJUnitDependencies detects a possible misconfiguration with spock and JUnit5 which could lead to tests silently not running.
==COMMIT_MSG==

## Possible downsides?
- the checkJUnitDependencies task is not cacheable, so might be slow on big projects.  Seems worth it to guarantee that people don't silently not run tests though!

