### PR TITLE
Enable checkNoUnusedPin on all projects

### DIFF
--- a/changelog/@unreleased/pr-1129.v2.yml
+++ b/changelog/@unreleased/pr-1129.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Projects with `com.palantir.baseline-versions.disable=true` will now
+    have `checkNoUnusedPin` task run as part of check, ensuring that the `versions.props`
+    file is minimal
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1129

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/versions/BaselineVersions.java
@@ -89,7 +89,7 @@ public final class BaselineVersions implements Plugin<Project> {
             checkNoUnusedPin.get().setShouldFix(task.getShouldFix());
         });
 
-        // TODO(someone): Remove this one day
+        // TODO(#1131): Remove this one day
         if (!project.hasProperty(DISABLE_PROPERTY)) {
             configureNebula(project, rootVersionsPropsFile, checkVersionsProps, checkNoUnusedPin);
         }


### PR DESCRIPTION
## Before this PR
Only users who were using nebula dependency recommender would have build time validation that their versions.props file was minimal

## After this PR
==COMMIT_MSG==
Projects with `com.palantir.baseline-versions.disable=true` will now have `checkNoUnusedPin` task run as part of check, ensuring that the `versions.props` file is minimal
==COMMIT_MSG==

## Possible downsides?
I tried this out on a few repos and it seemed to do the right thing, there may be cases where it does not and so it will prevent people from merging.

We'll probably also want to update the automation so that the "fix" is automatically applied as part of the upgrade

cc @jeremyjliu 