### PR TITLE
Relax SingleLineJavadoc to avoid fighting the formatter

### DIFF
--- a/changelog/@unreleased/pr-1051.v2.yml
+++ b/changelog/@unreleased/pr-1051.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Checkstyle no longer complains about single-line javadoc produced by
+    palantir-java-format.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1051

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -472,7 +472,6 @@
             <property name="format" value="^_?[a-z][a-zA-Z0-9]+$"/>
             <message key="name.invalidPattern" value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        <module name="SingleLineJavadoc"/> <!-- Java Style Guide: General form -->
         <module name="SummaryJavadocCheck"> <!-- Java Coding Guidelines: Javadoc -->
             <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
         </module>


### PR DESCRIPTION
## Before this PR

palantir-java-format reflows javadoc comments to fit on one line if possible, e.g.:

```java
/**
  * @param url lorem ipsum
  */	
public foo(String url) {
```

p-j-f reformatted: 

```java
/** @param url lorem ipsum */	
public foo(String url) {
```

Which resulted in checkstyle failing:

```
Single-line Javadoc comment should be multi-line.
ERROR: Single-line Javadoc comment should be multi-line.
Category: com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck
```

## After this PR
==COMMIT_MSG==
Checkstyle no longer complains about single-line javadoc produced by palantir-java-format.
==COMMIT_MSG==

It still works fine in IntelliJ:
<img width="787" alt="Screenshot 2019-11-18 at 13 22 13" src="https://user-images.githubusercontent.com/3473798/69055844-a73b8a00-0a06-11ea-9e1d-8212e1fcf205.png">

## Possible downsides?

- maybe there was some important reason for avoiding single-line javadoc that I don't know about?