### PR TITLE
Turn off ParenPad when p-j-f enabled

### DIFF
--- a/changelog/@unreleased/pr-1205.v2.yml
+++ b/changelog/@unreleased/pr-1205.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Checkstyle's `ParenPad` rule is turned off when using palantir-java-format,
+    to avoid disagreements that can't be fixed by the user.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1205

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
@@ -105,7 +105,8 @@ class BaselineConfig extends AbstractBaselinePlugin {
                                             + "        </module>\n",
                                     "")
                             .replace(
-                                    "        <module name=\"ParenPad\"/> <!-- Java Style Guide: Horizontal whitespace -->\n",
+                                    "        <module name=\"ParenPad\"/> <!-- Java Style Guide: Horizontal whitespace"
+                                            + " -->\n",
                                     "");
                     Preconditions.checkState(!contents.equals(replaced), "Patching checkstyle.xml must make a change");
                     Files.write(checkstyleXml, replaced.getBytes(StandardCharsets.UTF_8));

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
@@ -98,12 +98,15 @@ class BaselineConfig extends AbstractBaselinePlugin {
                 try {
                     String contents = new String(Files.readAllBytes(checkstyleXml), StandardCharsets.UTF_8);
                     String replaced = contents.replace(
-                            "        <module name=\"Indentation\"> "
-                                    + "<!-- Java Style Guide: Block indentation: +4 spaces -->\n"
-                                    + "            <property name=\"arrayInitIndent\" value=\"8\"/>\n"
-                                    + "            <property name=\"lineWrappingIndentation\" value=\"8\"/>\n"
-                                    + "        </module>\n",
-                            "");
+                                    "        <module name=\"Indentation\"> "
+                                            + "<!-- Java Style Guide: Block indentation: +4 spaces -->\n"
+                                            + "            <property name=\"arrayInitIndent\" value=\"8\"/>\n"
+                                            + "            <property name=\"lineWrappingIndentation\" value=\"8\"/>\n"
+                                            + "        </module>\n",
+                                    "")
+                            .replace(
+                                    "        <module name=\"ParenPad\"/> <!-- Java Style Guide: Horizontal whitespace -->\n",
+                                    "");
                     Preconditions.checkState(!contents.equals(replaced), "Patching checkstyle.xml must make a change");
                     Files.write(checkstyleXml, replaced.getBytes(StandardCharsets.UTF_8));
                 } catch (IOException e) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
@@ -149,5 +149,8 @@ class BaselineConfigIntegrationTest extends AbstractPluginTest {
         !new File(projectDir, '.baseline/checkstyle/checkstyle.xml').readLines().any {
             it.contains '<module name="Indentation">'
         }
+        !new File(projectDir, '.baseline/checkstyle/checkstyle.xml').readLines().any {
+            it.contains '<module name="ParenPad">'
+        }
     }
 }


### PR DESCRIPTION
## Before this PR

Enabling palantir-java-format on an internal repo triggered ParenPad on the following code snippet:
```java
        wc.filter(
                new ExcludeServletPathFilter( // Ignore cookie auth check for /api
                        new CookieAuthServletFilter(
                                wc.conjureClients()
                                        .client(RetrofitOAuth2Client.class, MULTIPASS)
                                        .get(),
```

it turns out it really wanted:

```java
                new ExcludeServletPathFilter(// Ignore cookie auth check for /api
```

I think this ParenPad check is asking for something silly here, and given that users can't bring back the old behaviour anyway, I think it's net negative.

## After this PR
==COMMIT_MSG==
Checkstyle's `ParenPad` rule is turned off when using palantir-java-format, to avoid disagreements that can't be fixed by the user.
==COMMIT_MSG==

## Possible downsides?

<!-- Please describe any way users could be negatively affected by this PR. -->

