### PR TITLE
Error prone RedundantModifier check supports more interface components

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
@@ -145,7 +145,7 @@ class RedundantModifierTest {
         helper().addSourceLines(
                 "Enclosing.java",
                 "interface Enclosing {",
-                "  public interface Test {",
+                "  interface Test {",
                 "  }",
                 "}"
         ).doTest();
@@ -322,6 +322,31 @@ class RedundantModifierTest {
                         "  int VALUE_3 = 3;",
                         "  int VALUE_4 = 4;",
                         "  int VALUE_5 = 5;",
+                        "}"
+                ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    void fixInterfaceNestedPublicClass() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  public static final class Class0 {}",
+                        "  public class Class1 {}",
+                        "  static class Class2 {}",
+                        "  final class Class3 {}",
+                        "  public interface Interface0 {}",
+                        "}"
+                )
+                .addOutputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  final class Class0 {}",
+                        "  class Class1 {}",
+                        "  class Class2 {}",
+                        "  final class Class3 {}",
+                        "  interface Interface0 {}",
                         "}"
                 ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
@@ -282,6 +282,50 @@ class RedundantModifierTest {
         ).doTest();
     }
 
+    @Test
+    void fixInterfacePublicStaticMethod() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  public static void a() {}",
+                        "}"
+                )
+                .addOutputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  static void a() {}",
+                        "}"
+                ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    void fixInterfaceStaticFieldModifiers() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  int VALUE_0 = 0;",
+                        "  public static final int VALUE_1 = 1;",
+                        "  public final int VALUE_2 = 2;",
+                        "  public static int VALUE_3 = 3;",
+                        "  final int VALUE_4 = 4;",
+                        "  static int VALUE_5 = 5;",
+                        "}"
+                )
+                .addOutputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  int VALUE_0 = 0;",
+                        "  int VALUE_1 = 1;",
+                        "  int VALUE_2 = 2;",
+                        "  int VALUE_3 = 3;",
+                        "  int VALUE_4 = 4;",
+                        "  int VALUE_5 = 5;",
+                        "}"
+                ).doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
     private RefactoringValidator fix() {
         return RefactoringValidator.of(new RedundantModifier(), getClass());
     }

--- a/changelog/@unreleased/pr-1021.v2.yml
+++ b/changelog/@unreleased/pr-1021.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Error prone RedundantModifier check supports interface static methods
+    and fields.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1021


### PR DESCRIPTION
```diff
public interface Iface {
-  public static void a() {}
+  static void a() {}
}
```

```diff
public interface Iface {
-  public static final int VALUE = 1;
+  int VALUE = 1;
}
```

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Error prone RedundantModifier check supports interface static methods and fields.
==COMMIT_MSG==

