### PR TITLE
Exclude Java 9 module-info.java

### DIFF
--- a/changelog/@unreleased/pr-1023.v2.yml
+++ b/changelog/@unreleased/pr-1023.v2.yml
@@ -1,7 +1,5 @@
 type: fix
 fix:
-  description: |-
-    <!-- User-facing outcomes this PR delivers -->
-    Ignore module-info.java files to support projects with Jigsaw.
+  description: Ignore module-info.java files to support projects with Jigsaw.
   links:
   - https://github.com/palantir/gradle-baseline/pull/1023

--- a/changelog/@unreleased/pr-1023.v2.yml
+++ b/changelog/@unreleased/pr-1023.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    <!-- User-facing outcomes this PR delivers -->
+    Ignore module-info.java files to support projects with Jigsaw.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1023

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -53,6 +53,9 @@
         <property name="optional" value="true"/>
     </module>
     <module name="SuppressWarningsFilter"/> <!-- baseline-gradle: README.md -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->
         <module name="SuppressionCommentFilter">


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Running checkstyle on repositories with Java 9 modules fails

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
Ignore module-info.java files to support projects with Jigsaw.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

