### PR TITLE
Don't apply errorprone rules to refaster rules project

### DIFF
--- a/baseline-refaster-rules/build.gradle
+++ b/baseline-refaster-rules/build.gradle
@@ -15,3 +15,5 @@ dependencies {
 // Do not apply refaster rules
 tasks.compileRefaster.enabled = false
 tasks.compileJava.onlyIf { project.properties.refasterApply == null }
+// Do not apply errorprone rules
+tasks.compileJava.options.errorprone.enabled = false


### PR DESCRIPTION
## Before this PR

Baseline upgrades rewrite our own refaster rules because they violate some of the errorproine rules.

See example: https://github.com/palantir/gradle-baseline/pull/1096

## After this PR
==COMMIT_MSG==
Don't apply errorprone rules to the refaster rules project
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

