### PR TITLE
[WIP] unit-test for disabling errorprone on generated code

### DIFF
--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -156,6 +156,18 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         '''.stripIndent()
     }
 
+    def 'errorprone should be disabled on generated code (especially from annotationprocessors)'() {
+        when:
+        buildFile << standardBuildFile
+        def badFile = file('build/generated/sources/annotationProcessor/java/main/test/Bad.java')
+        badFile << invalidJavaFile
+
+        then:
+        BuildResult result = with('compileJava').build()
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        badFile.text == invalidJavaFile // remain unchanged
+    }
+
     def 'compileJava applies patches when errorProneApply contains specific checks including disabled'() {
         when:
         buildFile << standardBuildFile

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -159,11 +159,14 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
     def 'errorprone should be disabled on generated code (especially from annotationprocessors)'() {
         when:
         buildFile << standardBuildFile
+        buildFile << """
+        compileJava.source += file "build/generated"
+        """
         def badFile = file('build/generated/sources/annotationProcessor/java/main/test/Bad.java')
         badFile << invalidJavaFile
 
         then:
-        BuildResult result = with('compileJava').build()
+        BuildResult result = with('compileJava', '-s').build()
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
         badFile.text == invalidJavaFile // remain unchanged
     }


### PR DESCRIPTION
## Before this PR

@dansanduleac put in a fix that _should_ have made error-prone calm down on windows paths (https://github.com/palantir/gradle-baseline/pull/1045), but because we didn't have windows CI we couldn't prove it worked.

Sadly, it seems it isn't actually working:

```
C:\Users\circleci\project\gradle-junit-reports\build\generated\sources\annotationProcessor\java\main\com\palantir\gradle\junit\Failure_Builder.java:51: error: [StrictUnusedVariable] The field '_unsetProperties' is read but has 'StrictUnusedVariable' suppressed because of its name.
  private final EnumSet<Failure_Builder.Property> _unsetProperties =
                                                  ^
```
https://circleci.com/gh/palantir/gradle-baseline/12448

## After this PR
==COMMIT_MSG==
We now have a unit-test for disabling errorprone on generated code. This should make it easier to iterate and fix whatever's necessary to get windows CI passing.
==COMMIT_MSG==

## Possible downsides?


