### PR TITLE
Allow leading underscores in variable names

### DIFF
--- a/changelog/@unreleased/pr-1200.v2.yml
+++ b/changelog/@unreleased/pr-1200.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow leading underscores in local variable names
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1200

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -453,7 +453,7 @@
         <module name="LocalFinalVariableName"/> <!-- Java Style Guide: Local variable names -->
         <module name="LocalVariableName"> <!-- Java Style Guide: Local variable names -->
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+            <property name="format" value="^[a-z_][a-zA-Z0-9]+$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern" value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We use leading underscores as a marking of intentionally unread variables, as required by StrictUnusedVariable. However checkstyle currently doesn't allow it in local variable names.
## After this PR
==COMMIT_MSG==
Allow leading underscores in local variable names
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

