### PR TITLE
Improve TestCheckUtils.isTestCode test detection

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
@@ -21,6 +21,7 @@ import com.google.errorprone.matchers.JUnitMatchers;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 
@@ -38,7 +39,11 @@ final class TestCheckUtils {
                 return true;
             }
         }
-        return false;
+        return state.getPath().getCompilationUnit().getImports()
+                .stream()
+                .map(ImportTree::getQualifiedIdentifier)
+                .map(Object::toString)
+                .anyMatch(TestCheckUtils::isTestImport);
     }
 
     private static final Matcher<ClassTree> hasJUnit5TestCases =
@@ -48,4 +53,11 @@ final class TestCheckUtils {
 
     private static final Matcher<ClassTree> hasTestCases = Matchers
             .anyOf(JUnitMatchers.hasJUnit4TestCases, hasJUnit5TestCases);
+
+    private static boolean isTestImport(String qualifiedName) {
+        return qualifiedName.startsWith("org.junit.") // junit 4 and 5
+                || qualifiedName.startsWith("junit.") // junit 3
+                || qualifiedName.startsWith("org.mockito.")
+                || qualifiedName.startsWith("org.assertj.");
+    }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptionsTest.java
@@ -164,6 +164,18 @@ public class PreferSafeLoggableExceptionsTest {
     }
 
     @Test
+    public void illegal_state_exception_with_assertj_import_doesnt_match() {
+        compilationHelper.addSourceLines(
+                "Foo.java",
+                "import static org.assertj.core.api.Assertions.assertThat;",
+                "class Foo {",
+                "  public void f() {",
+                "    throw new IllegalStateException(\"constant\");",
+                "  }",
+                "}").doTest();
+    }
+
+    @Test
     public void io_exception() {
         compilationHelper.addSourceLines(
                 "Bean.java",

--- a/changelog/@unreleased/pr-958.v2.yml
+++ b/changelog/@unreleased/pr-958.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve TestCheckUtils.isTestCode test detection
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/958


### PR DESCRIPTION
In addition to the previous checks, also validate that there are
no imports from know test packages (`org.junit`, `org.assertj`, etc)

## Before this PR
Test utilities were often flagged by error prone checks that are meant to avoid test code.

## After this PR
==COMMIT_MSG==
Improve TestCheckUtils.isTestCode test detection
==COMMIT_MSG==

## Possible downsides?
Execution isn't free, it might take a couple more microseconds to check if we're in test code. Fortunately we do test validation at the end of most checks because it's already expensive, so there's not likely much impact.

