### PR TITLE
Drop RedundantModifier to SUGGESTION and FinalClass to WARNING

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FinalClass.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FinalClass.java
@@ -44,7 +44,7 @@ import javax.lang.model.element.Modifier;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
-        severity = BugPattern.SeverityLevel.ERROR,
+        severity = BugPattern.SeverityLevel.WARNING,
         summary = "A class should be declared final if all of its constructors are private. Utility classes -- "
                 + "i.e., classes all of whose methods and fields are static -- have a private, empty, "
                 + "zero-argument constructor.\n"

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
@@ -42,7 +42,7 @@ import javax.lang.model.element.Modifier;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
-        severity = BugPattern.SeverityLevel.ERROR,
+        severity = BugPattern.SeverityLevel.SUGGESTION,
         summary = "Avoid using redundant modifiers")
 public final class RedundantModifier extends BugChecker
         implements BugChecker.ClassTreeMatcher, BugChecker.MethodTreeMatcher, BugChecker.VariableTreeMatcher {

--- a/changelog/@unreleased/pr-1028.v2.yml
+++ b/changelog/@unreleased/pr-1028.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Drop RedundantModifier to SUGGESTION and FinalClass to WARNING
+
+    These checks don't imply bugs, and automation will fix failing cases automatically, so it's not necessary to block compilation.
+    FinalClass moved to warning rather than suggestion because there are a few edge cases (e.g. dependent projects using mockito without inline mock maker) where releases can run into issues if the bots don't fix findings in time.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1028


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Drop RedundantModifier to SUGGESTION and FinalClass to WARNING

These checks don't imply bugs, and automation will fix failing cases automatically, so it's not necessary to block compilation.
FinalClass moved to warning rather than suggestion because there are a few edge cases (e.g. dependent projects using mockito without inline mock maker) where releases can run into issues if the bots don't fix findings in time.
==COMMIT_MSG==

## Possible downsides?
Code on develop may have issues detected, but not fixed.

Based on comments from @iamdanfox.

