### PR TITLE
Fix `LoggerEnclosingClass` edge cases for type parameters and anonymous classes

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LoggerEnclosingClassTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LoggerEnclosingClassTest.java
@@ -38,6 +38,23 @@ class LoggerEnclosingClassTest {
     }
 
     @Test
+    void testFix_generic() {
+        fix().addInputLines(
+                "Test.java",
+                "import org.slf4j.*;",
+                "class Test<T> {",
+                "    private static final Logger log = LoggerFactory.getLogger(String.class);",
+                "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import org.slf4j.*;",
+                        "class Test<T> {",
+                        "    private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testFix_interface() {
         fix().addInputLines(
                 "Test.java",
@@ -71,6 +88,29 @@ class LoggerEnclosingClassTest {
                         "    interface Nested {",
                         "        Logger log = LoggerFactory.getLogger(Nested.class);",
                         "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testFix_anonymous() {
+        fix().addInputLines(
+                "Test.java",
+                "import org.slf4j.*;",
+                "class Test {",
+                "    Runnable run = new Runnable() {",
+                "        private final Logger log = LoggerFactory.getLogger(String.class);",
+                "        @Override public void run() {}",
+                "    };",
+                "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                        "    Runnable run = new Runnable() {",
+                        "        private final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "        @Override public void run() {}",
+                        "    };",
                         "}")
                 .doTest();
     }

--- a/changelog/@unreleased/pr-1171.v2.yml
+++ b/changelog/@unreleased/pr-1171.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix `LoggerEnclosingClass` edge cases for type parameters and anonymous
+    classes
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1171


### PR DESCRIPTION
## Before this PR
Possible to suggest `LoggerFactory.getLogger(Bar<T>.class)` instead of `LoggerFactory.getLogger(Bar.class)`.
Also possible to fail when loggers are defined as fields of anonymous classes.

## After this PR
==COMMIT_MSG==
Fix `LoggerEnclosingClass` edge cases for type parameters and anonymous classes
==COMMIT_MSG==

