### PR TITLE
Error-prone OptionalOfNullableNonNull: Prefer Optional.of over ofNullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `ThrowSpecificity`: Prefer to declare more specific `throws` types than Exception and Throwable.
 - `UnsafeGaugeRegistration`: Use TaggedMetricRegistry.registerWithReplacement over TaggedMetricRegistry.gauge.
 - `BracesRequired`: Require braces for loops and if expressions.
+- `OptionalOfNullableNonNull`: Optional.of should be used over Optional.ofNullable for non-null values.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalOfNullableNonNull.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalOfNullableNonNull.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.ChildMultiMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Optional;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "OptionalOfNullableNonNull",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
+        severity = BugPattern.SeverityLevel.WARNING,
+        summary = "Optional.of should be used for non-null values. This produces code that is more obvious, "
+                + "making it easier for developers to discover unnecessary optionals.")
+public final class OptionalOfNullableNonNull extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final Matcher<ExpressionTree> matcher = Matchers.methodInvocation(
+            MethodMatchers.staticMethod()
+                    .onClass(Optional.class.getName())
+                    .named("ofNullable")
+                    .withParameters(Object.class.getName()),
+            ChildMultiMatcher.MatchType.LAST,
+            Matchers.isNonNull());
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!matcher.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        return buildDescription(tree)
+                .addFix(MoreSuggestedFixes.renameInvocationRetainingTypeArguments(tree, "of", state))
+                .build();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOfNullableNonNullTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOfNullableNonNullTest.java
@@ -100,9 +100,10 @@ class OptionalOfNullableNonNullTest {
                         "import java.util.function.*;",
                         "import javax.annotation.*;",
                         "class Test {",
-                        "  void f(Consumer<Object> sink, Object param0, @Nullable Object param1) {",
-                        "    sink.accept(Optional.ofNullable(param0));",
-                        "    sink.accept(Optional.ofNullable(param1));",
+                        "  void f(Consumer<Object> sink, Map<String, Object> map, Object p0, @Nullable Object p1) {",
+                        "    sink.accept(Optional.ofNullable(p0));",
+                        "    sink.accept(Optional.ofNullable(p1));",
+                        "    sink.accept(Optional.ofNullable(map.get(\"a\")).orElse(\"b\"));",
                         "  }",
                         "}")
                 .expectUnchanged()

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOfNullableNonNullTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOfNullableNonNullTest.java
@@ -1,0 +1,115 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+class OptionalOfNullableNonNullTest {
+
+    @Test
+    void testFix() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  Object f() {",
+                        "    return Optional.ofNullable(1);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  Object f() {",
+                        "    return Optional.of(1);",
+                        "  }",
+                        "}"
+                )
+                .doTest();
+    }
+
+    @Test
+    void testFix_annotatedNonnull() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import javax.annotation.*;",
+                        "class Test {",
+                        "  Object f(@Nonnull Object obj) {",
+                        "    return Optional.ofNullable(obj);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import javax.annotation.*;",
+                        "class Test {",
+                        "  Object f(@Nonnull Object obj) {",
+                        "    return Optional.of(obj);",
+                        "  }",
+                        "}"
+                )
+                .doTest();
+    }
+
+    @Test
+    void testFix_typeParameter() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  Object f() {",
+                        "    return Optional.<Integer>ofNullable(1);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  Object f() {",
+                        "    return Optional.<Integer>of(1);",
+                        "  }",
+                        "}"
+                )
+                .doTest();
+    }
+
+    @Test
+    void testNegative() {
+        fix()
+                .addInputLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.function.*;",
+                        "import javax.annotation.*;",
+                        "class Test {",
+                        "  void f(Consumer<Object> sink, Object param0, @Nullable Object param1) {",
+                        "    sink.accept(Optional.ofNullable(param0));",
+                        "    sink.accept(Optional.ofNullable(param1));",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(new OptionalOfNullableNonNull(), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-1137.v2.yml
+++ b/changelog/@unreleased/pr-1137.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'Error-prone OptionalOfNullableNonNull: Prefer Optional.of over ofNullable'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1137

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -30,6 +30,7 @@ public class BaselineErrorProneExtension {
             "ExecutorSubmitRunnableFutureIgnored",
             "FinalClass",
             "LambdaMethodReference",
+            "OptionalOfNullableNonNull",
             "OptionalOrElseMethodInvocation",
             "PreferBuiltInConcurrentKeySet",
             "PreferCollectionTransform",


### PR DESCRIPTION
## After this PR
==COMMIT_MSG==
Error-prone OptionalOfNullableNonNull: Prefer Optional.of over ofNullable
==COMMIT_MSG==

## Possible downsides?
If code is refactored later to allow nulls, Optional.of will throw instead of returning an empty optional.
This is already true of any parameter that becomes nullable when it is accessed directly, so there's no real additional risk in this case.

