### PR TITLE
Add dependency on mockito-errorprone

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -7,6 +7,7 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
     compile 'com.google.errorprone:error_prone_core'
+    compile 'org.mockito:mockito-errorprone'
 
     testCompile gradleApi()
     testCompile 'com.palantir.tokens:auth-tokens'

--- a/changelog/@unreleased/pr-1085.v2.yml
+++ b/changelog/@unreleased/pr-1085.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Baseline now depends on `mockito-errorprone` to get Mockito error-prone
+    checks.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1085

--- a/versions.props
+++ b/versions.props
@@ -25,7 +25,7 @@ commons-lang:commons-lang = 2.6
 org.assertj:assertj-core = 3.14.0
 org.hamcrest:hamcrest-core = 2.2
 org.junit.jupiter:* = 5.5.2
-org.mockito:mockito-core = 3.1.0
+org.mockito:* = 3.1.0
 com.fasterxml.jackson.*:* = 2.10.1
 com.palantir.tokens:auth-tokens = 3.6.1
 


### PR DESCRIPTION
The `MockitoInternalUsage` error-prone check was moved out of `error_prone_core` in https://github.com/google/error-prone/commit/8e821c8e4f0d587c6d64de24b8dfd562e4a8aea7. This PR adds `org.mockito:mockito-errorprone` as a dependency of `baseline-error-prone` to pull in Mockito error-prone checks.
