### PR TITLE
Turn off UnnecessaryLambda check in tests

### DIFF
--- a/changelog/@unreleased/pr-1210.v2.yml
+++ b/changelog/@unreleased/pr-1210.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Turn off UnnecessaryLambda in tests where it doesn't provide value
+    because there is a ubiquitous use case that is painful to fix.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1210

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -57,8 +57,7 @@ public class BaselineErrorProneExtension {
             "ArrayEquals",
             "MissingOverride",
             "UnnecessaryParentheses",
-            "PreferJavaTimeOverload",
-            "UnnecessaryLambda");
+            "PreferJavaTimeOverload");
 
     private final ListProperty<String> patchChecks;
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -57,7 +57,8 @@ public class BaselineErrorProneExtension {
             "ArrayEquals",
             "MissingOverride",
             "UnnecessaryParentheses",
-            "PreferJavaTimeOverload");
+            "PreferJavaTimeOverload",
+            "UnnecessaryLambda");
 
     private final ListProperty<String> patchChecks;
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -154,6 +154,17 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 errorProneOptions.check("PreferSafeLoggingPreconditions", CheckSeverity.OFF);
                                 errorProneOptions.check("PreconditionsConstantMessage", CheckSeverity.OFF);
                             }));
+
+            project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
+                ((ExtensionAware) javaCompile.getOptions())
+                        .getExtensions()
+                        .configure(ErrorProneOptions.class, errorProneOptions -> {
+                            // Relax some checks for test code
+                            if (errorProneOptions.isCompilingTestOnlyCode()) {
+                                errorProneOptions.check("UnnecessaryLambda", CheckSeverity.OFF);
+                            }
+                        });
+            });
         });
 
         // In case of java 8 we need to add errorprone javac compiler to bootstrap classpath of tasks that perform

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -154,17 +154,17 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                 errorProneOptions.check("PreferSafeLoggingPreconditions", CheckSeverity.OFF);
                                 errorProneOptions.check("PreconditionsConstantMessage", CheckSeverity.OFF);
                             }));
+        });
 
-            project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
-                ((ExtensionAware) javaCompile.getOptions())
-                        .getExtensions()
-                        .configure(ErrorProneOptions.class, errorProneOptions -> {
-                            // Relax some checks for test code
-                            if (errorProneOptions.isCompilingTestOnlyCode()) {
-                                errorProneOptions.check("UnnecessaryLambda", CheckSeverity.OFF);
-                            }
-                        });
-            });
+        project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
+            ((ExtensionAware) javaCompile.getOptions())
+                    .getExtensions()
+                    .configure(ErrorProneOptions.class, errorProneOptions -> {
+                        // Relax some checks for test code
+                        if (errorProneOptions.isCompilingTestOnlyCode()) {
+                            errorProneOptions.check("UnnecessaryLambda", CheckSeverity.OFF);
+                        }
+                    });
         });
 
         // In case of java 8 we need to add errorprone javac compiler to bootstrap classpath of tasks that perform


### PR DESCRIPTION
## Before this PR

UnnecessaryLambda errorprone check blocking baseline in projects with `-Werror`.

## After this PR
==COMMIT_MSG==
Turn off UnnecessaryLambda in tests where it doesn't provide value because there is a ubiquitous use case that is painful to fix.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

