### PR TITLE
Add a refaster rule to migrate ITE getTargetException -> getCause

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/InvocationTargetExceptionCause.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/InvocationTargetExceptionCause.java
@@ -1,3 +1,19 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.palantir.baseline.refaster;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/InvocationTargetExceptionCause.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/InvocationTargetExceptionCause.java
@@ -2,14 +2,14 @@ package com.palantir.baseline.refaster;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-
 import java.lang.reflect.InvocationTargetException;
 
 /**
  * {@link InvocationTargetException#getTargetException()} javadoc recommends using
- * {@link InvocationTargetException#getCause()} instead.
+ * {@link InvocationTargetException#getCause()} instead. getTargetException was added
+ * before throwables had getCause.
  */
-public class InvocationTargetExceptionCause {
+public final class InvocationTargetExceptionCause {
 
     @BeforeTemplate
     Throwable before(InvocationTargetException ite) {

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/InvocationTargetExceptionCause.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/InvocationTargetExceptionCause.java
@@ -1,0 +1,23 @@
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * {@link InvocationTargetException#getTargetException()} javadoc recommends using
+ * {@link InvocationTargetException#getCause()} instead.
+ */
+public class InvocationTargetExceptionCause {
+
+    @BeforeTemplate
+    Throwable before(InvocationTargetException ite) {
+        return ite.getTargetException();
+    }
+
+    @AfterTemplate
+    Throwable after(InvocationTargetException ite) {
+        return ite.getCause();
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/InvocationTargetExceptionCauseTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/InvocationTargetExceptionCauseTest.java
@@ -1,3 +1,19 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.palantir.baseline.refaster;
 
 import org.junit.Test;

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/InvocationTargetExceptionCauseTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/InvocationTargetExceptionCauseTest.java
@@ -1,0 +1,27 @@
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class InvocationTargetExceptionCauseTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(InvocationTargetExceptionCause.class)
+                .withInputLines(
+                        "Test",
+                        "import java.lang.reflect.InvocationTargetException;",
+                        "public class Test {",
+                        "  void unwrap(InvocationTargetException e) throws Throwable {",
+                        "    throw e.getTargetException();",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "import java.lang.reflect.InvocationTargetException;",
+                        "public class Test {",
+                        "  void unwrap(InvocationTargetException e) throws Throwable {",
+                        "    throw e.getCause();",
+                        "  }",
+                        "}");
+    }
+}

--- a/changelog/@unreleased/pr-1039.v2.yml
+++ b/changelog/@unreleased/pr-1039.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add a refaster rule to migrate InvocationTargetException.getTargetException
+    to getCause.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1039


### PR DESCRIPTION
==COMMIT_MSG==
Add a refaster rule to migrate InvocationTargetException.getTargetException to getCause.
==COMMIT_MSG==

