### PR TITLE
PreferAssertj disallows `assert` statements in test code.

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -41,6 +41,9 @@ public class PreferAssertjTests {
                         "    Assert.assertTrue(b);",
                         "    Assert.assertTrue(\"desc\", b);",
                         "    assertThat(\"desc\", b);",
+                        "    assert b;",
+                        "    assert b : \"desc\";",
+                        "    assert b : 123;",
                         "  }",
                         "}")
                 .addOutputLines(
@@ -55,6 +58,9 @@ public class PreferAssertjTests {
                         "    assertThat(b).isTrue();",
                         "    assertThat(b).describedAs(\"desc\").isTrue();",
                         "    assertThat(b).describedAs(\"desc\").isTrue();",
+                        "    assertThat(b).isTrue();",
+                        "    assertThat(b).describedAs(\"desc\").isTrue();",
+                        "    assertThat(b).describedAs(\"%s\", 123).isTrue();",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -947,6 +953,19 @@ public class PreferAssertjTests {
                         "    assertThat((Map<?, ?>) actual).describedAs(\"desc\").isNull();",
                         "  }",
                         "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void assertsIgnoredInProductionCode() {
+        test().addInputLines("Test.java",
+                "class Test {",
+                "  void execute(String input) {",
+                "    assert input != null : \"input should not be null\";",
+                "    assert input.length() == 5;",
+                "  }",
+                "}")
+                .expectUnchanged()
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 

--- a/changelog/@unreleased/pr-1052.v2.yml
+++ b/changelog/@unreleased/pr-1052.v2.yml
@@ -3,6 +3,6 @@ improvement:
   description: |-
     PreferAssertj disallows `assert` statements in test code.
 
-    Tests should use more specific AssertJ checks, which cannot be disabled by turning off asserts. Arguably the `assert` keyword should never be used, preferring preconditions allowing production environments to avoid invoking code paths that are impossible to test.
+    Tests should use more specific AssertJ checks, which cannot be disabled by turning off asserts. Arguably the `assert` keyword should never be used, preferring preconditions. This way production environments cannot reach code paths that are impossible to test.
   links:
   - https://github.com/palantir/gradle-baseline/pull/1052

--- a/changelog/@unreleased/pr-1052.v2.yml
+++ b/changelog/@unreleased/pr-1052.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    PreferAssertj disallows `assert` statements in test code.
+
+    Tests should use more specific AssertJ checks, which cannot be disabled by turning off asserts. Arguably the `assert` keyword should never be used, preferring preconditions allowing production environments to avoid invoking code paths that are impossible to test.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1052


### PR DESCRIPTION
==COMMIT_MSG==
PreferAssertj disallows `assert` statements in test code.

Tests should use more specific AssertJ checks, which cannot be disabled by turning off asserts. Arguably the `assert` keyword should never be used, preferring preconditions allowing production environments to avoid invoking code paths that are impossible to test. 
==COMMIT_MSG==
