### PR TITLE
Fix: Disable conflicting checkstyle rules if started migrating to PJF

### DIFF
--- a/changelog/@unreleased/pr-1064.v2.yml
+++ b/changelog/@unreleased/pr-1064.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Allow declaring that conversion to palantir-java-format has been started,
+    which ensures that conflicting checkstyle rules are removed.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1064

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.plugins;
 
 import com.google.common.base.Preconditions;
+import com.palantir.baseline.plugins.BaselineFormat.FormatterState;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -87,7 +88,8 @@ class BaselineConfig extends AbstractBaselinePlugin {
                 }
             });
 
-            if (BaselineFormat.palantirJavaFormatterEnabled(rootProject)) {
+            // Disable some checkstyle rules that clash with PJF
+            if (BaselineFormat.palantirJavaFormatterState(rootProject) != FormatterState.OFF) {
                 Path checkstyleXml = configDir.resolve("checkstyle/checkstyle.xml");
 
                 try {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -47,13 +47,13 @@ class BaselineFormat extends AbstractBaselinePlugin {
         this.project = project;
 
         if (project == project.getRootProject()) {
-            if (BaselineFormat.palantirJavaFormatterEnabled(project)) {
+            if (BaselineFormat.palantirJavaFormatterState(project) == FormatterState.ON) {
                 project.getPluginManager().apply(PalantirJavaFormatIdeaPlugin.class);
             }
         }
 
         project.getPluginManager().withPlugin("java", plugin -> {
-            if (palantirJavaFormatterEnabled(project)) {
+            if (palantirJavaFormatterState(project) == FormatterState.ON) {
                 project.getPlugins().apply(PalantirJavaFormatPlugin.class); // provides the formatDiff task
             }
         });
@@ -75,7 +75,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
                 // use empty string to specify one group for all non-static imports
                 java.importOrder("");
 
-                if (eclipseFormattingEnabled(project) && palantirJavaFormatterEnabled(project)) {
+                if (eclipseFormattingEnabled(project) && palantirJavaFormatterState(project) != FormatterState.OFF) {
                     throw new GradleException(
                             "Can't use both eclipse and palantir-java-format at the same time, please delete one of "
                                     + ECLIPSE_FORMATTING
@@ -88,7 +88,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
                     java.eclipse().configFile(project.file(eclipseXml.toString()));
                 }
 
-                if (palantirJavaFormatterEnabled(project)) {
+                if (palantirJavaFormatterState(project) == FormatterState.ON) {
                     Preconditions.checkState(
                             project.getRootProject().getPlugins().hasPlugin(PalantirJavaFormatProviderPlugin.class),
                             "Must apply `com.palantir.baseline-format` to root project when setting '%s'",
@@ -133,8 +133,25 @@ class BaselineFormat extends AbstractBaselinePlugin {
         return project.hasProperty(ECLIPSE_FORMATTING);
     }
 
-    static boolean palantirJavaFormatterEnabled(Project project) {
-        return project.hasProperty(PJF_PROPERTY);
+    static FormatterState palantirJavaFormatterState(Project project) {
+        if (!project.hasProperty(PJF_PROPERTY)) {
+            return FormatterState.OFF;
+        }
+        if (project.property(PJF_PROPERTY).equals("started")) {
+            return FormatterState.STARTED_CONVERTING;
+        }
+        if (project.property(PJF_PROPERTY).equals("true")) {
+            return FormatterState.ON;
+        }
+        throw new RuntimeException(String.format(
+                "Unexpected value for %s: %s.%nExpected one of [started, true].",
+                PJF_PROPERTY, project.property(PJF_PROPERTY)));
+    }
+
+    enum FormatterState {
+        OFF,
+        STARTED_CONVERTING,
+        ON
     }
 
     static Path eclipseConfigFile(Project project) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -137,15 +137,16 @@ class BaselineFormat extends AbstractBaselinePlugin {
         if (!project.hasProperty(PJF_PROPERTY)) {
             return FormatterState.OFF;
         }
-        if (project.property(PJF_PROPERTY).equals("started")) {
+        Object propertyValue = project.property(PJF_PROPERTY);
+        if ("started".equals(propertyValue)) {
             return FormatterState.STARTED_CONVERTING;
         }
-        if (project.property(PJF_PROPERTY).equals("true")) {
+        if ("true".equals(propertyValue) || "".equals(propertyValue)) {
             return FormatterState.ON;
         }
         throw new RuntimeException(String.format(
                 "Unexpected value for %s: %s.%nExpected one of [started, true].",
-                PJF_PROPERTY, project.property(PJF_PROPERTY)));
+                PJF_PROPERTY, propertyValue));
     }
 
     enum FormatterState {


### PR DESCRIPTION
## Before this PR

Excavator PRs that start migrating repos to palantir-java-format (but don't convert all files in one go) run into checkstyle errors because there is a check that conflicts with PJF style.

## After this PR
==COMMIT_MSG==
Allow declaring that conversion to palantir-java-format has been started, which ensures that conflicting checkstyle rules are removed.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

