### PR TITLE
Fix #1004: DangerousParallelStreamUsage catches more parallel stream uses

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousParallelStreamUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousParallelStreamUsageTest.java
@@ -39,7 +39,7 @@ public final class DangerousParallelStreamUsageTest {
                 "class Test {",
                 "   public static final void main(String[] args) {",
                 "       List<String> list = new ArrayList<>();",
-                "       // BUG: Diagnostic contains: Should not use .parallel() on a Java stream.",
+                "       // BUG: Diagnostic contains: Should not use parallel Java streams.",
                 "       list.stream().parallel();",
                 "   }",
                 "}"
@@ -243,11 +243,44 @@ public final class DangerousParallelStreamUsageTest {
                 "   public static final ForkJoinPool POOL_FOR_THIS_CLASS = new ForkJoinPool();",
                 "   public static final void main(String[] args) {",
                 "       FooStream<String> fooStream = new FooStream<>();",
-                "       // BUG: Diagnostic contains: Should not use .parallel() on a Java stream.",
+                "       // BUG: Diagnostic contains: Should not use parallel Java streams.",
                 "       fooStream.parallel();",
                 "       // This should fail too because it still won't allow you to properly control parallelism",
-                "       // BUG: Diagnostic contains: Should not use .parallel() on a Java stream.",
+                "       // BUG: Diagnostic contains: Should not use parallel Java streams.",
                 "       fooStream.parallel(POOL_FOR_THIS_CLASS);",
+                "   }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    public void should_warn_collection_parallelStream() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import java.util.List;",
+                "import java.util.ArrayList;",
+                "class Test {",
+                "   public static final void main(String[] args) {",
+                "       List<String> list = new ArrayList<>();",
+                "       // BUG: Diagnostic contains: Should not use parallel Java streams.",
+                "       list.parallelStream();",
+                "   }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    public void should_warn_stream_support_parallel() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import java.util.ArrayList;",
+                "import java.util.stream.StreamSupport;",
+                "class Test {",
+                "   public static final void main(String[] args) {",
+                "       StreamSupport.stream(new ArrayList<>().spliterator(), false);",
+                "       StreamSupport.stream(new ArrayList<>().spliterator(), args.length == 4);",
+                "       // BUG: Diagnostic contains: Should not use parallel Java streams.",
+                "       StreamSupport.stream(new ArrayList<>().spliterator(), true);",
                 "   }",
                 "}"
         ).doTest();

--- a/changelog/@unreleased/pr-1005.v2.yml
+++ b/changelog/@unreleased/pr-1005.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`DangerousParallelStreamUsage` checks for `Collection.parallelStream()`
+    and `StreamSupport` utility methods with parallel=true.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1005


### PR DESCRIPTION
Added checks for Collection.parallelStream and StreamSupport utility
methods with parallel=true.

## After this PR
==COMMIT_MSG==
`DangerousParallelStreamUsage` checks for `Collection.parallelStream()` and `StreamSupport` utility methods with parallel=true.
==COMMIT_MSG==

