### PR TITLE
Remove AssertjPrimitiveComparison from default-patch-checks

### DIFF
--- a/changelog/@unreleased/pr-1128.v2.yml
+++ b/changelog/@unreleased/pr-1128.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Remove AssertjPrimitiveComparison from default-patch-checks because
+    it has been relocated to assertj-automation.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1128

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -23,7 +23,6 @@ import org.gradle.api.provider.ListProperty;
 public class BaselineErrorProneExtension {
     private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
-            "AssertjPrimitiveComparison",
             "CatchBlockLogException",
             // TODO(ckozak): re-enable pending scala check
             //"CatchSpecificity",


### PR DESCRIPTION
==COMMIT_MSG==
Remove AssertjPrimitiveComparison from default-patch-checks because it has been relocated to assertj-automation.
==COMMIT_MSG==

