### PR TITLE
Mark test resources as test resources in IntelliJ

### DIFF
--- a/changelog/@unreleased/pr-1134.v2.yml
+++ b/changelog/@unreleased/pr-1134.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The `baseline-idea` plugin now correctly marks test resources as test
+    resources in IntelliJ.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1134

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -64,7 +64,6 @@ class BaselineIdea extends AbstractBaselinePlugin {
             }
 
             // Configure Idea module
-            markResourcesDirs(ideaModuleModel)
             moveProjectReferencesToEnd(ideaModuleModel)
         }
 
@@ -279,24 +278,6 @@ class BaselineIdea extends AbstractBaselinePlugin {
         }
 
         return base.appendNode(name, attributes + defaults)
-    }
-
-    /**
-     * By default the Idea plugin marks resources dirs as source dirs.
-     */
-    private void markResourcesDirs(IdeaModel ideaModel) {
-        ideaModel.module.iml.withXml {
-            def node = it.asNode()
-            def content = node.component.find { it.'@name' == 'NewModuleRootManager' }.content[0]
-            content.sourceFolder.each { sourceFolder ->
-                if(sourceFolder.@url?.endsWith('/resources')) {
-                    sourceFolder.attributes().with {
-                        boolean isTestSource = (remove('isTestSource') == 'true')
-                        put('type', isTestSource ? 'java-test-resource' : 'java-resource')
-                    }
-                }
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
## Before this PR
Test resources are marked as source resources in IntelliJ.

This logic from https://github.com/palantir/gradle-baseline/pull/156 is not correct because resource source folders do not have a `isTestSource` attribute.

The IDEA plugin added support for resources in https://github.com/gradle/gradle/pull/3724, which was first released in Gradle 4.7.0. 

## After this PR
Test resources are marked as test resources in IntelliJ.

I've verified the behavior using `publishToMavenLocal`.

Before:
```
<sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-resource"/>
```
After:
```
<sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource"/>
```