### PR TITLE
DangerousThrowableMessageSafeArg disallows Throwables

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArg.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArg.java
@@ -71,7 +71,7 @@ public final class DangerousThrowableMessageSafeArg extends BugChecker
                 state)) {
             return buildDescription(tree)
                     .setMessage("Do not use throwables as SafeArg values. "
-                            + "Throwables must be logged without an Arg wrapper as the last parameter, otherwise"
+                            + "Throwables must be logged without an Arg wrapper as the last parameter, otherwise "
                             + "unsafe data may be leaked from the unsafe message or the unsafe message of a cause.")
                     .build();
         }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArg.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArg.java
@@ -24,8 +24,8 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
-import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import java.util.List;
@@ -51,6 +51,8 @@ public final class DangerousThrowableMessageSafeArg extends BugChecker
             .onDescendantOf(Throwable.class.getName())
             .named("getMessage");
 
+    private static final Matcher<ExpressionTree> THROWABLE_MATCHER = Matchers.isSubtypeOf(Throwable.class);
+
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (!SAFEARG_FACTORY_METHOD.matches(tree, state)) {
@@ -65,10 +67,7 @@ public final class DangerousThrowableMessageSafeArg extends BugChecker
                             + "SafeLoggable.getLogMessage is guaranteed to be safe.")
                     .build();
         }
-        if (ASTHelpers.isCastable(
-                ASTHelpers.getResultType(safeValueArgument),
-                state.getTypeFromString(Throwable.class.getName()),
-                state)) {
+        if (THROWABLE_MATCHER.matches(safeValueArgument, state)) {
             return buildDescription(tree)
                     .setMessage("Do not use throwables as SafeArg values. "
                             + "Throwables must be logged without an Arg wrapper as the last parameter, otherwise "

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArgTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArgTest.java
@@ -63,4 +63,17 @@ public final class DangerousThrowableMessageSafeArgTest {
                 "}").doTest();
     }
 
+    @Test
+    public void unsafe_safearg_throwable() {
+        compilationHelper.addSourceLines(
+                "Bean.java",
+                "import " + SafeIllegalArgumentException.class.getName() + ';',
+                "import " + SafeArg.class.getName() + ';',
+                "class Bean {",
+                "  public SafeArg<?> foo() {",
+                "    // BUG: Diagnostic contains: Do not use throwables as SafeArg values",
+                "    return SafeArg.of(\"foo\", new SafeIllegalArgumentException(\"Foo\"));",
+                "  }",
+                "}").doTest();
+    }
 }

--- a/changelog/@unreleased/pr-997.v2.yml
+++ b/changelog/@unreleased/pr-997.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    DangerousThrowableMessageSafeArg disallows Throwables in SafeArg values.
+    Throwables must be logged without an Arg wrapper as the last parameter, otherwise unsafe data may be leaked from the unsafe message or the unsafe message of a cause.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/997


### PR DESCRIPTION
Update DangerousThrowableMessageSafeArg to disallow Throwable
objects as safe-arg values in addition to the result of
Throwable.getMessage.

## After this PR
==COMMIT_MSG==
DangerousThrowableMessageSafeArg disallows Throwables
==COMMIT_MSG==

