### PR TITLE
Fix `RedundantModifier` interpretation of implicit modifiers

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
@@ -48,30 +48,30 @@ public final class RedundantModifier extends BugChecker
 
     private static final Matcher<ClassTree> STATIC_ENUM_OR_INTERFACE = Matchers.allOf(
             Matchers.anyOf(Matchers.kindIs(Tree.Kind.ENUM), Matchers.kindIs(Tree.Kind.INTERFACE)),
-            Matchers.hasModifier(Modifier.STATIC));
+            classHasExplicitModifier(Modifier.STATIC));
 
     private static final Matcher<MethodTree> PRIVATE_ENUM_CONSTRUCTOR = Matchers.allOf(
             Matchers.methodIsConstructor(),
             Matchers.enclosingClass(Matchers.kindIs(Tree.Kind.ENUM)),
-            Matchers.hasModifier(Modifier.PRIVATE));
+            methodHasExplicitModifier(Modifier.PRIVATE));
 
     private static final Matcher<MethodTree> STATIC_FINAL_METHOD = Matchers.allOf(
-            Matchers.isStatic(),
-            Matchers.hasModifier(Modifier.FINAL));
+            methodHasExplicitModifier(Modifier.STATIC),
+            methodHasExplicitModifier(Modifier.FINAL));
 
     private static final Matcher<MethodTree> UNNECESSARY_INTERFACE_METHOD_MODIFIERS = Matchers.allOf(
             Matchers.enclosingClass(Matchers.kindIs(Tree.Kind.INTERFACE)),
             Matchers.not(Matchers.isStatic()),
             Matchers.not(Matchers.hasModifier(Modifier.DEFAULT)),
-            Matchers.anyOf(Matchers.hasModifier(Modifier.PUBLIC), Matchers.hasModifier(Modifier.ABSTRACT)));
+            Matchers.anyOf(methodHasExplicitModifier(Modifier.PUBLIC), methodHasExplicitModifier(Modifier.ABSTRACT)));
 
     private static final Matcher<MethodTree> UNNECESSARY_FINAL_METHOD_ON_FINAL_CLASS = Matchers.allOf(
             Matchers.not(Matchers.isStatic()),
             Matchers.enclosingClass(Matchers.allOf(
                     Matchers.kindIs(Tree.Kind.CLASS),
-                    Matchers.hasModifier(Modifier.FINAL))),
+                    classHasExplicitModifier(Modifier.FINAL))),
             Matchers.allOf(
-                    Matchers.hasModifier(Modifier.FINAL),
+                    methodHasExplicitModifier(Modifier.FINAL),
                     Matchers.not(Matchers.hasAnnotation(SafeVarargs.class))));
 
     @Override
@@ -114,5 +114,15 @@ public final class RedundantModifier extends BugChecker
                     .build();
         }
         return Description.NO_MATCH;
+    }
+
+    private static Matcher<MethodTree> methodHasExplicitModifier(Modifier modifier) {
+        return (Matcher<MethodTree>) (methodTree, state) ->
+                methodTree.getModifiers().getFlags().contains(modifier);
+    }
+
+    private static Matcher<ClassTree> classHasExplicitModifier(Modifier modifier) {
+        return (Matcher<ClassTree>) (classTree, state) ->
+                classTree.getModifiers().getFlags().contains(modifier);
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -50,6 +51,20 @@ class RedundantModifierTest {
     }
 
     @Test
+    void allowEnumResult() {
+        helper().addSourceLines(
+                "Test.java",
+                "public enum Test {",
+                "  INSTANCE(\"str\");",
+                "  private final String str;",
+                "  Test(String str) {",
+                "    this.str = str;",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
     @SuppressWarnings("checkstyle:RegexpSinglelineJava")
     void fixStaticEnum() {
         fix()
@@ -72,6 +87,18 @@ class RedundantModifierTest {
     }
 
     @Test
+    void testAllowPrivateEnum() {
+        helper().addSourceLines(
+                "Enclosing.java",
+                "public class Enclosing {",
+                "  private enum Test {",
+                "    INSTANCE",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
     void fixStaticInterface() {
         fix()
                 .addInputLines(
@@ -88,6 +115,20 @@ class RedundantModifierTest {
                         "  }",
                         "}"
                 ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    void allowInterface() {
+        helper().addSourceLines(
+                "Test.java",
+                "public enum Test {",
+                "  INSTANCE(\"str\");",
+                "  private final String str;",
+                "  Test(String str) {",
+                "    this.str = str;",
+                "  }",
+                "}"
+        ).doTest();
     }
 
     @Test
@@ -118,6 +159,21 @@ class RedundantModifierTest {
     }
 
     @Test
+    void allowValidInterfaceMethods() {
+        helper().addSourceLines(
+                "Enclosing.java",
+                "public class Enclosing {",
+                "  public interface Test {",
+                "    int a();",
+                "    int b();",
+                "    int c();",
+                "    int d();",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
     void fixFinalClassModifiers() {
         fix()
                 .addInputLines(
@@ -139,6 +195,20 @@ class RedundantModifierTest {
                         "  @SafeVarargs public final void d(Object... value) {}",
                         "}"
                 ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    void allowFinalClass() {
+        helper().addSourceLines(
+                "Test.java",
+                "public final class Test {",
+                "  public void a() {}",
+                "  private void b() {}",
+                "  void c() {}",
+                // SafeVarargs is a special case
+                "  @SafeVarargs public final void d(Object... value) {}",
+                "}"
+        ).doTest();
     }
 
     @Test
@@ -174,7 +244,29 @@ class RedundantModifierTest {
                 ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
+    @Test
+    void allowStaticMethods() {
+        helper().addSourceLines(
+                "Test.java",
+                "public class Test {",
+                "  public static int a() {",
+                "    return 1;",
+                "  }",
+                "  private static int b() {",
+                "    return 1;",
+                "  }",
+                "  static int c() {",
+                "    return 1;",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
     private BugCheckerRefactoringTestHelper fix() {
         return BugCheckerRefactoringTestHelper.newInstance(new RedundantModifier(), getClass());
+    }
+
+    private CompilationTestHelper helper() {
+        return CompilationTestHelper.newInstance(RedundantModifier.class, getClass());
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
@@ -120,12 +120,20 @@ class RedundantModifierTest {
     @Test
     void allowInterface() {
         helper().addSourceLines(
-                "Test.java",
-                "public enum Test {",
-                "  INSTANCE(\"str\");",
-                "  private final String str;",
-                "  Test(String str) {",
-                "    this.str = str;",
+                "Enclosing.java",
+                "public class Enclosing {",
+                "  public interface Test {",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    void allowNestedInterface() {
+        helper().addSourceLines(
+                "Enclosing.java",
+                "interface Enclosing {",
+                "  public interface Test {",
                 "  }",
                 "}"
         ).doTest();

--- a/changelog/@unreleased/pr-1014.v2.yml
+++ b/changelog/@unreleased/pr-1014.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix `RedundantModifier` interpretation of implicit modifiers
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1014


### PR DESCRIPTION
Updated RedundantModifier to check explicit modifiers only, added
test coverage for all output.

## After this PR
==COMMIT_MSG==
Fix `RedundantModifier` interpretation of implicit modifiers
==COMMIT_MSG==

