### PR TITLE
Implement `FinalClass` error prone check, replacing the checkstyle implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `ThrowError`: Prefer throwing a RuntimeException rather than Error.
 - `ReverseDnsLookup`: Calling address.getHostName may result in an unexpected DNS lookup.
 - `ReadReturnValueIgnored`: The result of a read call must be checked to know if EOF has been reached or the expected number of bytes have been consumed.
+- `FinalClass`: A class should be declared final if all of its constructors are private.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FinalClass.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FinalClass.java
@@ -82,6 +82,7 @@ public final class FinalClass extends BugChecker implements BugChecker.ClassTree
     private static Optional<SuggestedFix> buildFix(ClassTree tree, VisitorState state) {
         return SuggestedFixes.addModifiers(tree, state, Modifier.FINAL)
                 .map(fix -> {
+                    // Remove redundant 'final' methods modifers that are no longer necessary.
                     SuggestedFix.Builder builder = SuggestedFix.builder().merge(fix);
                     tree.getMembers().stream()
                             .filter(member -> member instanceof MethodTree)

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FinalClass.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FinalClass.java
@@ -22,8 +22,6 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
@@ -33,7 +31,6 @@ import com.sun.source.util.TreeScanner;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.NestingKind;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -50,8 +47,6 @@ import javax.lang.model.element.NestingKind;
                 + "https://github.com/palantir/gradle-baseline/tree/develop/docs/best-practices/"
                 + "java-coding-guidelines#private-constructors")
 public final class FinalClass extends BugChecker implements BugChecker.ClassTreeMatcher {
-
-    private static final Matcher<ClassTree> NOT_TOP_LEVEL = Matchers.not(Matchers.nestingKind(NestingKind.TOP_LEVEL));
 
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
@@ -83,41 +78,39 @@ public final class FinalClass extends BugChecker implements BugChecker.ClassTree
     }
 
     private static boolean isClassExtendedInternally(ClassTree tree, VisitorState state) {
-        if (NOT_TOP_LEVEL.matches(tree, state)) {
-            // Encapsulated classes can be extended by other nested classes, even if they have private constructors.
-            // In these cases we mustn't fail validation or suggest a final modifier.
-            for (Tree typeDeclaration : state.getPath().getCompilationUnit().getTypeDecls()) {
-                Boolean maybeResult = typeDeclaration.accept(new TreeScanner<Boolean, Void>() {
+        // Encapsulated classes can be extended by other nested classes, even if they have private constructors.
+        // In these cases we mustn't fail validation or suggest a final modifier.
+        for (Tree typeDeclaration : state.getPath().getCompilationUnit().getTypeDecls()) {
+            Boolean maybeResult = typeDeclaration.accept(new TreeScanner<Boolean, Void>() {
 
-                    @Override
-                    public Boolean reduce(Boolean lhs, Boolean rhs) {
-                        // Fail if any class extends 'tree'
-                        return Boolean.TRUE.equals(lhs) || Boolean.TRUE.equals(rhs);
-                    }
-
-                    @Override
-                    public Boolean visitClass(ClassTree classTree, Void attachment) {
-                        Tree extendsClause = classTree.getExtendsClause();
-                        if (extendsClause != null && ASTHelpers.isSameType(
-                                ASTHelpers.getType(tree), ASTHelpers.getType(extendsClause), state)) {
-                            return true;
-                        }
-                        return super.visitClass(classTree, attachment);
-                    }
-
-                    @Override
-                    public Boolean visitNewClass(NewClassTree newClassTree, Void attachment) {
-                        if (newClassTree.getClassBody() != null && ASTHelpers.isSameType(
-                                ASTHelpers.getType(tree), ASTHelpers.getType(newClassTree.getIdentifier()), state)) {
-                            return true;
-                        }
-                        return super.visitNewClass(newClassTree, attachment);
-                    }
-                }, null);
-                // Unfortunately TreeScanner doesn't provide a way to set a default value, so we must account for null.
-                if (Boolean.TRUE.equals(maybeResult)) {
-                    return true;
+                @Override
+                public Boolean reduce(Boolean lhs, Boolean rhs) {
+                    // Fail if any class extends 'tree'
+                    return Boolean.TRUE.equals(lhs) || Boolean.TRUE.equals(rhs);
                 }
+
+                @Override
+                public Boolean visitClass(ClassTree classTree, Void attachment) {
+                    Tree extendsClause = classTree.getExtendsClause();
+                    if (extendsClause != null && ASTHelpers.isSameType(
+                            ASTHelpers.getType(tree), ASTHelpers.getType(extendsClause), state)) {
+                        return true;
+                    }
+                    return super.visitClass(classTree, attachment);
+                }
+
+                @Override
+                public Boolean visitNewClass(NewClassTree newClassTree, Void attachment) {
+                    if (newClassTree.getClassBody() != null && ASTHelpers.isSameType(
+                            ASTHelpers.getType(tree), ASTHelpers.getType(newClassTree.getIdentifier()), state)) {
+                        return true;
+                    }
+                    return super.visitNewClass(newClassTree, attachment);
+                }
+            }, null);
+            // Unfortunately TreeScanner doesn't provide a way to set a default value, so we must account for null.
+            if (Boolean.TRUE.equals(maybeResult)) {
+                return true;
             }
         }
         return false;

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FinalClass.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FinalClass.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.Modifier;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "FinalClass",
+        // Support legacy suppressions from checkstyle
+        altNames = {"checkstyle:finalclass", "checkstyle:FinalClass"},
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
+        severity = BugPattern.SeverityLevel.ERROR,
+        summary = "A class should be declared final if all of its constructors are private. Utility classes -- "
+                + "i.e., classes all of whose methods and fields are static -- have a private, empty, "
+                + "zero-argument constructor.\n"
+                + "https://github.com/palantir/gradle-baseline/tree/develop/docs/best-practices/"
+                + "java-coding-guidelines#private-constructors")
+public final class FinalClass extends BugChecker implements BugChecker.ClassTreeMatcher {
+    @Override
+    public Description matchClass(ClassTree tree, VisitorState state) {
+        if (tree.getKind() != Tree.Kind.CLASS) {
+            // Don't apply to out interfaces and enums
+            return Description.NO_MATCH;
+        }
+        Set<Modifier> classModifiers = tree.getModifiers().getFlags();
+        if (classModifiers.contains(Modifier.FINAL)) {
+            // Already final, nothing to check
+            return Description.NO_MATCH;
+        }
+        List<MethodTree> constructors = ASTHelpers.getConstructors(tree);
+        if (constructors.isEmpty()) {
+            return Description.NO_MATCH;
+        }
+        for (MethodTree constructor : constructors) {
+            if (!constructor.getModifiers().getFlags().contains(Modifier.PRIVATE)) {
+                return Description.NO_MATCH;
+            }
+        }
+        return buildDescription(tree)
+                .addFix(SuggestedFixes.addModifiers(tree, state, Modifier.FINAL))
+                .build();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
@@ -54,6 +54,36 @@ public class FinalClassTest {
     }
 
     @Test
+    void testFixRemovesRedundantFinalModifiers() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  private Test() {}",
+                        "  private final String a() { return \"a\"; }",
+                        "  public final String b() { return \"b\"; }",
+                        "  protected final String c() { return \"c\"; }",
+                        "  protected final String d() { return \"d\"; }",
+                        "  final String e() { return \"e\"; }",
+                        "  public static final String f() { return \"f\"; }",
+                        "}"
+                )
+                .addOutputLines(
+                        "Test.java",
+                        "public final class Test {",
+                        "  private Test() {}",
+                        "  private String a() { return \"a\"; }",
+                        "  public String b() { return \"b\"; }",
+                        "  protected String c() { return \"c\"; }",
+                        "  protected String d() { return \"d\"; }",
+                        "  String e() { return \"e\"; }",
+                        // static final is redundant, however it's not within the scope of this check to fix
+                        "  public static final String f() { return \"f\"; }",
+                        "}"
+                ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
     void testNested() {
         helper().addSourceLines(
                 "Test.java",
@@ -87,7 +117,7 @@ public class FinalClassTest {
                         "    private Nested() {}",
                         "  }",
                         "}"
-                ).doTest();
+                ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
     @Test
@@ -121,7 +151,7 @@ public class FinalClassTest {
                         "    private Nested() {}",
                         "  }",
                         "}"
-                ).doTest();
+                ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
     @Test
@@ -237,7 +267,7 @@ public class FinalClassTest {
                         "    return new Nested<String>();",
                         "  }",
                         "}"
-                ).doTest();
+                ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
@@ -155,6 +155,32 @@ public class FinalClassTest {
         ).doTest();
     }
 
+    @Test
+    void testNestedAbstractClassIgnored() {
+        helper().addSourceLines(
+                "Test.java",
+                "public class Test {",
+                "  private abstract static class Nested {",
+                "    private Nested() {}",
+                "  }",
+                "  private static final class NestedImpl extends Nested {}",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void testNestedClassIgnored() {
+        helper().addSourceLines(
+                "Test.java",
+                "public class Test {",
+                "  private static class Nested {",
+                "    private Nested() {}",
+                "  }",
+                "  private static final class NestedImpl extends Nested {}",
+                "}"
+        ).doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(FinalClass.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
@@ -240,6 +240,23 @@ public class FinalClassTest {
                 ).doTest();
     }
 
+    @Test
+    void testTopLevelExtendedByNestedIgnored() {
+        helper().addSourceLines(
+                "Test.java",
+                "public class Test {",
+                "  private Test() {}",
+                "  public static Object get() {",
+                "    return new Test() {",
+                "      @Override public String toString() {",
+                "        return \"value\";",
+                "      }",
+                "    };",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(FinalClass.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
@@ -181,6 +181,65 @@ public class FinalClassTest {
         ).doTest();
     }
 
+    @Test
+    void testGenericNestedClassIgnored() {
+        helper().addSourceLines(
+                "Test.java",
+                "public class Test {",
+                "  private static final class NestedImpl extends Nested<String> {}",
+                "  private static class Nested<T extends CharSequence> {",
+                "    private Nested() {}",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void testNestedAnonymousClassIgnored() {
+        helper().addSourceLines(
+                "Test.java",
+                "public class Test {",
+                "  private static class Nested<T extends CharSequence> {",
+                "    private Nested() {}",
+                "  }",
+                "  public static Object get() {",
+                "    return new Nested<String>() {",
+                "      @Override public String toString() {",
+                "        return \"value\";",
+                "      }",
+                "    };",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void testNested_withNewInstance() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  private static class Nested<T extends CharSequence> {",
+                        "    private Nested() {}",
+                        "  }",
+                        "  public static Object get() {",
+                        "    return new Nested<String>();",
+                        "  }",
+                        "}"
+                )
+                .addOutputLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  private static final class Nested<T extends CharSequence> {",
+                        "    private Nested() {}",
+                        "  }",
+                        "  public static Object get() {",
+                        "    return new Nested<String>();",
+                        "  }",
+                        "}"
+                ).doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(FinalClass.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
@@ -1,0 +1,165 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+public class FinalClassTest {
+
+    @Test
+    void testSimple() {
+        helper().addSourceLines(
+                "Test.java",
+                "// BUG: Diagnostic contains: should be declared final",
+                "public class Test {",
+                "  private Test() {}",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void testSimple_fix() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  private Test() {}",
+                        "}"
+                )
+                .addOutputLines(
+                        "Test.java",
+                        "public final class Test {",
+                        "  private Test() {}",
+                        "}"
+                ).doTest();
+    }
+
+    @Test
+    void testNested() {
+        helper().addSourceLines(
+                "Test.java",
+                "public final class Test {",
+                "  private Test() {}",
+                "  // BUG: Diagnostic contains: should be declared final",
+                "  public static class Nested {",
+                "    private Nested() {}",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void testNested_fix() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "public final class Test {",
+                        "  private Test() {}",
+                        "  public static class Nested {",
+                        "    private Nested() {}",
+                        "  }",
+                        "}"
+                )
+                .addOutputLines(
+                        "Test.java",
+                        "public final class Test {",
+                        "  private Test() {}",
+                        "  public static final class Nested {",
+                        "    private Nested() {}",
+                        "  }",
+                        "}"
+                ).doTest();
+    }
+
+    @Test
+    void testNestedInInterface() {
+        helper().addSourceLines(
+                "Test.java",
+                "public interface Test {",
+                "  // BUG: Diagnostic contains: should be declared final",
+                "  class Nested {",
+                "    private Nested() {}",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void testNestedInInterface_fix() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  class Nested {",
+                        "    private Nested() {}",
+                        "  }",
+                        "}"
+                )
+                .addOutputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  final class Nested {",
+                        "    private Nested() {}",
+                        "  }",
+                        "}"
+                ).doTest();
+    }
+
+    @Test
+    void testDoesNotMatchGeneratedConstructor() {
+        helper().addSourceLines(
+                "Test.java",
+                "public class Test {",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void testCheckstyleSuppression_lowerCase() {
+        helper().addSourceLines(
+                "Test.java",
+                "@SuppressWarnings(\"checkstyle:finalclass\")",
+                "public class Test {",
+                "  private Test() {}",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void testCheckstyleSuppression_camelCase() {
+        helper().addSourceLines(
+                "Test.java",
+                "@SuppressWarnings(\"checkstyle:FinalClass\")",
+                "public class Test {",
+                "  private Test() {}",
+                "}"
+        ).doTest();
+    }
+
+    private CompilationTestHelper helper() {
+        return CompilationTestHelper.newInstance(FinalClass.class, getClass());
+    }
+
+    private BugCheckerRefactoringTestHelper fix() {
+        return BugCheckerRefactoringTestHelper.newInstance(new FinalClass(), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-1008.v2.yml
+++ b/changelog/@unreleased/pr-1008.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Implement `FinalClass` error prone check, replacing the checkstyle
+    implementation
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1008

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -112,7 +112,6 @@
         <module name="EmptyStatement"/> <!-- Java Style Guide: One statement per line -->
         <module name="EqualsHashCode"/>
         <module name="FallThrough"/> <!-- Java Style Guide: Fall-through: commented -->
-        <module name="FinalClass"/> <!-- Java Coding Guidelines: Private constructors -->
         <module name="GenericWhitespace"> <!-- Java Style Guide: Horizontal whitespace -->
             <message key="ws.followed" value="GenericWhitespace ''{0}'' is followed by whitespace."/>
             <message key="ws.preceded" value="GenericWhitespace ''{0}'' is preceded with whitespace."/>

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -25,6 +25,7 @@ public class BaselineErrorProneExtension {
             // Baseline checks
             "CatchBlockLogException",
             "ExecutorSubmitRunnableFutureIgnored",
+            "FinalClass",
             "LambdaMethodReference",
             "OptionalOrElseMethodInvocation",
             "PreferBuiltInConcurrentKeySet",


### PR DESCRIPTION
The error-prone check provides a suggested fix which is applied automatically.

## Before this PR
`FinalClass` was provided by checkstyle, which we would like to replace with a formatter, and standardize validation on error-prone.

## After this PR
This implementation is an improvement over checkstyle because it provides the ability to fix itself.
==COMMIT_MSG==
Implement `FinalClass` error prone check, replacing the checkstyle implementation
==COMMIT_MSG==

## Possible downsides?
It's possible the checkstyle validation catches a case which this implementation does not.

Note: This is not based on the checkstyle implementation, nor have I read the checkstyle implementation, which uses lgpl2.1.