### PR TITLE
PreferAssertj iterable-map fix retains map type parameters

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -465,9 +465,13 @@ public final class PreferAssertj
         String actualArgumentString = argSource(tree, state, actualIndex);
         ExpressionTree actualArgument = tree.getArguments().get(actualIndex);
         if (isIterableMap(actualArgument, state)) {
-            actualArgumentString = String.format("(%s<?, ?>) %s",
-                    SuggestedFixes.qualifyType(state, fix, "java.util.Map"),
-                    actualArgumentString);
+            String qualifiedMap = SuggestedFixes.qualifyType(
+                    state,
+                    fix,
+                    state.getTypes().asSuper(
+                            ASTHelpers.getType(actualArgument),
+                            state.getSymbolFromString("java.util.Map")));
+            actualArgumentString = String.format("(%s) %s", qualifiedMap, actualArgumentString);
         }
         assertThat.accept(qualified + '(' + actualArgumentString + ')', fix);
         return buildDescription(tree)

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -465,7 +465,7 @@ public final class PreferAssertj
         String actualArgumentString = argSource(tree, state, actualIndex);
         ExpressionTree actualArgument = tree.getArguments().get(actualIndex);
         if (isIterableMap(actualArgument, state)) {
-            String qualifiedMap = SuggestedFixes.qualifyType(
+            String qualifiedMap = SuggestedFixes.prettyType(
                     state,
                     fix,
                     state.getTypes().asSuper(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferAssertjTests.java
@@ -946,11 +946,11 @@ public class PreferAssertjTests {
                         "class Test {",
                         "  interface IMap<K, V> extends Map<K, V>, Iterable<Map.Entry<K, V>> {}",
                         "  <K, V> void foo(IMap<K, V> expected, IMap<K, V> actual) {",
-                        "    assertThat((Map<?, ?>) actual).isEqualTo(expected);",
-                        "    assertThat((Map<?, ?>) actual).isEqualTo(expected);",
-                        "    assertThat((Map<?, ?>) actual).describedAs(\"desc\").isEqualTo(expected);",
-                        "    assertThat((Map<?, ?>) actual).isNull();",
-                        "    assertThat((Map<?, ?>) actual).describedAs(\"desc\").isNull();",
+                        "    assertThat((Map<K, V>) actual).isEqualTo(expected);",
+                        "    assertThat((Map<K, V>) actual).isEqualTo(expected);",
+                        "    assertThat((Map<K, V>) actual).describedAs(\"desc\").isEqualTo(expected);",
+                        "    assertThat((Map<K, V>) actual).isNull();",
+                        "    assertThat((Map<K, V>) actual).describedAs(\"desc\").isNull();",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/changelog/@unreleased/pr-1071.v2.yml
+++ b/changelog/@unreleased/pr-1071.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: PreferAssertj iterable-map fix retains map type parameters
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1071


### PR DESCRIPTION
==COMMIT_MSG==
PreferAssertj iterable-map fix retains map type parameters
==COMMIT_MSG==

