### PR TITLE
Set `-XepCompilingTestOnlyCode` for tasks named `compileTestJava`

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchSpecificity.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchSpecificity.java
@@ -77,6 +77,9 @@ public final class CatchSpecificity extends BugChecker implements BugChecker.Try
     @Override
     @SuppressWarnings("CyclomaticComplexity")
     public Description matchTry(TryTree tree, VisitorState state) {
+        if (TestCheckUtils.isTestCodeQuickCheck(state)) {
+            return Description.NO_MATCH;
+        }
         List<Type> encounteredTypes = new ArrayList<>();
         for (CatchTree catchTree : tree.getCatches()) {
             Tree catchTypeTree = catchTree.getParameter().getType();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggableExceptions.java
@@ -65,7 +65,8 @@ public final class PreferSafeLoggableExceptions extends BugChecker implements Bu
     public Description matchNewClass(NewClassTree tree, VisitorState state) {
         // This is invoked for all new class creations, so we execute a fast check first to
         // rule out irrelevant code before doing more involved work.
-        if (!FAST_EXCEPTION_TYPE_CHECK.matches(tree.getIdentifier(), state)) {
+        if (TestCheckUtils.isTestCodeQuickCheck(state)
+                || !FAST_EXCEPTION_TYPE_CHECK.matches(tree.getIdentifier(), state)) {
             return Description.NO_MATCH;
         }
         List<? extends ExpressionTree> args = tree.getArguments();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -71,7 +71,7 @@ public final class PreferSafeLoggingPreconditions extends BugChecker implements 
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (!METHOD_MATCHER.matches(tree, state)) {
+        if (TestCheckUtils.isTestCodeQuickCheck(state) || !METHOD_MATCHER.matches(tree, state)) {
             return Description.NO_MATCH;
         }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -58,7 +58,7 @@ public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocati
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (!LOG_METHOD.matches(tree, state)) {
+        if (TestCheckUtils.isTestCodeQuickCheck(state) || !LOG_METHOD.matches(tree, state)) {
             return Description.NO_MATCH;
         }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
@@ -33,6 +33,9 @@ final class TestCheckUtils {
 
     /** Note that this is a relatively expensive check and should be executed after simpler validation. */
     static boolean isTestCode(VisitorState state) {
+        if (isTestCodeQuickCheck(state)) {
+            return true;
+        }
         TreePath path = state.getPath();
         for (Tree ancestor : path) {
             if (ancestor instanceof ClassTree && hasTestCases.matches((ClassTree) ancestor, state)) {
@@ -44,6 +47,11 @@ final class TestCheckUtils {
                 .map(ImportTree::getQualifiedIdentifier)
                 .map(Object::toString)
                 .anyMatch(TestCheckUtils::isTestImport);
+    }
+
+    /** Returns true if the error-prone <code>-XepCompilingTestOnlyCode</code> option is set. */
+    static boolean isTestCodeQuickCheck(VisitorState state) {
+        return state.errorProneOptions().isTestOnlyTarget();
     }
 
     private static final Matcher<ClassTree> hasJUnit5TestCases =

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ThrowError.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ThrowError.java
@@ -57,6 +57,9 @@ public final class ThrowError extends BugChecker implements BugChecker.ThrowTree
 
     @Override
     public Description matchThrow(ThrowTree tree, VisitorState state) {
+        if (TestCheckUtils.isTestCodeQuickCheck(state)) {
+            return Description.NO_MATCH;
+        }
         ExpressionTree expression = tree.getExpression();
         if (!(expression instanceof NewClassTree)) {
             return Description.NO_MATCH;

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ValidateConstantMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ValidateConstantMessage.java
@@ -70,7 +70,7 @@ public final class ValidateConstantMessage extends BugChecker implements BugChec
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (!VALIDATE_METHODS.matches(tree, state)) {
+        if (TestCheckUtils.isTestCodeQuickCheck(state) || !VALIDATE_METHODS.matches(tree, state)) {
             return Description.NO_MATCH;
         }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -216,6 +216,11 @@ public final class BaselineErrorProne implements Plugin<Project> {
             // Don't apply refaster to itself...
             return;
         }
+        // Hint to error-prone that we're compiling test code
+        if (javaCompile.getName().endsWith("compileTestJava")) {
+            errorProneOptions.getErrorproneArgumentProviders()
+                    .add(() -> ImmutableList.of("-XepCompilingTestOnlyCode"));
+        }
 
         if (isRefactoring(project)) {
             // Don't attempt to cache since it won't capture the source files that might be modified


### PR DESCRIPTION
This gives us a much faster way to check if we're in test code,
though doesn't allow us to tell whether or not we're not in test
code. Projects with lots of tests (obviously all of ours) will
build faster.

## After this PR
==COMMIT_MSG==
Set `-XepCompilingTestOnlyCode` for tasks named `compileTestJava`
==COMMIT_MSG==

TODO: needs test

