### PR TITLE
Add checkstyle rule for double boolean negation

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -383,6 +383,10 @@
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>
             <property name="message" value="Test setup/teardown methods are called before(), beforeClass(), after(), afterClass(), but not setUp, teardown, etc."/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="!!"/>
+            <property name="message" value="Unnecessary double negation (!!)."/>
+        </module>
         <module name="RightCurly"> <!-- Java Style Guide: Nonempty blocks: K & R style -->
             <property name="option" value="same"/>
             <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>

--- a/changelog/@unreleased/pr-976.v2.yml
+++ b/changelog/@unreleased/pr-976.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add a checkstyle rule to prevent double boolean negation (!!).
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/976


### PR DESCRIPTION
## Before this PR
Use of !! is almost certainly a typo. This typo was the cause of a bug that took a while to track down in one of our repos.

## After this PR
==COMMIT_MSG==
Add a checkstyle rule to prevent double boolean negation (!!).
==COMMIT_MSG==

## Possible downsides?
RegexpSinglelineJava doesn't exclude comments, so if someone gets a bit over-excited in a comment this rule may hit their excessive exclamation marks.
