### PR TITLE
Enable optimizing imports on the fly by default

### DIFF
--- a/changelog/@unreleased/pr-1144.v2.yml
+++ b/changelog/@unreleased/pr-1144.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Configure Intellij to optimize imports on the fly
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1144

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -60,6 +60,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 ideaRootModel.workspace.iws.withXml { provider ->
                     def node = provider.asNode()
                     setRunManagerWorkingDirectory(node)
+                    addEditorSettings(node)
                 }
             }
 
@@ -235,6 +236,14 @@ class BaselineIdea extends AbstractBaselinePlugin {
             <component name="JavacSettings">
                 <option name="PREFER_TARGET_JDK_COMPILER" value="false" />
             </component>
+            """.stripIndent()))
+    }
+
+    private void addEditorSettings(node) {
+        node.append(new XmlParser().parseText("""
+            <component name="CodeInsightWorkspaceSettings">
+                <option name="optimizeImportsOnTheFly" value="true" />
+              </component>
             """.stripIndent()))
     }
 


### PR DESCRIPTION
## Before this PR
Whenever you opened a project for the first time after running `./gradlew idea` the setting to optimize imports on the fly would be cleared resulting in many red builds because of unused imports

## After this PR
==COMMIT_MSG==
Configure Intellij to optimize imports on the fly
==COMMIT_MSG==

## Possible downsides?
N/A

