### PR TITLE
refaster for assertThat(a == b)

### DIFF
--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjPrimitiveEquals.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjPrimitiveEquals.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjPrimitiveEquals {
+
+    @BeforeTemplate
+    void bytes(byte actual, byte expected) {
+        assertThat(actual == expected).isTrue();
+    }
+
+    @BeforeTemplate
+    void shorts(short actual, short expected) {
+        assertThat(actual == expected).isTrue();
+    }
+
+    @BeforeTemplate
+    void ints(int actual, int expected) {
+        assertThat(actual == expected).isTrue();
+    }
+
+    @BeforeTemplate
+    void longs(long actual, long expected) {
+        assertThat(actual == expected).isTrue();
+    }
+
+    @BeforeTemplate
+    void floats(float actual, float expected) {
+        assertThat(actual == expected).isTrue();
+    }
+
+    @BeforeTemplate
+    void doubles(double actual, double expected) {
+        assertThat(actual == expected).isTrue();
+    }
+
+    @BeforeTemplate
+    void chars(char actual, char expected) {
+        assertThat(actual == expected).isTrue();
+    }
+
+    @BeforeTemplate
+    void booleans(boolean actual, boolean expected) {
+        assertThat(actual == expected).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    <T> void after(T actual, T expected) {
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjPrimitiveEqualsWithDescription.java
+++ b/baseline-refaster-rules/src/main/java/com/palantir/baseline/refaster/AssertjPrimitiveEqualsWithDescription.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Repeated;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+
+public final class AssertjPrimitiveEqualsWithDescription {
+
+    @BeforeTemplate
+    void bytes(byte actual, byte expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual == expected).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @BeforeTemplate
+    void shorts(short actual, short expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual == expected).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @BeforeTemplate
+    void ints(int actual, int expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual == expected).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @BeforeTemplate
+    void longs(long actual, long expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual == expected).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @BeforeTemplate
+    void floats(float actual, float expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual == expected).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @BeforeTemplate
+    void doubles(double actual, double expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual == expected).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @BeforeTemplate
+    void chars(char actual, char expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual == expected).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @BeforeTemplate
+    void booleans(boolean actual, boolean expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual == expected).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+    <T> void after(T actual, T expected, String description, @Repeated Object descriptionArgs) {
+        assertThat(actual).describedAs(description, descriptionArgs).isEqualTo(expected);
+    }
+}

--- a/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjPrimitiveEqualsTest.java
+++ b/baseline-refaster-rules/src/test/java/com/palantir/baseline/refaster/AssertjPrimitiveEqualsTest.java
@@ -1,0 +1,173 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.refaster;
+
+import org.junit.Test;
+
+public class AssertjPrimitiveEqualsTest {
+    @Test
+    public void bytes() {
+        RefasterTestHelper
+                .forRefactoring(AssertjPrimitiveEquals.class, AssertjPrimitiveEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(byte a, byte b) { assertThat(a == b).isTrue(); }",
+                        "  void g(byte a, byte b) { assertThat(a == b).describedAs(\"desc\").isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(byte a, byte b) { assertThat(a).isEqualTo(b); }",
+                        "  void g(byte a, byte b) { assertThat(a).describedAs(\"desc\").isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void shorts() {
+        RefasterTestHelper
+                .forRefactoring(AssertjPrimitiveEquals.class, AssertjPrimitiveEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(short a, short b) { assertThat(a == b).isTrue(); }",
+                        "  void g(short a, short b) { assertThat(a == b).describedAs(\"desc\").isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(short a, short b) { assertThat(a).isEqualTo(b); }",
+                        "  void g(short a, short b) { assertThat(a).describedAs(\"desc\").isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void ints() {
+        RefasterTestHelper
+                .forRefactoring(AssertjPrimitiveEquals.class, AssertjPrimitiveEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(int a, int b) { assertThat(a == b).isTrue(); }",
+                        "  void g(int a, int b) { assertThat(a == b).describedAs(\"desc\").isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(int a, int b) { assertThat(a).isEqualTo(b); }",
+                        "  void g(int a, int b) { assertThat(a).describedAs(\"desc\").isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void longs() {
+        RefasterTestHelper
+                .forRefactoring(AssertjPrimitiveEquals.class, AssertjPrimitiveEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(long a, long b) { assertThat(a == b).isTrue(); }",
+                        "  void g(long a, long b) { assertThat(a == b).describedAs(\"desc\").isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(long a, long b) { assertThat(a).isEqualTo(b); }",
+                        "  void g(long a, long b) { assertThat(a).describedAs(\"desc\").isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void floats() {
+        RefasterTestHelper
+                .forRefactoring(AssertjPrimitiveEquals.class, AssertjPrimitiveEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(float a, float b) { assertThat(a == b).isTrue(); }",
+                        "  void g(float a, float b) { assertThat(a == b).describedAs(\"desc\").isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(float a, float b) { assertThat(a).isEqualTo(b); }",
+                        "  void g(float a, float b) { assertThat(a).describedAs(\"desc\").isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void doubles() {
+        RefasterTestHelper
+                .forRefactoring(AssertjPrimitiveEquals.class, AssertjPrimitiveEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(double a, double b) { assertThat(a == b).isTrue(); }",
+                        "  void g(double a, double b) { assertThat(a == b).describedAs(\"desc\").isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(double a, double b) { assertThat(a).isEqualTo(b); }",
+                        "  void g(double a, double b) { assertThat(a).describedAs(\"desc\").isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void chars() {
+        RefasterTestHelper
+                .forRefactoring(AssertjPrimitiveEquals.class, AssertjPrimitiveEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(char a, char b) { assertThat(a == b).isTrue(); }",
+                        "  void g(char a, char b) { assertThat(a == b).describedAs(\"desc\").isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(char a, char b) { assertThat(a).isEqualTo(b); }",
+                        "  void g(char a, char b) { assertThat(a).describedAs(\"desc\").isEqualTo(b); }",
+                        "}");
+    }
+
+    @Test
+    public void booleans() {
+        RefasterTestHelper
+                .forRefactoring(AssertjPrimitiveEquals.class, AssertjPrimitiveEqualsWithDescription.class)
+                .withInputLines(
+                        "Test",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(boolean a, boolean b) { assertThat(a == b).isTrue(); }",
+                        "  void g(boolean a, boolean b) { assertThat(a == b).describedAs(\"desc\").isTrue(); }",
+                        "}")
+                .hasOutputLines(
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(boolean a, boolean b) { assertThat(a).isEqualTo(b); }",
+                        "  void g(boolean a, boolean b) { assertThat(a).describedAs(\"desc\").isEqualTo(b); }",
+                        "}");
+    }
+}

--- a/changelog/@unreleased/pr-1078.v2.yml
+++ b/changelog/@unreleased/pr-1078.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: refaster will automatically fix up assertions between primitives (a
+    == b) to provide better error messages
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1078


### PR DESCRIPTION
## Before this PR

I just came across this line of code:
```
assertThat(someAtomicLong.get() == MAX_QUEUE_SIZE).isTrue()
```

Which is bad because if the assertion ever fails, the dev will get an error message like "false did not equal true".

## After this PR
==COMMIT_MSG==
refaster will automatically fix up assertions between primitives (a == b) to provide better error messages
==COMMIT_MSG==

## Possible downsides?
- we might get the expected / actual the wrong way round, but I think this is still net positive.

