### PR TITLE
Fix `UnnecessaryLambdaArgumentParentheses` handling primitive lambda args

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnnecessaryLambdaArgumentParentheses.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnnecessaryLambdaArgumentParentheses.java
@@ -57,10 +57,10 @@ public final class UnnecessaryLambdaArgumentParentheses extends BugChecker
         for (int i = 0; i < tokens.size(); i++) {
             ErrorProneToken token = tokens.get(i);
             // parameters with types require parens
-            if (token.kind() == Tokens.TokenKind.IDENTIFIER && ++identifiers > 1) {
-                return Description.NO_MATCH;
-            } else if (token.kind() == Tokens.TokenKind.ARROW) {
-                return Description.NO_MATCH;
+            if (token.kind() == Tokens.TokenKind.IDENTIFIER) {
+                if (++identifiers > 1) {
+                    return Description.NO_MATCH;
+                }
             } else if (token.kind() == Tokens.TokenKind.LPAREN) {
                 depth++;
             } else if (token.kind() == Tokens.TokenKind.RPAREN && --depth == 0) {
@@ -73,6 +73,9 @@ public final class UnnecessaryLambdaArgumentParentheses extends BugChecker
                                 .replace(offsetToken.pos(), offsetToken.endPos(), "")
                                 .build())
                         .build();
+            } else {
+                // Bail when any unknown token types are encountered
+                return Description.NO_MATCH;
             }
         }
         return Description.NO_MATCH;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessaryLambdaArgumentParenthesesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessaryLambdaArgumentParenthesesTest.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
@@ -50,12 +51,14 @@ class UnnecessaryLambdaArgumentParenthesesTest {
         fix().addInputLines(
                         "Test.java",
                         "import " + Predicate.class.getName() + ';',
+                        "import " + LongPredicate.class.getName() + ';',
                         "class Test {",
                         "    Predicate<Object> a = value -> value == null;",
                         "    Predicate<Object> b =  value  -> value == null;",
                         "    Predicate<Object> c = /* (value) -> value*/value -> value == null;",
                         "    Predicate<Object> d = value /*(value) -> value*/ -> value == null;",
                         "    Predicate<?> e = (String value) -> value == null;",
+                        "    LongPredicate f = (LongPredicate) (long value) -> value == 0L;",
                         "}")
                 .expectUnchanged()
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/changelog/@unreleased/pr-1192.v2.yml
+++ b/changelog/@unreleased/pr-1192.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix `UnnecessaryLambdaArgumentParentheses` handling explicitly typed
+    primitive lambda args
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1192


### PR DESCRIPTION
## Before this PR
```diff
- forEach((long value) -> action.accept(value));
+ forEach(long value -> action.accept(value)); // does not compile
```

This makes the check safer when unknown inputs are encountered.

## After this PR
==COMMIT_MSG==
Fix `UnnecessaryLambdaArgumentParentheses` handling explicitly typed primitive lambda args
==COMMIT_MSG==
