### PR TITLE
fix #967: Suppress error-prone PreferCollectionConstructors on jdk13

### DIFF
--- a/changelog/@unreleased/pr-968.v2.yml
+++ b/changelog/@unreleased/pr-968.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Suppress error-prone PreferCollectionConstructors on jdk13
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/968

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -198,6 +198,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
             // Errorprone isn't officially compatible with Java13 either
             // https://github.com/google/error-prone/issues/1106
             errorProneOptions.check("TypeParameterUnusedInFormals", CheckSeverity.OFF);
+            errorProneOptions.check("PreferCollectionConstructors", CheckSeverity.OFF);
         }
 
         if (javaCompile.equals(compileRefaster)) {


### PR DESCRIPTION
==COMMIT_MSG==
Suppress error-prone PreferCollectionConstructors on jdk13
==COMMIT_MSG==
