### PR TITLE
Move DangerousStringInternUsage message to BugPattern.summary annotation

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousStringInternUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousStringInternUsage.java
@@ -33,24 +33,23 @@ import com.sun.source.tree.MethodInvocationTree;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.WARNING,
-        summary = "Disallow String.intern() invocations.")
+        summary = "Should not use String.intern(). "
+                + "Java string intern is complex and unpredictable. In most cases intern performs worse than pure-java "
+                + "implementations such as Guava Interners "
+                + "(https://guava.dev/releases/27.0.1-jre/api/docs/com/google/common/collect/Interners.html). If you "
+                + "are confident that String.intern is the correct tool, please make sure you fully understand the "
+                + "consequences."
+                + "\nFrom https://shipilev.net/jvm/anatomy-quarks/10-string-intern/"
+                + "\n> For OpenJDK, String.intern() is the gateway to native JVM String table, and it comes with"
+                + "\n> caveats: throughput, memory footprint, pause time problems will await the users. It is very"
+                + "\n> easy to underestimate the impact of these caveats. Hand-rolled deduplicators/interners are"
+                + "\n> working much more reliably, because they are working on Java side, are just the regular Java"
+                + "\n> objects, generally better sized/resized, and also can be thrown away completely when not needed"
+                + "\n> anymore. GC-assisted String deduplication does alleviate things even more."
+                + "\n> In almost every project we were taking care of, removing String.intern() from the hotpaths, "
+                + "\n> or optionally replacing it with a handrolled deduplicator, was the very profitable performance"
+                + "\n> optimization. Do not use String.intern() without thinking very hard about it, okay?")
 public final class DangerousStringInternUsage extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
-    private static final String MESSAGE = "Should not use String.intern(). "
-            + "Java string intern is complex and unpredictable. In most cases intern performs worse than pure-java "
-            + "implementations such as Guava Interners "
-            + "(https://guava.dev/releases/27.0.1-jre/api/docs/com/google/common/collect/Interners.html). If you are "
-            + "confident that String.intern is the correct tool, please make sure you fully understand the "
-            + "consequences."
-            + "\nFrom https://shipilev.net/jvm/anatomy-quarks/10-string-intern/"
-            + "\n> For OpenJDK, String.intern() is the gateway to native JVM String table, and it comes with"
-            + "\n> caveats: throughput, memory footprint, pause time problems will await the users. It is very"
-            + "\n> easy to underestimate the impact of these caveats. Hand-rolled deduplicators/interners are working"
-            + "\n> much more reliably, because they are working on Java side, are just the regular Java objects,"
-            + "\n> generally better sized/resized, and also can be thrown away completely when not needed anymore."
-            + "\n> GC-assisted String deduplication does alleviate things even more."
-            + "\n> In almost every project we were taking care of, removing String.intern() from the hotpaths, "
-            + "\n> or optionally replacing it with a handrolled deduplicator, was the very profitable performance"
-            + "\n> optimization. Do not use String.intern() without thinking very hard about it, okay?";
     private static final long serialVersionUID = 1L;
 
     private static final Matcher<ExpressionTree> STRING_INTERN_METHOD_MATCHER =
@@ -62,9 +61,7 @@ public final class DangerousStringInternUsage extends BugChecker implements BugC
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (STRING_INTERN_METHOD_MATCHER.matches(tree, state)) {
-            return buildDescription(tree)
-                    .setMessage(MESSAGE)
-                    .build();
+            return describeMatch(tree);
         }
         return Description.NO_MATCH;
     }


### PR DESCRIPTION
Simplifies the implementation, no reason not to include a full
description in the summary becuase it's not dependant on context
of the match.

==COMMIT_MSG==
Move DangerousStringInternUsage message to BugPattern.summary annotation
==COMMIT_MSG==

