### PR TITLE
NonComparableStreamSort validates direct types

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NonComparableStreamSortTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NonComparableStreamSortTests.java
@@ -41,7 +41,7 @@ public class NonComparableStreamSortTests {
                 "class Test {",
                 "   public static final void main(String[] args) {",
                 "       List<Object> list = new ArrayList<>();",
-                "       // BUG: Stream.sorted() should only be called on streams of Comparable types.",
+                "       // BUG: Diagnostic contains: Stream.sorted() should only be called on streams of Comparable",
                 "       list.stream().sorted();",
                 "   }",
                 "}"
@@ -59,6 +59,23 @@ public class NonComparableStreamSortTests {
                 "       List<String> list = new ArrayList<>();",
                 "       list.stream().sorted();",
                 "   }",
+                "}"
+        ).doTest();
+    }
+
+    @Test
+    public void should_fail_without_direct_types() {
+        compilationHelper.addSourceLines(
+                "Test.java",
+                "import java.util.List;",
+                "import java.util.ArrayList;",
+                "class Test {",
+                "   public static final void main(String[] args) {",
+                "       List<Iface> list = new ArrayList<>();",
+                "       // BUG: Diagnostic contains: Stream.sorted() should only be called on streams of Comparable",
+                "       list.stream().sorted();",
+                "   }",
+                "   interface Iface {}",
                 "}"
         ).doTest();
     }

--- a/changelog/@unreleased/pr-1070.v2.yml
+++ b/changelog/@unreleased/pr-1070.v2.yml
@@ -1,0 +1,13 @@
+type: improvement
+improvement:
+  description: |-
+    Improve `NonComparableStreamSort` to validate that stream types implement comparable, as opposed to validating that casting to comparable does not cause a compiler error.
+
+    This commit reduces the severity to WARNING because it's
+    possible that the check will flag code that happens to work
+    today, but we strongly recommend against sorting streams of
+    a type that is not directly comparable without a custom
+    comparator because it is likely to break later due to lack
+    of enforcement by the type system.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1070


### PR DESCRIPTION
## Before this PR
Previously NonComparableStreamSort only failed on types which
would cause a compilation error casting to Comparable. Now we
validate that the stream type is a subtype of Comparable.

## After this PR
==COMMIT_MSG==
Improve `NonComparableStreamSort` to validate that stream types implement comparable, as opposed to validating that casting to comparable does not cause a compiler error.

This commit reduces the severity to WARNING because it's
possible that the check will flag code that happens to work
today, but we strongly recommend against sorting streams of
a type that is not directly comparable without a custom
comparator because it is likely to break later due to lack
of enforcement by the type system.
==COMMIT_MSG==

## Possible downsides?
Possible this will cause friction if it flags new things. That friction is substantially lower than failures at runtime.