### PR TITLE
Implement a suggested fix for CatchBlockLogException

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchBlockLogException.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchBlockLogException.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
         name = "CatchBlockLogException",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = LinkType.CUSTOM,
+        providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
         severity = SeverityLevel.ERROR,
         summary = "log statement in catch block does not log the caught exception.")
 public final class CatchBlockLogException extends BugChecker implements BugChecker.CatchTreeMatcher {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CatchBlockLogExceptionTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CatchBlockLogExceptionTest.java
@@ -172,26 +172,6 @@ public class CatchBlockLogExceptionTest {
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
-    @Test
-    public void testFix_doesNotApplyToInfo() {
-        fix()
-                .addInputLines("Test.java",
-                        "import org.slf4j.Logger;",
-                        "import org.slf4j.LoggerFactory;",
-                        "class Test {",
-                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
-                        "  void f(String param) {",
-                        "    try {",
-                        "        log.info(\"hello\");",
-                        "    } catch (Throwable t) {",
-                        "        log.info(\"foo\");",
-                        "    }",
-                        "  }",
-                        "}")
-                .expectUnchanged()
-                .doTest();
-    }
-
     private void test(Class<? extends Throwable> exceptionClass, String catchStatement, Optional<String> error) {
         compilationHelper
                 .addSourceLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CatchBlockLogExceptionTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CatchBlockLogExceptionTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.errorprone;
 
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,6 +72,73 @@ public class CatchBlockLogExceptionTest {
         test(RuntimeException.class, "// Do nothing", Optional.empty());
     }
 
+    @Test
+    public void testFix_simple() {
+        fix()
+                .addInputLines("Test.java",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(String param) {",
+                        "    try {",
+                        "        log.info(\"hello\");",
+                        "    } catch (Throwable t) {",
+                        "        log.info(\"foo\");",
+                        "    }",
+                        "  }",
+                        "}")
+                .addOutputLines("Test.java",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(String param) {",
+                        "    try {",
+                        "        log.info(\"hello\");",
+                        "    } catch (Throwable t) {",
+                        "        log.info(\"foo\", t);",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testFix_ambiguous() {
+        // In this case there are multiple options, no fixes should be suggested.
+        fix()
+                .addInputLines("Test.java",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(String param) {",
+                        "    try {",
+                        "        log.info(\"hello\");",
+                        "    } catch (Throwable t) {",
+                        "        log.info(\"foo\");",
+                        "        log.debug(\"bar\");",
+                        "    }",
+                        "  }",
+                        "}")
+                .addOutputLines("Test.java",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(String param) {",
+                        "    try {",
+                        "        log.info(\"hello\");",
+                        "    } catch (Throwable t) {",
+                        "        log.info(\"foo\");",
+                        "        log.debug(\"bar\");",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
     private void test(Class<? extends Throwable> exceptionClass, String catchStatement, Optional<String> error) {
         compilationHelper
                 .addSourceLines(
@@ -89,5 +157,9 @@ public class CatchBlockLogExceptionTest {
                         "  }",
                         "}")
                 .doTest();
+    }
+
+    private BugCheckerRefactoringTestHelper fix() {
+        return BugCheckerRefactoringTestHelper.newInstance(new CatchBlockLogException(), getClass());
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CatchBlockLogExceptionTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CatchBlockLogExceptionTest.java
@@ -84,7 +84,7 @@ public class CatchBlockLogExceptionTest {
                         "    try {",
                         "        log.info(\"hello\");",
                         "    } catch (Throwable t) {",
-                        "        log.info(\"foo\");",
+                        "        log.error(\"foo\");",
                         "    }",
                         "  }",
                         "}")
@@ -97,7 +97,7 @@ public class CatchBlockLogExceptionTest {
                         "    try {",
                         "        log.info(\"hello\");",
                         "    } catch (Throwable t) {",
-                        "        log.info(\"foo\", t);",
+                        "        log.error(\"foo\", t);",
                         "    }",
                         "  }",
                         "}")
@@ -117,8 +117,8 @@ public class CatchBlockLogExceptionTest {
                         "    try {",
                         "        log.info(\"hello\");",
                         "    } catch (Throwable t) {",
-                        "        log.info(\"foo\");",
-                        "        log.debug(\"bar\");",
+                        "        log.error(\"foo\");",
+                        "        log.warn(\"bar\");",
                         "    }",
                         "  }",
                         "}")
@@ -131,12 +131,65 @@ public class CatchBlockLogExceptionTest {
                         "    try {",
                         "        log.info(\"hello\");",
                         "    } catch (Throwable t) {",
-                        "        log.info(\"foo\");",
-                        "        log.debug(\"bar\");",
+                        "        log.error(\"foo\");",
+                        "        log.warn(\"bar\");",
                         "    }",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testFix_getMessage() {
+        // In this case there are multiple options, no fixes should be suggested.
+        fix()
+                .addInputLines("Test.java",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(String param) {",
+                        "    try {",
+                        "        log.info(\"hello\");",
+                        "    } catch (Throwable t) {",
+                        "        log.error(\"foo\", t.getMessage());",
+                        "    }",
+                        "  }",
+                        "}")
+                .addOutputLines("Test.java",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(String param) {",
+                        "    try {",
+                        "        log.info(\"hello\");",
+                        "    } catch (Throwable t) {",
+                        "        log.error(\"foo\", t);",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testFix_doesNotApplyToInfo() {
+        fix()
+                .addInputLines("Test.java",
+                        "import org.slf4j.Logger;",
+                        "import org.slf4j.LoggerFactory;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(String param) {",
+                        "    try {",
+                        "        log.info(\"hello\");",
+                        "    } catch (Throwable t) {",
+                        "        log.info(\"foo\");",
+                        "    }",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
     }
 
     private void test(Class<? extends Throwable> exceptionClass, String catchStatement, Optional<String> error) {

--- a/changelog/@unreleased/pr-998.v2.yml
+++ b/changelog/@unreleased/pr-998.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement a suggested fix for CatchBlockLogException
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/998

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -23,6 +23,7 @@ import org.gradle.api.provider.ListProperty;
 public class BaselineErrorProneExtension {
     private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
+            "CatchBlockLogException",
             "ExecutorSubmitRunnableFutureIgnored",
             "LambdaMethodReference",
             "OptionalOrElseMethodInvocation",


### PR DESCRIPTION
## Before this PR
No great path to fix exceedingly large projects with thousands of violations.

## After this PR
==COMMIT_MSG==
Implement a suggested fix for CatchBlockLogException
==COMMIT_MSG==

## Possible downsides?
In some places this may increase logging noise, if exceptions are expected or used for control flow. That risk is relatively low, and those codepaths should provide the exception at a less severe logging level. I believe its worth the trade-off against failures which don't provide enough data to debug.

