### PR TITLE
Fix: Unsanitized regex breaking errorprone on windows paths

### DIFF
--- a/changelog/@unreleased/pr-1045.v2.yml
+++ b/changelog/@unreleased/pr-1045.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix using errorprone when running under Windows.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1045

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.ltgt.gradle.errorprone.CheckSeverity;
@@ -186,7 +187,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.setEnabled(true);
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
         errorProneOptions.setExcludedPaths(
-                String.format("%s/(build|src/generated.*)/.*", project.getProjectDir().getPath()));
+                String.format("%s/(build|src/generated.*)/.*", Pattern.quote(project.getProjectDir().getPath())));
         errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -189,8 +189,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
         String projectPath = project.getProjectDir().getPath();
         String separator = Paths.get(projectPath).getFileSystem().getSeparator();
-        errorProneOptions.setExcludedPaths(
-                String.format("%s%s(build|src/generated.*)%s.*", Pattern.quote(projectPath), separator, separator));
+        errorProneOptions.setExcludedPaths(String.format(
+                "%s%s(build|src%sgenerated.*)%s.*", Pattern.quote(projectPath), separator, separator, separator));
         errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -24,6 +24,7 @@ import com.google.common.collect.MoreCollectors;
 import com.palantir.baseline.extensions.BaselineErrorProneExtension;
 import com.palantir.baseline.tasks.CompileRefasterTask;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.AbstractList;
 import java.util.Collections;
 import java.util.List;
@@ -186,8 +187,10 @@ public final class BaselineErrorProne implements Plugin<Project> {
 
         errorProneOptions.setEnabled(true);
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
+        String projectPath = project.getProjectDir().getPath();
+        String separator = Paths.get(projectPath).getFileSystem().getSeparator();
         errorProneOptions.setExcludedPaths(
-                String.format("%s/(build|src/generated.*)/.*", Pattern.quote(project.getProjectDir().getPath())));
+                String.format("%s%s(build|src/generated.*)%s.*", separator, Pattern.quote(projectPath), separator));
         errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -188,7 +188,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.setEnabled(true);
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
         String projectPath = project.getProjectDir().getPath();
-        String separator = Paths.get(projectPath).getFileSystem().getSeparator();
+        String separator = Pattern.quote(Paths.get(projectPath).getFileSystem().getSeparator());
         errorProneOptions.setExcludedPaths(String.format(
                 "%s%s(build|src%sgenerated.*)%s.*", Pattern.quote(projectPath), separator, separator, separator));
         errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -190,7 +190,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         String projectPath = project.getProjectDir().getPath();
         String separator = Paths.get(projectPath).getFileSystem().getSeparator();
         errorProneOptions.setExcludedPaths(
-                String.format("%s%s(build|src/generated.*)%s.*", separator, Pattern.quote(projectPath), separator));
+                String.format("%s%s(build|src/generated.*)%s.*", Pattern.quote(projectPath), separator, separator));
         errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);


### PR DESCRIPTION
## Before this PR
Errorprone was breaking due to an unsatinized regex exclusion when using windows paths.
https://ci.appveyor.com/project/CRogers/gradle-conjure/builds/28845076

```
Caused by: java.util.regex.PatternSyntaxException: Unknown character property name {r} near index 4
C:\projects\gradle-conjure\gradle-conjure-api/(build|src/generated.*)/.*
^
at com.google.errorprone.ErrorProneOptions.processArgs(ErrorProneOptions.java:428)
at com.google.errorprone.ErrorProneOptions.processArgs(ErrorProneOptions.java:448)
at com.google.errorprone.ErrorProneJavacPlugin.init(ErrorProneJavacPlugin.java:45)
```

## After this PR
==COMMIT_MSG==
Fix using errorprone when running under Windows.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->