### PR TITLE
Exempt slf4j logger from unused field removal

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -132,7 +132,8 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
     private static final ImmutableSet<String> EXEMPTING_SUPER_TYPES = ImmutableSet.of();
 
     /** The set of types exempting a field of type extending them. */
-    private static final ImmutableSet<String> EXEMPTING_FIELD_SUPER_TYPES = ImmutableSet.of("org.junit.rules.TestRule");
+    private static final ImmutableSet<String> EXEMPTING_FIELD_SUPER_TYPES =
+            ImmutableSet.of("org.junit.rules.TestRule", "org.slf4j.Logger");
 
     private static final ImmutableList<String> SPECIAL_FIELDS = ImmutableList.of(
             "serialVersionUID",


### PR DESCRIPTION
## Before this PR
Unused logger fields are removed but the logger initialization remains in a static{} block.

## After this PR
==COMMIT_MSG==
Don't mark unused slf4j logger fields as StrictUnusedVariable.
==COMMIT_MSG==

## Possible downsides?
Unused loggers stick around bloating classes.