### PR TITLE
baseline-class-uniqueness is updated by `./gradlew --write-locks`

### DIFF
--- a/changelog/@unreleased/pr-1153.v2.yml
+++ b/changelog/@unreleased/pr-1153.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Running `./gradlew --write-locks` will now update the baseline-class-uniqueness.lock
+    file.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1153

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
@@ -57,7 +57,7 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
         result.getOutput().contains("javax.el.ArrayELResolver");
         !lockfile.exists()
 
-        with("checkClassUniqueness", "--write-locks").build()
+        with("--write-locks").build()
         lockfile.exists()
 
         File expected = new File("src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock")


### PR DESCRIPTION
## Before this PR

Currently running `./gradlew --write-locks` will not actually update people's baseline-class-uniqueness.lock file.  (Amusingly I had this code locally, I just had forgotten to push it).

This is bad because many of our excavators rely on just running `--write-locks` after touching plugins, so they're currently red (e.g. onelogger on build2).

## After this PR
==COMMIT_MSG==
Running `./gradlew --write-locks` will now update the baseline-class-uniqueness.lock file.
==COMMIT_MSG==

## Possible downsides?
The `--write-locks` invocation is quite a frequently invoked thing, and this makes it a little slower :/

