### PR TITLE
Restrict migration to safe-logging to source sets that have the library

### DIFF
--- a/changelog/@unreleased/pr-981.v2.yml
+++ b/changelog/@unreleased/pr-981.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description: Stop migrating source sets to safe-logging, unless they already have
-    the requisite libraries (`com.palantir.safe-logging:{preconditions,safe-logging}`).
+    the requisite library (`com.palantir.safe-logging:preconditions`).
   links:
   - https://github.com/palantir/gradle-baseline/pull/981

--- a/changelog/@unreleased/pr-981.v2.yml
+++ b/changelog/@unreleased/pr-981.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Stop migrating source sets to safe-logging, unless they already have
+    the requisite libraries (`com.palantir.safe-logging:{preconditions,safe-logging}`).
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/981

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -17,10 +17,18 @@
 package com.palantir.baseline.extensions;
 
 import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.CheckReturnValue;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.ListProperty;
 
 public class BaselineErrorProneExtension {
+    private static final Logger log = Logging.getLogger(BaselineErrorProneExtension.class);
 
     private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
@@ -51,5 +59,33 @@ public class BaselineErrorProneExtension {
 
     public final ListProperty<String> getPatchChecks() {
         return patchChecks;
+    }
+
+    /**
+     * Filters down the patch checks, removing checks that depend on certain libraries being present on the compile
+     * class path.
+     */
+    public final List<String> getFilteredPatchChecks(FileCollection compileClasspath) {
+        boolean hasSafeLogging = !compileClasspath.filter(file -> file.getName().startsWith("safe-logging-")).isEmpty();
+        boolean hasPreconditions =
+                // The real 'preconditions' brings in 'safe-logging'. Because of inaccurate jar name checks, we
+                // use that fact to ensure we're not picking up another jar named 'preconditions' by mistake.
+                hasSafeLogging
+                        && !compileClasspath.filter(file -> file.getName().startsWith("preconditions-")).isEmpty();
+        Stream<String> checksStream = patchChecks.get().stream();
+        if (!hasPreconditions) {
+            checksStream = disableCheck(compileClasspath, checksStream, "PreferSafeLoggingPreconditions");
+        }
+        if (!hasSafeLogging) {
+            checksStream = disableCheck(compileClasspath, checksStream, "PreferSafeLoggableExceptions");
+        }
+        return checksStream.collect(Collectors.toList());
+    }
+
+    @CheckReturnValue
+    private static Stream<String> disableCheck(
+            FileCollection compileClasspath, Stream<String> checksStream, String checkName) {
+        log.info("Disabling check " + checkName + " as library missing from source set for {}", compileClasspath);
+        return checksStream.filter(check -> !check.equals(checkName));
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -17,19 +17,10 @@
 package com.palantir.baseline.extensions;
 
 import com.google.common.collect.ImmutableList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.annotation.CheckReturnValue;
 import org.gradle.api.Project;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.ListProperty;
 
 public class BaselineErrorProneExtension {
-    private static final Logger log = Logging.getLogger(BaselineErrorProneExtension.class);
-
     private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
             "ExecutorSubmitRunnableFutureIgnored",
@@ -59,33 +50,5 @@ public class BaselineErrorProneExtension {
 
     public final ListProperty<String> getPatchChecks() {
         return patchChecks;
-    }
-
-    /**
-     * Filters down the patch checks, removing checks that depend on certain libraries being present on the compile
-     * class path.
-     */
-    public final List<String> getFilteredPatchChecks(FileCollection compileClasspath) {
-        boolean hasSafeLogging = !compileClasspath.filter(file -> file.getName().startsWith("safe-logging-")).isEmpty();
-        boolean hasPreconditions =
-                // The real 'preconditions' brings in 'safe-logging'. Because of inaccurate jar name checks, we
-                // use that fact to ensure we're not picking up another jar named 'preconditions' by mistake.
-                hasSafeLogging
-                        && !compileClasspath.filter(file -> file.getName().startsWith("preconditions-")).isEmpty();
-        Stream<String> checksStream = patchChecks.get().stream();
-        if (!hasPreconditions) {
-            checksStream = disableCheck(compileClasspath, checksStream, "PreferSafeLoggingPreconditions");
-        }
-        if (!hasSafeLogging) {
-            checksStream = disableCheck(compileClasspath, checksStream, "PreferSafeLoggableExceptions");
-        }
-        return checksStream.collect(Collectors.toList());
-    }
-
-    @CheckReturnValue
-    private static Stream<String> disableCheck(
-            FileCollection compileClasspath, Stream<String> checksStream, String checkName) {
-        log.info("Disabling check " + checkName + " as library missing from source set for {}", compileClasspath);
-        return checksStream.filter(check -> !check.equals(checkName));
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -242,7 +242,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
             BaselineErrorProneExtension errorProneExtension,
             JavaCompile javaCompile,
             ErrorProneOptions errorProneOptions) {
-        return errorProneExtension.getPatchChecks().get().stream().filter(check -> {
+        return errorProneExtension.getFilteredPatchChecks(javaCompile.getClasspath()).stream().filter(check -> {
             if (checkExplicitlyDisabled(errorProneOptions, check)) {
                 log.info(
                         "Task {}: not applying errorprone check {} because it has severity OFF in errorProneOptions",

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -261,7 +261,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // If this javaCompile is associated with a source set, use it to figure out if it has preconditions or not.
         Predicate<String> filterOutPreconditions = maybeSourceSet
                 .map(ss -> filterOutPreconditions(
-                        ss, project.getConfigurations().getByName(ss.getCompileClasspathConfigurationName())))
+                        project.getConfigurations().getByName(ss.getCompileClasspathConfigurationName())))
                 .orElse(check -> true);
 
         return errorProneExtension.getPatchChecks().get().stream().filter(check -> {
@@ -287,7 +287,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
     }
 
     /** Filters out preconditions checks if the required libraries are not on the classpath. */
-    public static Predicate<String> filterOutPreconditions(SourceSet sourceSet, Configuration compileClasspath) {
+    public static Predicate<String> filterOutPreconditions(Configuration compileClasspath) {
         boolean hasPreconditions =
                 hasDependenciesMatching(compileClasspath, BaselineErrorProne::isSafeLoggingPreconditionsDep);
 
@@ -295,16 +295,16 @@ public final class BaselineErrorProne implements Plugin<Project> {
             if (!hasPreconditions) {
                 if (check.equals("PreferSafeLoggingPreconditions")) {
                     log.info(
-                            "Disabling check PreferSafeLoggingPreconditions as 'com.palantir.safe-logging:safe-logging'"
-                                    + " missing from {}",
-                            sourceSet);
+                            "Disabling check PreferSafeLoggingPreconditions as "
+                                    + "'com.palantir.safe-logging:preconditions' missing from {}",
+                            compileClasspath);
                     return false;
                 }
                 if (check.equals("PreferSafeLoggableExceptions")) {
                     log.info(
                             "Disabling check PreferSafeLoggableExceptions as 'com.palantir.safe-logging:preconditions' "
                                     + "missing from {}",
-                            sourceSet);
+                            compileClasspath);
                     return false;
                 }
             }


### PR DESCRIPTION
## Before this PR

Baseline keeps opening PRs that migrate people's preconditions and exceptions to safe-logging, but this breaks when those libraries actually aren't on the classpath of the respective source set being migrated.

## After this PR
==COMMIT_MSG==
Stop migrating source sets to safe-logging, unless they already have the requisite library (`com.palantir.safe-logging:preconditions`).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

