### PR TITLE
PreferJavaTimeOverload:OFF

### DIFF
--- a/changelog/@unreleased/pr-1094.v2.yml
+++ b/changelog/@unreleased/pr-1094.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The `PreferJavaTimeOverload` error-prone check is turned off as it
+    produces noisy false positives relating to custom AssertJ utilities.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1094

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -50,7 +50,8 @@ public class BaselineErrorProneExtension {
             // Built-in checks
             "ArrayEquals",
             "MissingOverride",
-            "UnnecessaryParentheses");
+            "UnnecessaryParentheses",
+            "PreferJavaTimeOverload");
 
     private final ListProperty<String> patchChecks;
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -192,6 +192,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.setExcludedPaths(String.format(
                 "%s%s(build|src%sgenerated.*)%s.*", Pattern.quote(projectPath), separator, separator, separator));
         errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);
+        errorProneOptions.check("PreferJavaTimeOverload", CheckSeverity.OFF); // https://github.com/google/error-prone/issues/1435, https://github.com/google/error-prone/issues/1437
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
         errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
@@ -200,13 +201,13 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.check("URLEqualsHashCode", CheckSeverity.ERROR);
 
         if (jdkVersion.compareTo(JavaVersion.toVersion("12.0.1")) >= 0) {
-            // Errorprone isn't officially compatible with Java12, but in practise everything
+            // As of version 2.3.4, Errorprone isn't officially compatible with Java12, but in practise everything
             // works apart from this one check: https://github.com/google/error-prone/issues/1106
             errorProneOptions.check("Finally", CheckSeverity.OFF);
         }
 
         if (jdkVersion.compareTo(JavaVersion.toVersion("13.0.0")) >= 0) {
-            // Errorprone isn't officially compatible with Java13 either
+            // Errorprone 2.3.4 isn't officially compatible with Java13 either
             // https://github.com/google/error-prone/issues/1106
             errorProneOptions.check("TypeParameterUnusedInFormals", CheckSeverity.OFF);
             errorProneOptions.check("PreferCollectionConstructors", CheckSeverity.OFF);


### PR DESCRIPTION
## Before this PR

A bunch of our repos internally use custom assertj libraries (e.g. the c-j-r-api test-utils, audit logging test utils, safe-logging test-utils), which triggers this wonky error-prone behaviour: https://github.com/google/error-prone/issues/1435

I even saw this pretty non-sensical message internally in sls-logging:

```
/Volumes/git/sls-logging/sls-logging-log4j/src/test/java/com/palantir/sls/logging/log4j/Log4jSlsLoggingSubscribersMetricsTest.java:143: warning: [PreferJavaTimeOverload] If the numeric primitive (eventLengthHistogram.getCount()) represents a Instant, please call assertThat(Instant) instead.
                    .untilAsserted(() -> assertThat(eventLengthHistogram.getCount()).isOne());
```

## After this PR
==COMMIT_MSG==
The `PreferJavaTimeOverload` error-prone check is turned off to avoid false positives
==COMMIT_MSG==

## Possible downsides?


