### PR TITLE
Fix: Disable CatchSpecificity on java 13

### DIFF
--- a/changelog/@unreleased/pr-1107.v2.yml
+++ b/changelog/@unreleased/pr-1107.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Disable CatchSpecificity on java 13
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1107

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -211,6 +211,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
             // https://github.com/google/error-prone/issues/1106
             errorProneOptions.check("TypeParameterUnusedInFormals", CheckSeverity.OFF);
             errorProneOptions.check("PreferCollectionConstructors", CheckSeverity.OFF);
+            errorProneOptions.check("CatchSpecificity", CheckSeverity.OFF);
         }
 
         if (javaCompile.equals(compileRefaster)) {


### PR DESCRIPTION
## Before this PR
```
An unhandled exception was thrown by the Error Prone static analysis plugin.
ERROR: An unhandled exception was thrown by the Error Prone static analysis plugin.
                    try {
                    ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.3.4
     BugPattern: CatchSpecificity
```

## After this PR
==COMMIT_MSG==
Disable CatchSpecificity on java 13
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

