### PR TITLE
Fix error-prone `UnnecessaryParentheses` by default

### DIFF
--- a/changelog/@unreleased/pr-952.v2.yml
+++ b/changelog/@unreleased/pr-952.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix error-prone `UnnecessaryParentheses` by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/952

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -37,7 +37,8 @@ public class BaselineErrorProneExtension {
 
             // Built-in checks
             "ArrayEquals",
-            "MissingOverride");
+            "MissingOverride",
+            "UnnecessaryParentheses");
 
     private final ListProperty<String> patchChecks;
 


### PR DESCRIPTION
I've used this fix frequently on our largest internal projects
without any negative consequences. Fixing it by default will
resolve some compiler warnings and improve compilation log SNR.

## After this PR
==COMMIT_MSG==
Fix error-prone `UnnecessaryParentheses` by default
==COMMIT_MSG==

## Possible downsides?
- code changes stop excavator baseline upgrades auto-merging, which may hamper getting other baseline functionality onto develop.

