### PR TITLE
Fix #1182: Don't run baseline-error-prone tests concurrently

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CatchBlockLogExceptionTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CatchBlockLogExceptionTest.java
@@ -21,10 +21,7 @@ import com.google.errorprone.CompilationTestHelper;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class CatchBlockLogExceptionTest {
 
     private static final String errorMsg =

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousCompletableFutureUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousCompletableFutureUsageTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class DangerousCompletableFutureUsageTest {
     private CompilationTestHelper compilationHelper;
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousJsonTypeInfoUsageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousJsonTypeInfoUsageTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class DangerousJsonTypeInfoUsageTests {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousParallelStreamUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousParallelStreamUsageTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class DangerousParallelStreamUsageTest {
     private CompilationTestHelper compilationHelper;
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousStringInternUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousStringInternUsageTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class DangerousStringInternUsageTest {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousThreadPoolExecutorUsageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousThreadPoolExecutorUsageTests.java
@@ -7,10 +7,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class DangerousThreadPoolExecutorUsageTests {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArgTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousThrowableMessageSafeArgTest.java
@@ -21,10 +21,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class DangerousThrowableMessageSafeArgTest {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FinalClassTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class FinalClassTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleCacheableTaskActionTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleCacheableTaskActionTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class GradleCacheableTaskActionTest {
 
     private static final String errorMsg =

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GuavaPreconditionsConstantMessageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GuavaPreconditionsConstantMessageTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class GuavaPreconditionsConstantMessageTests extends PreconditionsTests {
 
     private static final String DIAGNOSTIC = "non-constant message";

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GuavaPreconditionsMessageFormatTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GuavaPreconditionsMessageFormatTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class GuavaPreconditionsMessageFormatTests extends PreconditionsTests {
 
     private static final String DIAGNOSTIC = "Use printf-style formatting";

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/InvocationHandlerDelegationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/InvocationHandlerDelegationTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class InvocationHandlerDelegationTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JUnit5RuleUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JUnit5RuleUsageTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class JUnit5RuleUsageTest {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JUnit5SuiteMisuseTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JUnit5SuiteMisuseTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class JUnit5SuiteMisuseTest {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JooqResultStreamLeakTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JooqResultStreamLeakTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class JooqResultStreamLeakTest {
 
     private final CompilationTestHelper testHelper =

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
@@ -23,10 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class LambdaMethodReferenceTest {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogSafePreconditionsMessageFormatTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogSafePreconditionsMessageFormatTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class LogSafePreconditionsMessageFormatTests extends PreconditionsTests {
 
     private static final String PRINTF_DIAGNOSTIC = "Do not use printf-style formatting";

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NonComparableStreamSortTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NonComparableStreamSortTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class NonComparableStreamSortTests {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocationTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseMethodInvocationTests.java
@@ -20,10 +20,7 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class OptionalOrElseMethodInvocationTests {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseThrowThrowsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseThrowThrowsTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class OptionalOrElseThrowThrowsTest {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferBuiltInConcurrentKeySetTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferBuiltInConcurrentKeySetTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class PreferBuiltInConcurrentKeySetTests {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferCollectionConstructorsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferCollectionConstructorsTest.java
@@ -21,10 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class PreferCollectionConstructorsTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferCollectionTransformTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferCollectionTransformTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class PreferCollectionTransformTests {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferListsPartitionTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferListsPartitionTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class PreferListsPartitionTests {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditionsTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditionsTests.java
@@ -20,10 +20,7 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class PreferSafeLoggingPreconditionsTests {
     private CompilationTestHelper compilationHelper;
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class PreventTokenLoggingTests {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantMethodReferenceTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class RedundantMethodReferenceTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class RedundantModifierTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ReverseDnsLookupTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ReverseDnsLookupTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class ReverseDnsLookupTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingExceptionMessageFormatTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingExceptionMessageFormatTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class SafeLoggingExceptionMessageFormatTests {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ShutdownHookTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ShutdownHookTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class ShutdownHookTests {
 
     private static final String errorMsg = "BUG: Diagnostic contains: "

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessageTests.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class Slf4jConstantLogMessageTests {
 
     private void test(String log) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLevelCheckTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLevelCheckTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class Slf4jLevelCheckTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgsTest.java
@@ -20,10 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class Slf4jLogsafeArgsTest {
 
     private static final ImmutableList<String> LOG_LEVELS = ImmutableList.of("trace", "debug", "info", "warn", "error");

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jThrowableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jThrowableTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class Slf4jThrowableTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamOfEmptyTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamOfEmptyTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class StreamOfEmptyTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictCollectionIncompatibleTypeTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictCollectionIncompatibleTypeTest.java
@@ -18,10 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class StrictCollectionIncompatibleTypeTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -20,10 +20,7 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class StrictUnusedVariableTest {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StringBuilderConstantParametersTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StringBuilderConstantParametersTests.java
@@ -20,10 +20,7 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class StringBuilderConstantParametersTests {
     private CompilationTestHelper compilationHelper;
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCaseTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SwitchStatementDefaultCaseTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public class SwitchStatementDefaultCaseTest {
 
     private CompilationTestHelper compilationHelper;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ThrowErrorTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ThrowErrorTest.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 class ThrowErrorTest {
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ValidateConstantMessageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ValidateConstantMessageTests.java
@@ -19,10 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
 public final class ValidateConstantMessageTests {
 
     private CompilationTestHelper compilationHelper;


### PR DESCRIPTION
Error prone validation is memory-intensive and parallel execution
can cause OOMs and segfaults.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
baseline-error-prone tests no longer run concurrently in order to avoid OOMs.
==COMMIT_MSG==

## Possible downsides?
Tests take longer to run on systems with sufficient resources in configurations where gradle provides enough heap.

