### PR TITLE
Less checkstyle.xml when palantir-java-format is enabled

### DIFF
--- a/changelog/@unreleased/pr-987.v2.yml
+++ b/changelog/@unreleased/pr-987.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: checkstyle Indentation rule is disabled when palantir-java-format is
+    enabled
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/987

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
@@ -45,7 +45,9 @@ class BaselineConfigIntegrationTest extends AbstractPluginTest {
         """.stripIndent()
 
         then:
-        with('--stacktrace', '--info', 'baselineUpdateConfig', '-Pcom.palantir.baseline-format.eclipse').build()
+        with('--stacktrace', '--info', 'baselineUpdateConfig',
+                '-Pcom.palantir.baseline-format.eclipse',
+                '-Pcom.palantir.baseline-format.palantir-java-format').build()
         directory('.baseline').list().toList().toSet() == [
                 'checkstyle', 'copyright', 'eclipse', 'idea', 'spotless'
         ].toSet()


### PR DESCRIPTION
## Before this PR

with palantir-java-format 0.2.7 we have something that produces pretty much exactly what a human would plausibly write. The only trouble is it adds a bit of extra indenting in some cases (to try to differentiate arguments from chained calls), which actually _fails_ checkstyle.

The formatter would produce this:
```java
        return Comparator.comparing(
                        (ComponentIdentifier id) -> tryCast(ModuleComponentIdentifier.class, id),
                        Comparators.emptiesFirst(moduleComponentIdentifierOrdering))
                .thenComparing(ComponentIdentifier::getDisplayName);
```

But checkstyle wants this (which is IMO less readable):

```java
        return Comparator.comparing(
                (ComponentIdentifier id) -> tryCast(ModuleComponentIdentifier.class, id),
                Comparators.emptiesFirst(moduleComponentIdentifierOrdering))
                .thenComparing(ComponentIdentifier::getDisplayName);
```

Example failed build: https://circleci.com/gh/palantir/gradle-consistent-versions/3648

## After this PR
==COMMIT_MSG==
checkstyle Indentation rule is disabled when palantir-java-format is enabled
==COMMIT_MSG==

## Possible downsides?

- we're taking away a safety net here, because if p-j-f produces some egregious indentation, it's just down to humans to catch it!

