### PR TITLE
Refaster rule to eliminate unnecessary casting.

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/UnnecessaryCast.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/UnnecessaryCast.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+
+final class UnnecessaryCast<T> {
+
+    @BeforeTemplate
+    @SuppressWarnings("RedundantCast")
+    T before(T input) {
+        return (T) input;
+    }
+
+    @AfterTemplate
+    T after(T input) {
+        return input;
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/UnnecessaryCastTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/UnnecessaryCastTest.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class UnnecessaryCastTest {
+
+    @Test
+    public void testUnnecessaryCast() {
+        RefasterTestHelper
+                .forRefactoring(UnnecessaryCast.class)
+                .withInputLines(
+                        "Test",
+                        "public class Test {",
+                        "  void f(String input) {",
+                        "    CharSequence cs = (CharSequence) input;",
+                        "  }",
+                        "}")
+                .hasOutputLines(
+                        "public class Test {",
+                        "  void f(String input) {",
+                        "    CharSequence cs = input;",
+                        "  }",
+                        "}");
+    }
+}

--- a/changelog/@unreleased/pr-1060.v2.yml
+++ b/changelog/@unreleased/pr-1060.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refaster rule to eliminate unnecessary casting.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1060


### PR DESCRIPTION
```diff
- CharSequence cs = (CharSequence) "value";
+ CharSequence cs = "value";
```

==COMMIT_MSG==
Refaster rule to eliminate unnecessary casting.
==COMMIT_MSG==

