### PR TITLE
Refaster rule to convert Stream.of() -> Stream.empty()

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/StreamEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/StreamEmpty.java
@@ -1,0 +1,21 @@
+package com.palantir.baseline.refaster;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.AlsoNegation;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+public class StreamEmpty<T> {
+
+    @BeforeTemplate
+    Stream<T> streamNoParams() {
+        return Stream.of();
+    }
+
+    @AfterTemplate
+    Stream<T> streamEmpty() {
+        return Stream.empty();
+    }
+
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/StreamEmpty.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/StreamEmpty.java
@@ -1,12 +1,26 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.palantir.baseline.refaster;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
-import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import java.util.Collection;
 import java.util.stream.Stream;
 
-public class StreamEmpty<T> {
+public final class StreamEmpty<T> {
 
     @BeforeTemplate
     Stream<T> streamNoParams() {

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/StreamEmptyTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/StreamEmptyTest.java
@@ -1,0 +1,25 @@
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class StreamEmptyTest {
+
+    @Test
+    public void test() {
+        RefasterTestHelper
+                .forRefactoring(StreamEmpty.class)
+                .withInputLines(
+                        "Test",
+                        "import java.util.*;",
+                        "import java.util.stream.Stream;",
+                        "public class Test {",
+                        "  Stream<Integer> i = Stream.of();",
+                        "}")
+                .hasOutputLines(
+                        "import java.util.*;",
+                        "import java.util.stream.Stream;",
+                        "public class Test {",
+                        "  Stream<Integer> i = Stream.empty();",
+                        "}");
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/StreamEmptyTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/StreamEmptyTest.java
@@ -1,3 +1,19 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.palantir.baseline.refaster;
 
 import org.junit.Test;

--- a/changelog/@unreleased/pr-1061.v2.yml
+++ b/changelog/@unreleased/pr-1061.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add Refaster rule to convert Stream.of() -> Stream.empty()
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1061


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Add Refaster rule to convert Stream.of() -> Stream.empty()
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

