### PR TITLE
Fix: baseline-idea correctly filters save actions to java files

### DIFF
--- a/changelog/@unreleased/pr-1158.v2.yml
+++ b/changelog/@unreleased/pr-1158.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix a bug in the Save Actions plugin configuration where it would format
+    any file on save, instead of just java files.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1158

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -350,7 +350,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 appendNode('option', [value: 'reformat'])
             }
             appendNode('option', [name: 'configurationPath', value: ''])
-            appendNode('inclusions').appendNode('set').with {
+            appendNode('option', [name: 'inclusions']).appendNode('set').with {
                 appendNode('option', [value: 'src/.*\\.java'])
             }
         }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -351,7 +351,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             }
             appendNode('option', [name: 'configurationPath', value: ''])
             appendNode('option', [name: 'inclusions']).appendNode('set').with {
-                appendNode('option', [value: "src${File.pathSeparator}.*\\.java"])
+                appendNode('option', [value: "src${File.separator}.*\\.java"])
             }
         }
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -351,7 +351,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             }
             appendNode('option', [name: 'configurationPath', value: ''])
             appendNode('option', [name: 'inclusions']).appendNode('set').with {
-                appendNode('option', [value: 'src/.*\\.java'])
+                appendNode('option', [value: "src${File.pathSeparator}.*\\.java"])
             }
         }
     }


### PR DESCRIPTION
## Before this PR
Made a mistake in configuring the include filters for the Save Actions plugin.
Thus, the plugin would format any file on save, not just java files.

## After this PR
==COMMIT_MSG==
Fix a bug in the Save Actions plugin configuration where it would format any file on save, instead of just java files.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->