### PR TITLE
Fix RedundantModifier failures types nested in interfaces

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
@@ -132,8 +132,9 @@ public final class RedundantModifier extends BugChecker
             return false;
         }
         String source = state.getSourceForNode(tree);
+        // getSourceForNode returns null when there are no modifiers specified
         if (source == null) {
-            return true; // When source is not available, rely on the modifier flags
+            return false;
         }
         // nested interfaces report a static modifier despite not being present
         return source.contains(modifier.name().toLowerCase(Locale.ENGLISH));

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
@@ -99,6 +99,18 @@ class RedundantModifierTest {
     }
 
     @Test
+    void testAllowInterfaceNestedEnum() {
+        helper().addSourceLines(
+                "Enclosing.java",
+                "public interface Enclosing {",
+                "  enum Test {",
+                "    INSTANCE",
+                "  }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
     void fixStaticInterface() {
         fix()
                 .addInputLines(

--- a/changelog/@unreleased/pr-1017.v2.yml
+++ b/changelog/@unreleased/pr-1017.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix RedundantModifier failures types nested in interfaces
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1017


### PR DESCRIPTION
## Before this PR
erroneous failure:
```java
interface Enclosing {
    enum Reproducer {
    // ^ erroneous failure that Reproducer should not be static.
        INSTANCE
    }
}
```

## After this PR
==COMMIT_MSG==
Fix RedundantModifier failures types nested in interfaces
==COMMIT_MSG==

