### PR TITLE
./gradlew test -Drecreate=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,4 +371,7 @@ Configures some sensible defaults:
 
 The plugin also adds a `checkJUnitDependencies` to make the migration to JUnit5 safer.  Specifically, it should prevent cases where the tests could silently not run due to misconfigured dependencies.
 
+3. For repos that use 'snapshot' style testing, it's convenient to have a single command to accept the updated snapshots after a code change.
+This plugin ensures that if you run tests with `./gradlew test -Drecreate=true`, the system property will be passed down to the running Java process (which can be detected with `Boolean.getBoolean("recreate")`).
+
 

--- a/changelog/@unreleased/pr-1220.v2.yml
+++ b/changelog/@unreleased/pr-1220.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: For repos that use snapshot-style testing, `./gradlew test -Drecreate=true`
+    will ensure the `"recreate"` system property is passed through to Java correctly.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1220

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -46,6 +46,12 @@ public final class BaselineTesting implements Plugin<Project> {
                 // Never cache test tasks, until we work out the correct inputs for ETE / integration tests
                 task.getOutputs().cacheIf(t -> false);
             }
+
+            // repos that use 'snapshot' style testing should all use one convenient task to refresh the snapshots,
+            // ./gradlew test -Drecreate=true
+            String shouldRecreate = System.getProperty("recreate", "false");
+            task.systemProperty("recreate", shouldRecreate);
+            task.getInputs().property("recreate", shouldRecreate);
         });
 
         project.getPlugins().withType(JavaPlugin.class, unusedPlugin -> {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -51,7 +51,9 @@ public final class BaselineTesting implements Plugin<Project> {
             // ./gradlew test -Drecreate=true
             String shouldRecreate = System.getProperty("recreate", "false");
             task.systemProperty("recreate", shouldRecreate);
-            task.getInputs().property("recreate", shouldRecreate);
+            if (Boolean.valueOf(shouldRecreate)) {
+                task.getOutputs().cacheIf(t -> false);
+            }
         });
 
         project.getPlugins().withType(JavaPlugin.class, unusedPlugin -> {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -49,10 +49,10 @@ public final class BaselineTesting implements Plugin<Project> {
 
             // repos that use 'snapshot' style testing should all use one convenient task to refresh the snapshots,
             // ./gradlew test -Drecreate=true
-            String shouldRecreate = System.getProperty("recreate", "false");
-            task.systemProperty("recreate", shouldRecreate);
-            if (Boolean.valueOf(shouldRecreate)) {
-                task.getOutputs().cacheIf(t -> false);
+            boolean shouldRecreate = Boolean.getBoolean("recreate");
+            task.systemProperty("recreate", Boolean.toString(shouldRecreate));
+            if (shouldRecreate) {
+                task.getOutputs().upToDateWhen(t -> false);
             }
         });
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -175,5 +175,8 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
 
         BuildResult result3 = with('test', '-Drecreate=true').build()
         result3.task(':test').getOutcome() == TaskOutcome.SUCCESS
+
+        BuildResult result4 = with('test', '-Drecreate=true').build()
+        result4.task(':test').getOutcome() == TaskOutcome.SUCCESS
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -160,4 +160,20 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
         BuildResult result = with('checkJUnitDependencies').buildAndFail()
         result.output.contains 'Tests may be silently not running! Spock dependency detected'
     }
+
+    def 'running -Drecreate=true will re-run tests even if no code changes'() {
+        when:
+        buildFile << standardBuildFile
+        file('src/test/java/test/TestClass4.java') << junit4Test
+
+        then:
+        BuildResult result = with('test').build()
+        result.task(':test').getOutcome() == TaskOutcome.SUCCESS
+
+        BuildResult result2 = with('test').build()
+        result2.task(':test').getOutcome() == TaskOutcome.UP_TO_DATE
+
+        BuildResult result3 = with('test', '-Drecreate=true').build()
+        result3.task(':test').getOutcome() == TaskOutcome.SUCCESS
+    }
 }


### PR DESCRIPTION
## Before this PR

A number of our repos use the `./gradlew test -Drecreate=true` pattern, but I recently found (on our circle-templates repo) that we've been doing it wrong the entire time.  Specifically, the task short-circuits and doesn't run when there are no code changes, even though the behaviour _should_ be different when `-Drecreate=true` is passed in.

## After this PR
==COMMIT_MSG==
For repos that use snapshot-style testing, `./gradlew test -Drecreate=true` will ensure the `"recreate"` system property is passed through to Java correctly.
==COMMIT_MSG==

## Possible downsides?


