### PR TITLE
errorprone 2.3.3 -> 2.3.4

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
@@ -28,7 +28,6 @@ import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
-import java.util.regex.Pattern;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -44,19 +43,20 @@ public final class GradleCacheableTaskAction extends BugChecker implements Lambd
 
     private static final Matcher<ExpressionTree> TASK_ACTION = MethodMatchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Task")
-            .withNameMatching(Pattern.compile("doFirst|doLast"));
+            .namedAnyOf("doFirst", "doLast");
 
-    // private static final Matcher<ExpressionTree> IS_TASK_ACTION =
-    //         Matchers.allOf(Matchers.parentNode(Matchers.methodInvocation(TASK_ACTION)), IS_ACTION);
+    private static final Matcher<ExpressionTree> IS_TASK_ACTION =
+            Matchers.allOf(
+                    Matchers.parentNode(Matchers.toType(ExpressionTree.class, Matchers.methodInvocation(TASK_ACTION))),
+                    IS_ACTION);
 
     @Override
-    public Description matchLambdaExpression(LambdaExpressionTree _tree, VisitorState _state) {
-        return Description.NO_MATCH;
-        // if (!IS_TASK_ACTION.matches(tree, state)) {
-        //     return Description.NO_MATCH;
-        // }
-        // return buildDescription(tree)
-        //         .setMessage("Gradle task actions are not cacheable when implemented by lambdas")
-        //         .build();
+    public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
+        if (!IS_TASK_ACTION.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+        return buildDescription(tree)
+                .setMessage("Gradle task actions are not cacheable when implemented by lambdas")
+                .build();
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableTaskAction.java
@@ -46,16 +46,17 @@ public final class GradleCacheableTaskAction extends BugChecker implements Lambd
             .onDescendantOf("org.gradle.api.Task")
             .withNameMatching(Pattern.compile("doFirst|doLast"));
 
-    private static final Matcher<ExpressionTree> IS_TASK_ACTION =
-            Matchers.allOf(Matchers.parentNode(Matchers.methodInvocation(TASK_ACTION)), IS_ACTION);
+    // private static final Matcher<ExpressionTree> IS_TASK_ACTION =
+    //         Matchers.allOf(Matchers.parentNode(Matchers.methodInvocation(TASK_ACTION)), IS_ACTION);
 
     @Override
-    public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
-        if (!IS_TASK_ACTION.matches(tree, state)) {
-            return Description.NO_MATCH;
-        }
-        return buildDescription(tree)
-                .setMessage("Gradle task actions are not cacheable when implemented by lambdas")
-                .build();
+    public Description matchLambdaExpression(LambdaExpressionTree _tree, VisitorState _state) {
+        return Description.NO_MATCH;
+        // if (!IS_TASK_ACTION.matches(tree, state)) {
+        //     return Description.NO_MATCH;
+        // }
+        // return buildDescription(tree)
+        //         .setMessage("Gradle task actions are not cacheable when implemented by lambdas")
+        //         .build();
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ReadReturnValueIgnored.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ReadReturnValueIgnored.java
@@ -104,8 +104,8 @@ public final class ReadReturnValueIgnored extends AbstractReturnValueIgnored {
     }
 
     @Override
-    public Description describe(MethodInvocationTree methodInvocationTree, VisitorState state) {
-        Description result = super.describe(methodInvocationTree, state);
+    public Description describeReturnValueIgnored(MethodInvocationTree methodInvocationTree, VisitorState state) {
+        Description result = super.describeReturnValueIgnored(methodInvocationTree, state);
         if (Description.NO_MATCH.equals(result)) {
             return result;
         }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -434,7 +434,8 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                                             ? null
                                             : state.getSourceForNode(variableTree.getModifiers()));
                     String newContent = String.format(
-                            "%s%s unused", modifiers.isEmpty() ? "" : (modifiers + " "), variableTree.getType());
+                            "%s%s unused", modifiers.isEmpty() ? "" : (modifiers + " "),
+                            state.getSourceForNode(variableTree.getType()));
                     // The new content for the second fix should be identical to the content for the first
                     // fix in this case because we can't just remove the enhanced for loop variable.
                     fix.replace(variableTree, newContent);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessageTests.java
@@ -17,7 +17,6 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -25,15 +24,8 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 @Execution(ExecutionMode.CONCURRENT)
 public final class Slf4jConstantLogMessageTests {
 
-    private CompilationTestHelper compilationHelper;
-
-    @BeforeEach
-    public void before() {
-        compilationHelper = CompilationTestHelper.newInstance(Slf4jConstantLogMessage.class, getClass());
-    }
-
-    private void test(String log) throws Exception {
-        compilationHelper
+    private void test(String log) {
+        helper()
                 .addSourceLines(
                         "Test.java",
                         "import org.slf4j.Logger;",
@@ -76,8 +68,8 @@ public final class Slf4jConstantLogMessageTests {
     }
 
     @Test
-    public void negative() throws Exception {
-        compilationHelper
+    public void negative() {
+        helper()
                 .addSourceLines(
                         "Test.java",
                         "import org.slf4j.Logger;",
@@ -150,4 +142,7 @@ public final class Slf4jConstantLogMessageTests {
                 .doTest();
     }
 
+    private CompilationTestHelper helper() {
+        return CompilationTestHelper.newInstance(Slf4jConstantLogMessage.class, getClass());
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ allprojects {
                 check("PreferSafeLoggableExceptions", CheckSeverity.OFF)
                 check("PreferSafeLoggingPreconditions", CheckSeverity.OFF)
                 check("PreconditionsConstantMessage", CheckSeverity.OFF)
+                check("GradleCacheableTaskAction", CheckSeverity.OFF)
             }
         }
     }

--- a/changelog/@unreleased/pr-1082.v2.yml
+++ b/changelog/@unreleased/pr-1082.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: "We now run error-prone 2.3.4, to benefit from smarter static analysis,
+    and hopefully pick up the claimed performance Improvements: \n\n> 40% speedup
+    when run against Google's codebase with errors enabled."
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1082

--- a/versions.props
+++ b/versions.props
@@ -1,9 +1,9 @@
 com.diffplug.spotless:spotless-plugin-gradle = 3.26.0
 com.google.auto.service:auto-service = 1.0-rc4
-com.google.errorprone:error_prone_annotations = 2.3.3
-com.google.errorprone:error_prone_core = 2.3.3
-com.google.errorprone:error_prone_refaster = 2.3.3
-com.google.errorprone:error_prone_test_helpers = 2.3.3
+com.google.errorprone:error_prone_annotations = 2.3.4
+com.google.errorprone:error_prone_core = 2.3.4
+com.google.errorprone:error_prone_refaster = 2.3.4
+com.google.errorprone:error_prone_test_helpers = 2.3.4
 com.google.guava:guava = 27.1-jre
 com.netflix.nebula:nebula-dependency-recommender = 9.0.0
 com.palantir.configurationresolver:gradle-configuration-resolver-plugin = 0.4.0


### PR DESCRIPTION
## Before this PR

error-prone's last release was in March, with a _ton_ of cool stuff piled up on develop.

## After this PR
==COMMIT_MSG==
We now run error-prone 2.3.4, to benefit from smarter static analysis, and hopefully pick up the claimed performance Improvements: 

> 40% speedup when run against Google's codebase with errors enabled.
==COMMIT_MSG==

https://github.com/google/error-prone/releases

## Possible downsides?
- any release has a risk of unexpected false positives, slowing down error-prone adoption

