### PR TITLE
Turn off UnnecessaryLambda, ThrowSpecificity on Java 13

### DIFF
--- a/changelog/@unreleased/pr-1095.v2.yml
+++ b/changelog/@unreleased/pr-1095.v2.yml
@@ -1,7 +1,7 @@
 type: fix
 fix:
-  description: When building with Java13, two more error-prone checks are turned off
-    to avoid NoSuchMethodErrors in the compiler. They still run if your project builds
-    on Java8 or 11.
+  description: When building with Java13, two more error-prone checks (`UnnecessaryLambda`
+    and `ThrowSpecificity`) are turned off to avoid NoSuchMethodErrors in the compiler.
+    They still run if your project builds on Java8 or 11.
   links:
   - https://github.com/palantir/gradle-baseline/pull/1095

--- a/changelog/@unreleased/pr-1095.v2.yml
+++ b/changelog/@unreleased/pr-1095.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: When building with Java13, two more error-prone checks are turned off
+    to avoid NoSuchMethodErrors in the compiler. They still run if your project builds
+    on Java8 or 11.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1095

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -211,6 +211,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
             // https://github.com/google/error-prone/issues/1106
             errorProneOptions.check("TypeParameterUnusedInFormals", CheckSeverity.OFF);
             errorProneOptions.check("PreferCollectionConstructors", CheckSeverity.OFF);
+            errorProneOptions.check("UnnecessaryLambda", CheckSeverity.OFF);
+            errorProneOptions.check("ThrowSpecificity", CheckSeverity.OFF);
         }
 
         if (javaCompile.equals(compileRefaster)) {


### PR DESCRIPTION
## Before this PR

A few early adopters internally are building/running with Java13, but the recent error-prone 2.3.4 upgrade seems to have introduced a couple of blockers, seemingly with a similar root cause:
```
Caused by: java.lang.NoSuchMethodException: com.sun.tools.javac.comp.Resolve.findIdent(com.sun.tools.javac.comp.Env,com.sun.tools.javac.util.Name,com.sun.tools.javac.code.Kinds$KindSelector)
```


```
An unhandled exception was thrown by the Error Prone static analysis plugin.
    private static final Supplier<RuntimeException> NOT_AUTHORIZED = () -> new ServiceException(
                                                    ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:

     error-prone version: 2.3.4
     BugPattern: UnnecessaryLambda
     Stack Trace:
     java.lang.LinkageError: com.sun.tools.javac.comp.Resolve.findIdent(com.sun.tools.javac.comp.Env,com.sun.tools.javac.util.Name,com.sun.tools.javac.code.Kinds$KindSelector)
        at com.google.errorprone.util.FindIdentifiers.findIdent(FindIdentifiers.java:104)
        at com.google.errorprone.fixes.SuggestedFixes.qualifyType(SuggestedFixes.java:289)
        at com.google.errorprone.fixes.SuggestedFixes$5.visitClassType(SuggestedFixes.java:1082)
        at com.google.errorprone.fixes.SuggestedFixes$5.visitClassType(SuggestedFixes.java:1065)
        at jdk.compiler/com.sun.tools.javac.code.Type$ClassType.accept(Type.java:1010)
        at com.google.errorprone.fixes.SuggestedFixes.prettyType(SuggestedFixes.java:1064)
        at com.google.errorprone.bugpatterns.UnnecessaryLambda.lambdaToMethod(UnnecessaryLambda.java:215)
        at com.google.errorprone.bugpatterns.UnnecessaryLambda.matchVariable(UnnecessaryLambda.java:162)
        at com.google.errorprone.scanner.ErrorProneScanner.processMatchers(ErrorProneScanner.java:451)
        ...
  Caused by: java.lang.NoSuchMethodException: com.sun.tools.javac.comp.Resolve.findIdent(com.sun.tools.javac.comp.Env,com.sun.tools.javac.util.Name,com.sun.tools.javac.code.Kinds$KindSelector)
        at java.base/java.lang.Class.getDeclaredMethod(Class.java:2476)
        at com.google.errorprone.util.FindIdentifiers.findIdent(FindIdentifiers.java:98)
        ... 174 more
```

```
An unhandled exception was thrown by the Error Prone static analysis plugin.
    private Stream<SourceMessage> runInternal() throws Exception {
                                  ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.3.4
     BugPattern: ThrowSpecificity
     Stack Trace:
     java.lang.LinkageError: com.sun.tools.javac.comp.Resolve.findIdent(com.sun.tools.javac.comp.Env,com.sun.tools.javac.util.Name,com.sun.tools.javac.code.Kinds$KindSelector)
  	at com.google.errorprone.util.FindIdentifiers.findIdent(FindIdentifiers.java:104)
  	at com.google.errorprone.fixes.SuggestedFixes.qualifyType(SuggestedFixes.java:289)
  	at com.google.errorprone.fixes.SuggestedFixes$5.visitClassType(SuggestedFixes.java:1082)
  	at com.google.errorprone.fixes.SuggestedFixes$5.visitClassType(SuggestedFixes.java:1065)
  	at jdk.compiler/com.sun.tools.javac.code.Type$ClassType.accept(Type.java:1010)
  	at com.google.errorprone.fixes.SuggestedFixes.prettyType(SuggestedFixes.java:1064)
  	at com.palantir.baseline.errorprone.ThrowSpecificity.lambda$matchMethod$1(ThrowSpecificity.java:93)
  	...
  Caused by: java.lang.NoSuchMethodException: com.sun.tools.javac.comp.Resolve.findIdent(com.sun.tools.javac.comp.Env,com.sun.tools.javac.util.Name,com.sun.tools.javac.code.Kinds$KindSelector)
  	at java.base/java.lang.Class.getDeclaredMethod(Class.java:2476)
  	at com.google.errorprone.util.FindIdentifiers.findIdent(FindIdentifiers.java:98)
  	... 276 more
```

## After this PR
==COMMIT_MSG==
When building with Java13, two more error-prone checks (`UnnecessaryLambda` and `ThrowSpecificity`) are turned off to avoid NoSuchMethodErrors in the compiler. They still run if your project builds on Java8 or 11.
==COMMIT_MSG==

## Possible downsides?
- if we forget to re-enable these in the future then we're just taking away people's nice static analysis :/
- honestly I think there are probably a crap ton more problems like this, so this PR is likely not completely sufficient to get people building with Java13...

