### PR TITLE
Allow non-default errorprone fixes to be applied from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,15 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 
 There exist a number of programmatic code modifications available via [refaster](https://errorprone.info/docs/refaster). You can run these on your code to apply some refactorings automatically:
 
-```
+```bash
 ./gradlew compileJava compileTestJava -PrefasterApply -PerrorProneApply
+```
+
+You may apply specific error-prone refactors including those which are not enabled by default by providing a comma
+delimited list of check names to the `-PerrorProneApply` option.
+
+```bash
+./gradlew compileJava compileTestJava -PerrorProneApply=PreferAssertj
 ```
 
 ## com.palantir.baseline-checkstyle

--- a/changelog/@unreleased/pr-1109.v2.yml
+++ b/changelog/@unreleased/pr-1109.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    You may apply specific error-prone refactors including those which are
+    not enabled by default by providing a comma delimited list of check
+    names to the `-PerrorProneApply` option.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1109


### PR DESCRIPTION
## Before this PR

In an internal project we have used a similar flag to test refactors
prior to rollout, and I have wished that it was available to help
with Assertj rollout to avoid temporarily modifying gradle
configurations.


## After this PR
==COMMIT_MSG==
You may apply specific error-prone refactors including those which are
not enabled by default by providing a comma delimited list of check
names to the `-PerrorProneApply` option.
==COMMIT_MSG==


```bash
./gradlew compileJava compileTestJava -PerrorProneApply=PreferAssertj
```

