### PR TITLE
Add an ErrorProne check for raw types

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `CollectionStreamForEach`: Collection.forEach is more efficient than Collection.stream().forEach.
 - `LoggerEnclosingClass`: Loggers created using getLogger(Class<?>) must reference their enclosing class.
 - `UnnecessaryLambdaArgumentParentheses`: Lambdas with a single parameter do not require argument parentheses.
+- `RawTypes`: Avoid raw types; add appropriate type parameters if possible.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RawTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RawTypes.java
@@ -61,10 +61,11 @@ public final class RawTypes extends BugChecker
 
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
-        List<Tree> types = new ArrayList<>();
-        types.add(tree.getExtendsClause());
-        types.addAll(tree.getImplementsClause());
-        return testTypes(types);
+        Description extendsResult = testType(tree.getExtendsClause());
+        if (extendsResult != Description.NO_MATCH) {
+            return extendsResult;
+        }
+        return testTypes(tree.getImplementsClause());
     }
 
     @Override

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RawTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RawTypes.java
@@ -1,0 +1,104 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.ParameterizedTypeTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "RawTypes",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.WARNING,
+        // Support SuppressWarnings("rawtypes"), which is already in use
+        altNames = {"rawtypes"},
+        summary =
+                "Avoid raw types; add appropriate type parameters if possible.\n"
+                        + "This can be suppressed with @SuppressWarnings(\"rawtypes\") where necessary, such as when "
+                        + "interacting with older library code.")
+public final class RawTypes extends BugChecker
+        implements BugChecker.VariableTreeMatcher,
+                BugChecker.NewClassTreeMatcher,
+                BugChecker.ClassTreeMatcher,
+                BugChecker.MethodTreeMatcher {
+    @Override
+    public Description matchVariable(VariableTree tree, VisitorState state) {
+        return testType(tree.getType());
+    }
+
+    @Override
+    public Description matchNewClass(NewClassTree tree, VisitorState state) {
+        return testType(tree.getIdentifier());
+    }
+
+    @Override
+    public Description matchClass(ClassTree tree, VisitorState state) {
+        List<Tree> types = new ArrayList<>();
+        types.add(tree.getExtendsClause());
+        types.addAll(tree.getImplementsClause());
+        return testTypes(types);
+    }
+
+    @Override
+    public Description matchMethod(MethodTree tree, VisitorState state) {
+        return testType(tree.getReturnType());
+    }
+
+    private Description testTypes(Iterable<? extends Tree> types) {
+        for (Tree type : types) {
+            Description description = testType(type);
+            if (description != Description.NO_MATCH) {
+                return description;
+            }
+        }
+        return Description.NO_MATCH;
+    }
+
+    private Description testType(Tree type) {
+        if (type == null) {
+            return Description.NO_MATCH;
+        }
+        Type realType = ASTHelpers.getType(type);
+        if (realType != null && realType.isRaw()) {
+            return buildDescription(type)
+                    .setMessage("Avoid raw types; add appropriate type parameters if possible. "
+                            + "The type was: "
+                            + realType
+                            + "\nThis can be suppressed with @SuppressWarnings(\"rawtypes\") "
+                            + "where necessary, such as when interacting with older library code.")
+                    .build();
+        }
+        if (type.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+            return testTypes(((ParameterizedTypeTree) type).getTypeArguments());
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RawTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RawTypes.java
@@ -91,7 +91,7 @@ public final class RawTypes extends BugChecker
             return buildDescription(type)
                     .setMessage("Avoid raw types; add appropriate type parameters if possible. "
                             + "The type was: "
-                            + realType
+                            + MoreSuggestedFixes.prettyType(null, null, realType)
                             + "\nThis can be suppressed with @SuppressWarnings(\"rawtypes\") "
                             + "where necessary, such as when interacting with older library code.")
                     .build();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RawTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RawTypes.java
@@ -27,10 +27,9 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Type;
-import java.util.ArrayList;
-import java.util.List;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -45,10 +44,11 @@ import java.util.List;
                         + "This can be suppressed with @SuppressWarnings(\"rawtypes\") where necessary, such as when "
                         + "interacting with older library code.")
 public final class RawTypes extends BugChecker
-        implements BugChecker.VariableTreeMatcher,
+        implements BugChecker.ClassTreeMatcher,
+                BugChecker.MethodTreeMatcher,
                 BugChecker.NewClassTreeMatcher,
-                BugChecker.ClassTreeMatcher,
-                BugChecker.MethodTreeMatcher {
+                BugChecker.TypeCastTreeMatcher,
+                BugChecker.VariableTreeMatcher {
     @Override
     public Description matchVariable(VariableTree tree, VisitorState state) {
         return testType(tree.getType());
@@ -71,6 +71,11 @@ public final class RawTypes extends BugChecker
     @Override
     public Description matchMethod(MethodTree tree, VisitorState state) {
         return testType(tree.getReturnType());
+    }
+
+    @Override
+    public Description matchTypeCast(TypeCastTree tree, VisitorState state) {
+        return testType(tree.getType());
     }
 
     private Description testTypes(Iterable<? extends Tree> types) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RawTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RawTypesTest.java
@@ -111,6 +111,38 @@ class RawTypesTest {
     }
 
     @Test
+    void testCast1() {
+        helper().addSourceLines(
+                "Test.java",
+                "import " + ArrayList.class.getName() + ";",
+                "class Test {",
+                "    int f() {",
+                "        ArrayList<String> list = new ArrayList<String>();",
+                "        // BUG: Diagnostic contains: Avoid raw types",
+                "        Object obj = (ArrayList) list;",
+                "        return obj.hashCode();",
+                "    }",
+                "}")
+                .doTest();
+    }
+
+    @Test
+    void testCast2() {
+        helper().addSourceLines(
+                "Test.java",
+                "import " + ArrayList.class.getName() + ";",
+                "class Test {",
+                "    int f() {",
+                "        ArrayList<String> list = new ArrayList<String>();",
+                "        // BUG: Diagnostic contains: Avoid raw types",
+                "        ArrayList<Integer> list2 = (ArrayList<Integer>) (ArrayList) list;",
+                "        return list2.hashCode();",
+                "    }",
+                "}")
+                .doTest();
+    }
+
+    @Test
     void testExtends() {
         helper().addSourceLines(
                         "Test.java",
@@ -125,7 +157,6 @@ class RawTypesTest {
     void testImplements1() {
         helper().addSourceLines(
                         "Test.java",
-                        "import " + List.class.getName() + ";",
                         "interface A<T> {}",
                         "// BUG: Diagnostic contains: Avoid raw types",
                         "class MyClass implements A {",
@@ -149,8 +180,6 @@ class RawTypesTest {
     void testImplements3() {
         helper().addSourceLines(
                         "Test.java",
-                        "import " + List.class.getName() + ";",
-                        "import " + Set.class.getName() + ";",
                         "interface A<T> {}",
                         "interface B<T> {}",
                         "// BUG: Diagnostic contains: Avoid raw types",
@@ -237,6 +266,22 @@ class RawTypesTest {
                         "        return new ArrayList<String>();",
                         "    }",
                         "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeCast() {
+        helper().addSourceLines(
+                "Test.java",
+                "import " + ArrayList.class.getName() + ";",
+                "import " + List.class.getName() + ";",
+                "class Test {",
+                "    int f() {",
+                "        List<String> list = new ArrayList<String>();",
+                "        ArrayList<String> list2 = (ArrayList<String>) list;",
+                "        return list2.hashCode();",
+                "    }",
+                "}")
                 .doTest();
     }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RawTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RawTypesTest.java
@@ -1,0 +1,267 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.common.collect.Lists;
+import com.google.errorprone.CompilationTestHelper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RawTypesTest {
+
+    @Test
+    void testVariableDeclaration() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        // BUG: Diagnostic contains: Avoid raw types",
+                        "        ArrayList list = new ArrayList<String>();",
+                        "        return list.size();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testRawParameter() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        // BUG: Diagnostic contains: Avoid raw types",
+                        "        ArrayList<ArrayList> list = new ArrayList<>();",
+                        "        return list.size();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testFieldDeclaration() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    // BUG: Diagnostic contains: Avoid raw types",
+                        "    ArrayList list;",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testMethodArgument() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    // BUG: Diagnostic contains: Avoid raw types",
+                        "    int f(ArrayList list) {",
+                        "        return list.size();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testReturnType() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    // BUG: Diagnostic contains: Avoid raw types",
+                        "    ArrayList f() {",
+                        "        return new ArrayList<String>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testClassInstantiation() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        // BUG: Diagnostic contains: Avoid raw types",
+                        "        ArrayList<String> list = new ArrayList();",
+                        "        return list.size();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testExtends() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "// BUG: Diagnostic contains: Avoid raw types",
+                        "class MyList extends ArrayList {",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testImplements1() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + List.class.getName() + ";",
+                        "interface A<T> {}",
+                        "// BUG: Diagnostic contains: Avoid raw types",
+                        "class MyClass implements A {",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testImplements2() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "interface A {}",
+                        "interface B<T> {}",
+                        "// BUG: Diagnostic contains: Avoid raw types",
+                        "class MyClass implements A, B {",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testImplements3() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + List.class.getName() + ";",
+                        "import " + Set.class.getName() + ";",
+                        "interface A<T> {}",
+                        "interface B<T> {}",
+                        "// BUG: Diagnostic contains: Avoid raw types",
+                        "class MyClass implements A, B {",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeExplicitParameter() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "import " + Lists.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        ArrayList<String> list = new ArrayList<String>();",
+                        "        return list.size();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeDiamond() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "import " + Lists.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        ArrayList<String> list = new ArrayList<>();",
+                        "        return list.size();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeInnerParameter() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        ArrayList<ArrayList<String>> list = new ArrayList<>();",
+                        "        return list.size();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeField() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    ArrayList<String> list;",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeMethodArgument() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    int f(ArrayList<String> list) {",
+                        "        return list.size();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeReturnType() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    ArrayList<String> f() {",
+                        "        return new ArrayList<String>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeExtends() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class MyList extends ArrayList<String> {",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNegativeImplements3() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "interface A<T> {}",
+                        "interface B<T> {}",
+                        "class MyClass implements A<String>, B<Integer> {",
+                        "}")
+                .doTest();
+    }
+
+    private CompilationTestHelper helper() {
+        return CompilationTestHelper.newInstance(RawTypes.class, getClass());
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RawTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RawTypesTest.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import com.google.errorprone.CompilationTestHelper;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class RawTypesTest {
@@ -113,32 +112,32 @@ class RawTypesTest {
     @Test
     void testCast1() {
         helper().addSourceLines(
-                "Test.java",
-                "import " + ArrayList.class.getName() + ";",
-                "class Test {",
-                "    int f() {",
-                "        ArrayList<String> list = new ArrayList<String>();",
-                "        // BUG: Diagnostic contains: Avoid raw types",
-                "        Object obj = (ArrayList) list;",
-                "        return obj.hashCode();",
-                "    }",
-                "}")
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        ArrayList<String> list = new ArrayList<String>();",
+                        "        // BUG: Diagnostic contains: Avoid raw types",
+                        "        Object obj = (ArrayList) list;",
+                        "        return obj.hashCode();",
+                        "    }",
+                        "}")
                 .doTest();
     }
 
     @Test
     void testCast2() {
         helper().addSourceLines(
-                "Test.java",
-                "import " + ArrayList.class.getName() + ";",
-                "class Test {",
-                "    int f() {",
-                "        ArrayList<String> list = new ArrayList<String>();",
-                "        // BUG: Diagnostic contains: Avoid raw types",
-                "        ArrayList<Integer> list2 = (ArrayList<Integer>) (ArrayList) list;",
-                "        return list2.hashCode();",
-                "    }",
-                "}")
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        ArrayList<String> list = new ArrayList<String>();",
+                        "        // BUG: Diagnostic contains: Avoid raw types",
+                        "        ArrayList<Integer> list2 = (ArrayList<Integer>) (ArrayList) list;",
+                        "        return list2.hashCode();",
+                        "    }",
+                        "}")
                 .doTest();
     }
 
@@ -272,16 +271,16 @@ class RawTypesTest {
     @Test
     void testNegativeCast() {
         helper().addSourceLines(
-                "Test.java",
-                "import " + ArrayList.class.getName() + ";",
-                "import " + List.class.getName() + ";",
-                "class Test {",
-                "    int f() {",
-                "        List<String> list = new ArrayList<String>();",
-                "        ArrayList<String> list2 = (ArrayList<String>) list;",
-                "        return list2.hashCode();",
-                "    }",
-                "}")
+                        "Test.java",
+                        "import " + ArrayList.class.getName() + ";",
+                        "import " + List.class.getName() + ";",
+                        "class Test {",
+                        "    int f() {",
+                        "        List<String> list = new ArrayList<String>();",
+                        "        ArrayList<String> list2 = (ArrayList<String>) list;",
+                        "        return list2.hashCode();",
+                        "    }",
+                        "}")
                 .doTest();
     }
 

--- a/changelog/@unreleased/pr-1197.v2.yml
+++ b/changelog/@unreleased/pr-1197.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add an ErrorProne check for raw types
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1197

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -38,6 +38,7 @@ public class BaselineErrorProneExtension {
             "PreferListsPartition",
             "PreferSafeLoggableExceptions",
             "PreferSafeLoggingPreconditions",
+            "RawTypes",
             "ReadReturnValueIgnored",
             "RedundantMethodReference",
             "RedundantModifier",

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -38,7 +38,6 @@ public class BaselineErrorProneExtension {
             "PreferListsPartition",
             "PreferSafeLoggableExceptions",
             "PreferSafeLoggingPreconditions",
-            "RawTypes",
             "ReadReturnValueIgnored",
             "RedundantMethodReference",
             "RedundantModifier",


### PR DESCRIPTION
This adds an ErrorProne check that fails when it detects raw types. Currently, javac has a built-in warning type for this, but it's not as flexible as ErrorProne; for example, you can't fail on raw-types errors without also failing on deprecation warnings, and you can't add exemptions for generated code.

Upstream ErrorProne doesn't seem to have any check for this or requests for such a check, beyond this issue: https://github.com/google/error-prone/issues/253

For @SuppressWarnings, the check respects "rawtypes", which is already used by javac and Eclipse.

The current level is "warning"; feel free to change that.

I added the check to the BaselineErrorProneExtension due to seeing it in another PR adding a check.