### PR TITLE
Allow _ prefix for local var

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -454,7 +454,7 @@
         <module name="LocalFinalVariableName"/> <!-- Java Style Guide: Local variable names -->
         <module name="LocalVariableName"> <!-- Java Style Guide: Local variable names -->
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+            <property name="format" value="^_?[a-z][a-zA-Z0-9]+$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern" value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -237,4 +237,3 @@ public class StrictUnusedVariableTest {
                 .doTest();
     }
 }
-

--- a/changelog/@unreleased/pr-1104.v2.yml
+++ b/changelog/@unreleased/pr-1104.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Allow local variables to start with `_` if they are unused but still
+    necessary in order to satisfy `StrictUnusedVariable`'s exclusion list.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1104


### PR DESCRIPTION
## Before this PR

Can't write code that satisfies both `CheckReturnValue` and `StrictUnusedVariable` - when a variable is created only to acklowledge that we don't care about the result of a `CheckReturnValue` function.
The only way to satisfy them both is to prepend `_` to the variable name, but checkstyle bans that. 😠 

## After this PR
==COMMIT_MSG==
Allow local variables to start with `_` if they are unused but still necessary in order to satisfy `StrictUnusedVariable`'s exclusion list.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

