### PR TITLE
fix #1053 Implement `Slf4jThrowable` check to ensure throwable args are logged last

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `RedundantModifier`: Avoid using redundant modifiers.
 - `StrictCollectionIncompatibleType`: Likely programming error due to using the wrong type in a method that accepts Object.
 - `InvocationHandlerDelegation`: InvocationHandlers which delegate to another object must catch and unwrap InvocationTargetException.
+- `Slf4jThrowable`: Slf4j loggers require throwables to be the last parameter otherwise a stack trace is not produced.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jThrowable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jThrowable.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.ChildMultiMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "Slf4jThrowable",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
+        severity = SeverityLevel.WARNING,
+        summary = "Slf4j loggers require throwables to be the last parameter otherwise a stack trace is not produced. "
+                + "Documentation is available here: http://www.slf4j.org/faq.html#paramException")
+public final class Slf4jThrowable extends BugChecker implements MethodInvocationTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Matcher<ExpressionTree> THROWABLE = MoreMatchers.isSubtypeOf(Throwable.class);
+
+    private static final Matcher<ExpressionTree> LOG_METHOD = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.slf4j.Logger")
+            .withNameMatching(Pattern.compile("trace|debug|info|warn|error"));
+
+    private static final Matcher<ExpressionTree> CORRECT_THROWABLE = Matchers.methodInvocation(
+            LOG_METHOD, ChildMultiMatcher.MatchType.LAST, THROWABLE);
+
+    private static final Matcher<ExpressionTree> ANY_THROWABLE = Matchers.methodInvocation(
+            LOG_METHOD, ChildMultiMatcher.MatchType.AT_LEAST_ONE, THROWABLE);
+
+    private static final Matcher<ExpressionTree> MATCHER = Matchers.allOf(
+            Matchers.not(CORRECT_THROWABLE),
+            ANY_THROWABLE);
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!ANY_THROWABLE.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+        List<? extends ExpressionTree> arguments = tree.getArguments();
+        int lastIndex = arguments.size() - 1;
+        int throwableIndex = getFirstThrowableArgumentIndex(arguments, state);
+        if (throwableIndex == lastIndex) {
+            // Correct usage
+            return Description.NO_MATCH;
+        }
+        if (countThrowableArguments(arguments, state) > 1) {
+            // We cannot fix cases with multiple throwables.
+            return describeMatch(arguments.get(throwableIndex));
+        }
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        for (int i = throwableIndex; i < lastIndex; i++) {
+            fix.replace(arguments.get(i), state.getSourceForNode(arguments.get(i + 1)));
+        }
+        ExpressionTree throwableArgument = arguments.get(throwableIndex);
+        return buildDescription(throwableArgument)
+                .addFix(fix.replace(arguments.get(lastIndex), state.getSourceForNode(throwableArgument)).build())
+                .build();
+    }
+
+    private static int getFirstThrowableArgumentIndex(List<? extends ExpressionTree> arguments, VisitorState state) {
+        for (int i = 0; i < arguments.size(); i++) {
+            ExpressionTree argument = arguments.get(i);
+            if (THROWABLE.matches(argument, state)) {
+                return i;
+            }
+        }
+        throw new IllegalStateException("Failed to find a throwable argument");
+    }
+
+    @SuppressWarnings("ForLoopReplaceableByForEach")
+    private static int countThrowableArguments(List<? extends ExpressionTree> arguments, VisitorState state) {
+        int count = 0;
+        for (int i = 0; i < arguments.size(); i++) {
+            if (THROWABLE.matches(arguments.get(i), state)) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jThrowableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jThrowableTest.java
@@ -1,0 +1,77 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class Slf4jThrowableTest {
+
+    @Test
+    void testFix() {
+        fix()
+                .addInputLines("Test.java",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                                "private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(RuntimeException t) {",
+                        "    log.trace(\"message\", \"first\", \"second\", t, \"third\");",
+                        "    log.debug(\"message\", t, \"first\", \"second\", \"third\");",
+                        "    log.info(\"message\", t);",
+                        "    log.warn(\"message\", \"first\", t, \"second\");",
+                        "    log.error(\"message\", t, \"arg\");",
+                        "  }",
+                        "}")
+                .addOutputLines("Test.java",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                        "private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(RuntimeException t) {",
+                        "    log.trace(\"message\", \"first\", \"second\", \"third\", t);",
+                        "    log.debug(\"message\", \"first\", \"second\", \"third\", t);",
+                        "    log.info(\"message\", t);",
+                        "    log.warn(\"message\", \"first\", \"second\", t);",
+                        "    log.error(\"message\", \"arg\", t);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    void testMultipleExceptionsNotFixed() {
+        fix()
+                .addInputLines("Test.java",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                        "private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void f(Throwable one, Exception two) {",
+                        "    log.warn(\"message\", one, two);",
+                        "    log.error(\"message\",  \"arg\", one, two);",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                // This should fail validation, but no fixes should be attempted
+                .doTestExpectingFailure(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    RefactoringValidator fix() {
+        return RefactoringValidator.of(new Slf4jThrowable(), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-1054.v2.yml
+++ b/changelog/@unreleased/pr-1054.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Implement `Slf4jThrowable` check to ensure throwable args are logged
+    last
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1054

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -37,6 +37,7 @@ public class BaselineErrorProneExtension {
             "RedundantModifier",
             "Slf4jLevelCheck",
             "Slf4jLogsafeArgs",
+            "Slf4jThrowable",
             "StrictUnusedVariable",
             "StringBuilderConstantParameters",
             "ThrowError",


### PR DESCRIPTION
fix #1053
==COMMIT_MSG==
Implement `Slf4jThrowable` check to ensure throwable args are logged last
==COMMIT_MSG==

## Possible downsides?
If folks are logging exceptions expecting the string value, they will get warnings. We don't recommend logging exceptions without a stack trace because we lose the most helpful information.

