### PR TITLE
Remove checkstyle LineLength when formatted

### DIFF
--- a/changelog/@unreleased/pr-1172.v2.yml
+++ b/changelog/@unreleased/pr-1172.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Stop enforcing 120 character limit for repos which enrolled in palantir-java-format.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1172

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
@@ -95,15 +95,19 @@ class BaselineConfig extends AbstractBaselinePlugin {
 
                 try {
                     String contents = new String(Files.readAllBytes(checkstyleXml), StandardCharsets.UTF_8);
-                    String replaced = contents.replace(
-                            "        <module name=\"Indentation\"> "
-                                    + "<!-- Java Style Guide: Block indentation: +4 spaces -->\n"
-                                    + "            <property name=\"arrayInitIndent\" value=\"8\"/>\n"
-                                    + "            <property name=\"lineWrappingIndentation\" value=\"8\"/>\n"
-                                    + "        </module>\n",
-                            "");
-                    Preconditions.checkState(!contents.equals(replaced), "Patching checkstyle.xml must make a change");
-                    Files.write(checkstyleXml, replaced.getBytes(StandardCharsets.UTF_8));
+                    contents = assertReplace(contents, ""
+                            + "        <module name=\"Indentation\"> "
+                            + "<!-- Java Style Guide: Block indentation: +4 spaces -->\n"
+                            + "            <property name=\"arrayInitIndent\" value=\"8\"/>\n"
+                            + "            <property name=\"lineWrappingIndentation\" value=\"8\"/>\n"
+                            + "        </module>\n");
+                    contents = assertReplace(contents, ""
+                            + "        <module name=\"LineLength\"> <!-- Java Style Guide: No line-wrapping -->\n"
+                            + "            <property name=\"max\" value=\"120\"/>\n"
+                            + "            <property name=\"ignorePattern\" value=\"^package.*|^import.*|a "
+                            + "href|href|http://|https://|ftp://\"/>\n"
+                            + "        </module>\n");
+                    Files.write(checkstyleXml, contents.getBytes(StandardCharsets.UTF_8));
                 } catch (IOException e) {
                     throw new RuntimeException("Unable to patch " + checkstyleXml, e);
                 }
@@ -125,6 +129,12 @@ class BaselineConfig extends AbstractBaselinePlugin {
                     copySpec.setIncludeEmptyDirs(false);
                 });
             }
+        }
+
+        private String assertReplace(String contents, String target) {
+            String replaced = contents.replace(target, "");
+            Preconditions.checkState(!contents.equals(replaced), "Patching checkstyle.xml must make a change");
+            return replaced;
         }
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
@@ -147,7 +147,7 @@ class BaselineConfigIntegrationTest extends AbstractPluginTest {
 
         then:
         !new File(projectDir, '.baseline/checkstyle/checkstyle.xml').readLines().any {
-            it.contains '<module name="Indentation">'
+            it.contains('<module name="Indentation">') || it.contains('<module name="LineLength">')
         }
     }
 }


### PR DESCRIPTION
## Before this PR

Repos being formatted with [palantir-java-format](https://github.com/palantir/palantir-java-format) can still run into line length issues, for instance due to a long `{@link ...}` in a javadoc.

However, we consider these acceptable.

## After this PR
==COMMIT_MSG==
Stop enforcing 120 character limit for repos which enrolled in palantir-java-format.
==COMMIT_MSG==

## Possible downsides?

A formatter regression could cause bad PRs with very long lines to still get merged automatically.

cc @robert3005 