### PR TITLE
Correctly rewrite verifyZeroInteractions

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/MockitoVerifyZeroInteractions.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/MockitoVerifyZeroInteractions.java
@@ -16,7 +16,7 @@
 
 package com.palantir.baseline.refaster;
 
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import com.google.errorprone.refaster.ImportPolicy;
@@ -25,7 +25,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 
-public final class MockitoVerifyNoInteractions {
+public final class MockitoVerifyZeroInteractions {
 
     @BeforeTemplate
     @SuppressWarnings("deprecation")
@@ -37,6 +37,6 @@ public final class MockitoVerifyNoInteractions {
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(@Repeated Object varargs) {
-        verifyNoInteractions(varargs);
+        verifyNoMoreInteractions(varargs);
     }
 }

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/MockitoVerifyZeroInteractionsTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/MockitoVerifyZeroInteractionsTest.java
@@ -18,12 +18,12 @@ package com.palantir.baseline.refaster;
 
 import org.junit.Test;
 
-public class MockitoVerifyNoInteractionsTest {
+public class MockitoVerifyZeroInteractionsTest {
 
     @Test
     public void testSingleArg() {
         RefasterTestHelper
-                .forRefactoring(MockitoVerifyNoInteractions.class)
+                .forRefactoring(MockitoVerifyZeroInteractions.class)
                 .withInputLines(
                         "Test",
                         "import static org.mockito.Mockito.verifyZeroInteractions;",
@@ -33,11 +33,11 @@ public class MockitoVerifyNoInteractionsTest {
                         "  }",
                         "}")
                 .hasOutputLines(
-                        "import static org.mockito.Mockito.verifyNoInteractions;",
+                        "import static org.mockito.Mockito.verifyNoMoreInteractions;",
                         "import static org.mockito.Mockito.verifyZeroInteractions;",
                         "public class Test {",
                         "  void test(Object mock) {",
-                        "    verifyNoInteractions(mock);",
+                        "    verifyNoMoreInteractions(mock);",
                         "  }",
                         "}");
     }
@@ -45,7 +45,7 @@ public class MockitoVerifyNoInteractionsTest {
     @Test
     public void testMultipleArgs() {
         RefasterTestHelper
-                .forRefactoring(MockitoVerifyNoInteractions.class)
+                .forRefactoring(MockitoVerifyZeroInteractions.class)
                 .withInputLines(
                         "Test",
                         "import static org.mockito.Mockito.verifyZeroInteractions;",
@@ -55,11 +55,11 @@ public class MockitoVerifyNoInteractionsTest {
                         "  }",
                         "}")
                 .hasOutputLines(
-                        "import static org.mockito.Mockito.verifyNoInteractions;",
+                        "import static org.mockito.Mockito.verifyNoMoreInteractions;",
                         "import static org.mockito.Mockito.verifyZeroInteractions;",
                         "public class Test {",
                         "  void test(Object mock1, Object mock2) {",
-                        "    verifyNoInteractions(mock1, mock2);",
+                        "    verifyNoMoreInteractions(mock1, mock2);",
                         "  }",
                         "}");
     }
@@ -67,7 +67,7 @@ public class MockitoVerifyNoInteractionsTest {
     @Test
     public void testVarArgs() {
         RefasterTestHelper
-                .forRefactoring(MockitoVerifyNoInteractions.class)
+                .forRefactoring(MockitoVerifyZeroInteractions.class)
                 .withInputLines(
                         "Test",
                         "import static org.mockito.Mockito.verifyZeroInteractions;",
@@ -77,11 +77,11 @@ public class MockitoVerifyNoInteractionsTest {
                         "  }",
                         "}")
                 .hasOutputLines(
-                        "import static org.mockito.Mockito.verifyNoInteractions;",
+                        "import static org.mockito.Mockito.verifyNoMoreInteractions;",
                         "import static org.mockito.Mockito.verifyZeroInteractions;",
                         "public class Test {",
                         "  void test(Object... mocks) {",
-                        "    verifyNoInteractions(mocks);",
+                        "    verifyNoMoreInteractions(mocks);",
                         "  }",
                         "}");
     }

--- a/changelog/@unreleased/pr-975.v2.yml
+++ b/changelog/@unreleased/pr-975.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The deprecated `verifyZeroInteractions` now gets rewritten to `verifyNoMoreInteractions`,
+    which has the same behaviour.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/975


### PR DESCRIPTION
## Before this PR

We were rewriting `verifyZeroInteractions` to `verifyNoInteractions`, which has different behaviour.
It expects that there were never any interactions, ignoring previously acknowledged interactions.

## After this PR

==COMMIT_MSG==
The deprecated `verifyZeroInteractions` now gets rewritten to `verifyNoMoreInteractions`, which has the same behaviour.
==COMMIT_MSG==