### PR TITLE
Migrate baseline error-prone checks to use jdk13 compatible qualifiers

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/AssertjPrimitiveComparison.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/AssertjPrimitiveComparison.java
@@ -21,7 +21,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -119,7 +118,7 @@ public final class AssertjPrimitiveComparison extends BugChecker implements BugC
         if (strict ? types.isSameType(resultType, targetType) : types.isAssignable(resultType, targetType)) {
             return source;
         }
-        String cast = '(' + SuggestedFixes.prettyType(state, null, targetType) + ") ";
+        String cast = '(' + MoreSuggestedFixes.prettyType(state, null, targetType) + ") ";
         if (ASTHelpers.requiresParentheses(expression, state)) {
             return cast + '(' + source + ')';
         }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchSpecificity.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchSpecificity.java
@@ -23,7 +23,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -131,7 +130,7 @@ public final class CatchSpecificity extends BugChecker implements BugChecker.Try
                         catchTree.accept(new ImpossibleConditionScanner(
                                 fix, replacements, parameterName), state);
                         fix.replace(catchTypeTree, replacements.stream()
-                                .map(type -> SuggestedFixes.prettyType(state, fix, type))
+                                .map(type -> MoreSuggestedFixes.prettyType(state, fix, type))
                                 .collect(Collectors.joining(" | ")));
                     }
                     state.reportMatch(buildDescription(catchTree)

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreASTHelpers.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreASTHelpers.java
@@ -19,7 +19,6 @@ package com.palantir.baseline.errorprone;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.CatchTree;
 import com.sun.source.tree.ClassTree;
@@ -78,7 +77,7 @@ final class MoreASTHelpers {
                         type != item
                                 && state.getTypes().isSubtype(type, item)))
                 // Sort by pretty name
-                .sorted(Comparator.comparing(type -> SuggestedFixes.prettyType(state, null, type)))
+                .sorted(Comparator.comparing(type -> MoreSuggestedFixes.prettyType(state, null, type)))
                 .collect(ImmutableList.toImmutableList());
     }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreSuggestedFixes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreSuggestedFixes.java
@@ -81,8 +81,8 @@ final class MoreSuggestedFixes {
             // the output is correct in most cases, in the failures are easy for
             // humans to fix.
             for (int startOfClass = typeName.indexOf('.');
-                 startOfClass > 0;
-                 startOfClass = typeName.indexOf('.', startOfClass + 1)) {
+                    startOfClass > 0;
+                    startOfClass = typeName.indexOf('.', startOfClass + 1)) {
                 int endOfClass = typeName.indexOf('.', startOfClass + 1);
                 if (endOfClass < 0) {
                     endOfClass = typeName.length();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferAssertj.java
@@ -28,7 +28,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -352,7 +351,7 @@ public final class PreferAssertj
                     fix.replace(tree, assertThat
                             + replacement.orElseGet(() ->
                             ".is(new "
-                            + SuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.HamcrestCondition")
+                            + MoreSuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.HamcrestCondition")
                             + "<>("
                             + argSource(tree, state, 1) + "))")));
         }
@@ -363,7 +362,7 @@ public final class PreferAssertj
                     fix.replace(tree, assertThat
                             + ".describedAs(" + argSource(tree, state, 0) + ")"
                             + replacement.orElseGet(() -> ".is(new "
-                            + SuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.HamcrestCondition")
+                            + MoreSuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.HamcrestCondition")
                             + "<>(" + argSource(tree, state, 2) + "))")));
         }
         if (ASSERT_EQUALS_CATCHALL.matches(tree, state)) {
@@ -465,7 +464,7 @@ public final class PreferAssertj
         String actualArgumentString = argSource(tree, state, actualIndex);
         ExpressionTree actualArgument = tree.getArguments().get(actualIndex);
         if (isIterableMap(actualArgument, state)) {
-            String qualifiedMap = SuggestedFixes.prettyType(
+            String qualifiedMap = MoreSuggestedFixes.prettyType(
                     state,
                     fix,
                     state.getTypes().asSuper(
@@ -486,7 +485,7 @@ public final class PreferAssertj
                     .addStaticImport("org.assertj.core.api.Assertions.assertThat");
             return "assertThat";
         } else {
-            return SuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.Assertions.assertThat");
+            return MoreSuggestedFixes.qualifyType(state, fix, "org.assertj.core.api.Assertions.assertThat");
         }
     }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferBuiltInConcurrentKeySet.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferBuiltInConcurrentKeySet.java
@@ -21,7 +21,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
@@ -53,7 +52,7 @@ public final class PreferBuiltInConcurrentKeySet extends BugChecker implements B
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (MATCHER.matches(tree, state)) {
             SuggestedFix.Builder fix = SuggestedFix.builder();
-            String qualifiedType = SuggestedFixes.qualifyType(state, fix, "java.util.concurrent.ConcurrentHashMap");
+            String qualifiedType = MoreSuggestedFixes.qualifyType(state, fix, "java.util.concurrent.ConcurrentHashMap");
             return buildDescription(tree)
                     .setMessage(ERROR_MESSAGE)
                     .addFix(fix.replace(tree.getMethodSelect(), qualifiedType + ".newKeySet").build())

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionConstructors.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionConstructors.java
@@ -23,7 +23,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
@@ -280,7 +279,7 @@ public final class PreferCollectionConstructors extends BugChecker implements Bu
         }
 
         SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
-        String collectionType = SuggestedFixes.qualifyType(state, fixBuilder, collectionClass.getName());
+        String collectionType = MoreSuggestedFixes.qualifyType(state, fixBuilder, collectionClass.getName());
         String typeArgs = tree.getTypeArguments()
                 .stream()
                 .map(state::getSourceForNode)

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionTransform.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionTransform.java
@@ -22,7 +22,6 @@ import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
@@ -64,11 +63,11 @@ public final class PreferCollectionTransform extends BugChecker
                 SuggestedFix.Builder fix = SuggestedFix.builder();
                 if (LIST_MATCHER.matches(args.get(0), state)) {
                     // Fail on any 'Iterables.transform(List, Function) invocation
-                    qualifiedType = SuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Lists");
+                    qualifiedType = MoreSuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Lists");
                     errorMessage = "Prefer Lists.transform";
                 } else {
                     // Fail on any 'Iterables.transform(Collection, Function) invocation
-                    qualifiedType = SuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Collections2");
+                    qualifiedType = MoreSuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Collections2");
                     errorMessage = "Prefer Collections2.transform";
                 }
                 String method = qualifiedType + ".transform";

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionTransform.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionTransform.java
@@ -67,7 +67,8 @@ public final class PreferCollectionTransform extends BugChecker
                     errorMessage = "Prefer Lists.transform";
                 } else {
                     // Fail on any 'Iterables.transform(Collection, Function) invocation
-                    qualifiedType = MoreSuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Collections2");
+                    qualifiedType = MoreSuggestedFixes.qualifyType(
+                            state, fix, "com.google.common.collect.Collections2");
                     errorMessage = "Prefer Collections2.transform";
                 }
                 String method = qualifiedType + ".transform";

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferListsPartition.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferListsPartition.java
@@ -22,7 +22,6 @@ import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
@@ -67,7 +66,7 @@ public final class PreferListsPartition extends BugChecker
             if (LIST_MATCHER.matches(args.get(0), state)) {
                 // Fail on any 'Iterables.partition(List, int) invocation
                 SuggestedFix.Builder fix = SuggestedFix.builder();
-                String qualifiedType = SuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Lists");
+                String qualifiedType = MoreSuggestedFixes.qualifyType(state, fix, "com.google.common.collect.Lists");
                 String method = qualifiedType + ".partition";
                 return buildDescription(tree)
                         .setMessage(ERROR_MESSAGE)

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -22,7 +22,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
@@ -96,7 +95,7 @@ public final class PreferSafeLoggingPreconditions extends BugChecker implements 
         }
 
         SuggestedFix.Builder fix = SuggestedFix.builder();
-        String logSafeQualifiedClassName = SuggestedFixes.qualifyType(state, fix, "com.palantir.logsafe.Preconditions");
+        String logSafeQualifiedClassName = MoreSuggestedFixes.qualifyType(state, fix, "com.palantir.logsafe.Preconditions");
         String logSafeMethodName = getLogSafeMethodName(ASTHelpers.getSymbol(tree));
         String replacement = String.format("%s.%s", logSafeQualifiedClassName, logSafeMethodName);
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -95,7 +95,8 @@ public final class PreferSafeLoggingPreconditions extends BugChecker implements 
         }
 
         SuggestedFix.Builder fix = SuggestedFix.builder();
-        String logSafeQualifiedClassName = MoreSuggestedFixes.qualifyType(state, fix, "com.palantir.logsafe.Preconditions");
+        String logSafeQualifiedClassName = MoreSuggestedFixes.qualifyType(
+                state, fix, "com.palantir.logsafe.Preconditions");
         String logSafeMethodName = getLogSafeMethodName(ASTHelpers.getSymbol(tree));
         String replacement = String.format("%s.%s", logSafeQualifiedClassName, logSafeMethodName);
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ReadReturnValueIgnored.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ReadReturnValueIgnored.java
@@ -145,7 +145,7 @@ public final class ReadReturnValueIgnored extends AbstractReturnValueIgnored {
         }
         MemberSelectTree memberSelectTree = (MemberSelectTree) methodSelect;
         SuggestedFix.Builder fix = SuggestedFix.builder();
-        String qualifiedReference = SuggestedFixes.qualifyType(state, fix, fullyQualifiedReplacement);
+        String qualifiedReference = MoreSuggestedFixes.qualifyType(state, fix, fullyQualifiedReplacement);
         CharSequence args = sourceCode.subSequence(
                 state.getEndPosition(methodSelect) + 1,
                 state.getEndPosition(lastItem(tree.getArguments())));

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictCollectionIncompatibleType.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictCollectionIncompatibleType.java
@@ -299,7 +299,7 @@ public final class StrictCollectionIncompatibleType
      * state and builder, it doesn't add relevant imports.
      */
     private static String prettyType(Type type) {
-        return SuggestedFixes.prettyType(null, null, type);
+        return MoreSuggestedFixes.prettyType(null, null, type);
     }
 
     private interface IncompatibleTypeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ThrowError.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ThrowError.java
@@ -21,7 +21,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
@@ -86,7 +85,7 @@ public final class ThrowError extends BugChecker implements BugChecker.ThrowTree
         List<? extends ExpressionTree> arguments = newClassTree.getArguments();
         if (arguments.isEmpty()) {
             SuggestedFix.Builder fix = SuggestedFix.builder();
-            String qualifiedName = SuggestedFixes.qualifyType(state, fix, IllegalStateException.class.getName());
+            String qualifiedName = MoreSuggestedFixes.qualifyType(state, fix, IllegalStateException.class.getName());
             return Optional.of(fix.replace(newClassTree.getIdentifier(), qualifiedName).build());
         }
         ExpressionTree firstArgument = arguments.get(0);
@@ -95,7 +94,7 @@ public final class ThrowError extends BugChecker implements BugChecker.ThrowTree
                 state.getTypeFromString(String.class.getName()),
                 state)) {
             SuggestedFix.Builder fix = SuggestedFix.builder();
-            String qualifiedName = SuggestedFixes.qualifyType(state, fix,
+            String qualifiedName = MoreSuggestedFixes.qualifyType(state, fix,
                     compileTimeConstExpressionMatcher.matches(firstArgument, state)
                     ? "com.palantir.logsafe.exceptions.SafeIllegalStateException"
                     : IllegalStateException.class.getName());

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ThrowSpecificity.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ThrowSpecificity.java
@@ -90,7 +90,7 @@ public final class ThrowSpecificity extends BugChecker implements BugChecker.Met
         SuggestedFix.Builder fix = SuggestedFix.builder();
         return buildDescription(throwsExpression)
                 .addFix(fix.replace(throwsExpression, checkedExceptions.stream()
-                        .map(checkedException -> SuggestedFixes.prettyType(state, fix, checkedException))
+                        .map(checkedException -> MoreSuggestedFixes.prettyType(state, fix, checkedException))
                         .collect(Collectors.joining(", ")))
                         .build())
                 .build();

--- a/changelog/@unreleased/pr-1110.v2.yml
+++ b/changelog/@unreleased/pr-1110.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Migrate baseline error-prone checks to use jdk13 compatible qualifiers
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1110

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -210,7 +210,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
             // Errorprone 2.3.4 isn't officially compatible with Java13 either
             // https://github.com/google/error-prone/issues/1106
             errorProneOptions.check("TypeParameterUnusedInFormals", CheckSeverity.OFF);
-            errorProneOptions.check("PreferCollectionConstructors", CheckSeverity.OFF);
         }
 
         if (javaCompile.equals(compileRefaster)) {


### PR DESCRIPTION
## Before this PR
The compiler failed on jdk13 when checks with suggested fixes were found.

## After this PR
==COMMIT_MSG==
Migrate baseline error-prone checks to use jdk13 compatible qualifiers
==COMMIT_MSG==

## Possible downsides?
We don't run any tests on jdk13

