### PR TITLE
Disable ThrowSpecificty and CatchSpecificity fixes by default

### DIFF
--- a/changelog/@unreleased/pr-1098.v2.yml
+++ b/changelog/@unreleased/pr-1098.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Disable ThrowSpecificty and CatchSpecificity fixes by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1098

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -25,7 +25,8 @@ public class BaselineErrorProneExtension {
             // Baseline checks
             "AssertjPrimitiveComparison",
             "CatchBlockLogException",
-            "CatchSpecificity",
+            // TODO(ckozak): re-enable pending scala check
+            //"CatchSpecificity",
             "ExecutorSubmitRunnableFutureIgnored",
             "FinalClass",
             "LambdaMethodReference",
@@ -45,7 +46,8 @@ public class BaselineErrorProneExtension {
             "StrictUnusedVariable",
             "StringBuilderConstantParameters",
             "ThrowError",
-            "ThrowSpecificity",
+            // TODO(ckozak): re-enable pending scala check
+            //"ThrowSpecificity",
 
             // Built-in checks
             "ArrayEquals",


### PR DESCRIPTION
We can reenable these once we have scala detection. Scala code
throws checked exceptions without declaring them.

## Before this PR
Code which interacts with scala stops catching checked exceptions because they aren't declared.

## After this PR
==COMMIT_MSG==
Disable ThrowSpecificty and CatchSpecificity fixes by default
==COMMIT_MSG==

## Possible downsides?
`Note:` calling these out in the compiler logs until we implement scala detection.

