### PR TITLE
-Pcom.palantir.baseline-error-prone.disable

### DIFF
--- a/changelog/@unreleased/pr-1213.v2.yml
+++ b/changelog/@unreleased/pr-1213.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: '`./gradlew compileJava -Pcom.palantir.baseline-error-prone.disable`
+    turns off error-prone, to allow compilation on Java 13 which is not yet supported
+    by error-prone.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1213

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -136,20 +136,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
                             });
         }
 
-        if (project.hasProperty(DISABLE_PROPERY)) {
-            log.info("Disabling baseline-error-prone for {} due to {}", project, DISABLE_PROPERY);
-            return;
-        }
-
-        configureCompileTasks(project, errorProneExtension, refasterRulesFile, compileRefaster);
-    }
-
-    private static void configureCompileTasks(
-            Project project,
-            BaselineErrorProneExtension errorProneExtension,
-            Provider<File> refasterRulesFile,
-            CompileRefasterTask compileRefaster) {
-
         project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
             ((ExtensionAware) javaCompile.getOptions())
                     .getExtensions()
@@ -208,7 +194,13 @@ public final class BaselineErrorProne implements Plugin<Project> {
         JavaVersion jdkVersion =
                 JavaVersion.toVersion(javaCompile.getToolChain().getVersion());
 
-        errorProneOptions.setEnabled(true);
+        if (project.hasProperty(DISABLE_PROPERY)) {
+            log.info("Disabling baseline-error-prone for {} due to {}", project, DISABLE_PROPERY);
+            errorProneOptions.setEnabled(false);
+        } else {
+            errorProneOptions.setEnabled(true);
+        }
+
         errorProneOptions.setDisableWarningsInGeneratedCode(true);
         String projectPath = project.getProjectDir().getPath();
         String separator = Pattern.quote(Paths.get(projectPath).getFileSystem().getSeparator());

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-versions.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-versions.properties
@@ -1,1 +1,0 @@
-implementation-class=com.palantir.baseline.plugins.versions.BaselineVersions

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -97,6 +97,15 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         result.output.contains("[ArrayEquals] Reference equality used to compare arrays")
     }
 
+    def 'error-prone can be suppressed using property'() {
+        when:
+        buildFile << standardBuildFile
+        file('src/main/java/test/Test.java') << invalidJavaFile
+
+        then:
+        BuildResult result = with('compileJava', '-Pcom.palantir.baseline-error-prone.disable').build()
+    }
+
     def 'compileJava succeeds when error-prone finds no errors'() {
         when:
         buildFile << standardBuildFile


### PR DESCRIPTION
## Before this PR

I want to start running some unit tests with Java13, but currently error-prone barfs, see:

- https://github.com/palantir/gradle-baseline/pull/1107
- https://github.com/palantir/gradle-baseline/pull/1106
- https://github.com/palantir/gradle-baseline/pull/1095

## After this PR
==COMMIT_MSG==
`./gradlew compileJava -Pcom.palantir.baseline-error-prone.disable` turns off error-prone, to allow compilation on Java 13 which is not yet supported by error-prone.
==COMMIT_MSG==

## Possible downsides?
- not sure I want people to start using this as part of their regular dev workflow :/

