### PR TITLE
License replacement attempts to preserve existing year info

### DIFF
--- a/changelog/@unreleased/pr-1227.v2.yml
+++ b/changelog/@unreleased/pr-1227.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Auto-fixing license headers will attempt to preserve the existing year
+    of creation.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1227

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -97,12 +97,9 @@ class BaselineFormat extends AbstractBaselinePlugin {
      * by {@code baselineUpdateConfig}.
      */
     private FormatterStep createLazyLicenseHeaderStep(Project project) {
-        // Spotless will consider the license header to be the file prefix up to the first line starting with delimiter
-        String delimiter = "(?! \\*|/\\*| \\*/)";
-
         return new LazyFormatterStep(MultiLicenseHeaderStep.name(), () -> {
             List<String> headers = computeCopyrightHeaders(project);
-            return MultiLicenseHeaderStep.createFromHeaders(headers, delimiter);
+            return MultiLicenseHeaderStep.createFromHeaders(headers);
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -18,8 +18,6 @@ package com.palantir.baseline.plugins;
 
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import com.diffplug.spotless.FormatterStep;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Streams;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -131,19 +129,11 @@ class BaselineFormat extends AbstractBaselinePlugin {
     }
 
     private static String computeCopyrightComment(Path copyrightFile) {
-        String copyrightContents;
         try {
-            copyrightContents = new String(Files.readAllBytes(copyrightFile), StandardCharsets.UTF_8);
+            return new String(Files.readAllBytes(copyrightFile), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException("Couldn't read copyright file " + copyrightFile, e);
         }
-        String copyright = copyrightContents.trim();
-        // Spotless expects the literal header so we have to add the Java comment guard and prefixes
-        return Streams.concat(
-                        Stream.of("/*"),
-                        Streams.stream(Splitter.on('\n').split(copyright)).map(line -> " " + ("* " + line).trim()),
-                        Stream.of(" */"))
-                .collect(Collectors.joining("\n"));
     }
 
     private static void configureSpotlessJava(Project project, SpotlessExtension spotlessExtension) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.api.GradleException;
@@ -138,10 +137,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
         } catch (IOException e) {
             throw new RuntimeException("Couldn't read copyright file " + copyrightFile, e);
         }
-        // Spotless expects '$YEAR' but our current patterns use ${today.year}
-        String copyright = copyrightContents
-                .replaceAll(Pattern.quote("${today.year}"), "\\$YEAR")
-                .trim();
+        String copyright = copyrightContents.trim();
         // Spotless expects the literal header so we have to add the Java comment guard and prefixes
         return Streams.concat(
                         Stream.of("/*"),

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
@@ -80,6 +80,7 @@ public final class MultiLicenseHeaderStep implements Serializable {
     private static class LicenseHeader implements Serializable {
         private static final long serialVersionUID = 1L;
         private static final Pattern YEAR_RANGE = Pattern.compile("[0-9]{4}(-[0-9]{4})?");
+        private static final String YEAR_TOKEN = "${today.year}";
 
         private final String licenseHeader;
         private final boolean hasYearToken;
@@ -88,11 +89,11 @@ public final class MultiLicenseHeaderStep implements Serializable {
 
         LicenseHeader(String licenseHeader0) {
             this.licenseHeader = sanitizeLicenseHeader(licenseHeader0);
-            int yearTokenIndex = licenseHeader.indexOf("$YEAR");
+            int yearTokenIndex = licenseHeader.indexOf(YEAR_TOKEN);
             this.hasYearToken = yearTokenIndex != -1;
             if (this.hasYearToken) {
                 this.licenseHeaderBeforeYearToken = licenseHeader.substring(0, yearTokenIndex);
-                this.licenseHeaderAfterYearToken = licenseHeader.substring(yearTokenIndex + 5);
+                this.licenseHeaderAfterYearToken = licenseHeader.substring(yearTokenIndex + YEAR_TOKEN.length());
             }
         }
 
@@ -128,7 +129,7 @@ public final class MultiLicenseHeaderStep implements Serializable {
                 String year = existingHeaderContainsYear
                         ? yearInfo.group(0)
                         : String.valueOf(YearMonth.now().getYear());
-                return licenseHeader.replace("$YEAR", year);
+                return licenseHeader.replace(YEAR_TOKEN, year);
             }
             return licenseHeader;
         }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
@@ -41,14 +41,16 @@ import com.google.common.collect.Streams;
 import java.io.Serializable;
 import java.time.YearMonth;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-/** Prefixes a license header before the package statement. */
-public final class MultiLicenseHeaderStep implements Serializable {
+/**
+ * Ensures java files begin with one of a number of approved copyright licenses. Inspired by spotless'
+ * {@link LicenseHeaderStep}.
+ */
+final class MultiLicenseHeaderStep implements Serializable {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -64,16 +66,16 @@ public final class MultiLicenseHeaderStep implements Serializable {
 
     private final List<LicenseHeader> licenseHeaders;
 
-    private MultiLicenseHeaderStep(List<String> licenseHeaders) {
-        Objects.requireNonNull(licenseHeaders, "licenseHeaders");
-        this.licenseHeaders =
-                licenseHeaders.stream().map(LicenseHeader::fromTemplate).collect(Collectors.toList());
+    private MultiLicenseHeaderStep(List<LicenseHeader> licenseHeaders) {
+        this.licenseHeaders = licenseHeaders;
     }
 
     /** Creates a spotless {@link FormatterStep} which forces the start of each file to match a license header. */
-    public static FormatterStep createFromHeaders(List<String> licenseHeaders) {
+    public static FormatterStep createFromHeaders(List<String> templates) {
+        List<LicenseHeader> headers =
+                templates.stream().map(LicenseHeader::fromTemplate).collect(Collectors.toList());
         return FormatterStep.create(
-                MultiLicenseHeaderStep.NAME, new MultiLicenseHeaderStep(licenseHeaders), step -> step::format);
+                MultiLicenseHeaderStep.NAME, new MultiLicenseHeaderStep(headers), step -> step::format);
     }
 
     public static String name() {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
@@ -80,7 +80,6 @@ public final class MultiLicenseHeaderStep implements Serializable {
     private static class LicenseHeader implements Serializable {
         private static final long serialVersionUID = 1L;
         private static final Pattern YEAR_RANGE = Pattern.compile("[0-9]{4}(-[0-9]{4})?");
-        private static final Pattern SINGLE_YEAR = Pattern.compile("[0-9]{4}");
 
         private final String licenseHeader;
         private final boolean hasYearToken;
@@ -124,10 +123,10 @@ public final class MultiLicenseHeaderStep implements Serializable {
 
         private String render(String existingHeader) {
             if (hasYearToken) {
-                Matcher singleYear = SINGLE_YEAR.matcher(existingHeader);
-                boolean existingHeaderContainsYear = singleYear.find();
+                Matcher yearInfo = YEAR_RANGE.matcher(existingHeader);
+                boolean existingHeaderContainsYear = yearInfo.find();
                 String year = existingHeaderContainsYear
-                        ? singleYear.group(0)
+                        ? yearInfo.group(0)
                         : String.valueOf(YearMonth.now().getYear());
                 return licenseHeader.replace("$YEAR", year);
             }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatCopyrightIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatCopyrightIntegrationTest.groovy
@@ -50,6 +50,14 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
          */
     """.stripIndent()
 
+    static generatedCopyright2015 = """\
+        /*
+         * (c) Copyright 2015 GoodCorp
+         *
+         * EXTRA
+         */
+    """.stripIndent()
+
     static goodCopyright = """\
         /*
          * (c) Copyright 2019 GoodCorp
@@ -105,7 +113,7 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
     def 'check fails on #copyrightType copyright in #lang project'() {
         buildFile << standardBuildFile
         def javaFile = file("src/main/$lang/test/Test.$lang")
-        javaFile << copyright
+        javaFile << input
         javaFile << validJavaFile
 
         expect:
@@ -117,14 +125,14 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
         with('format').build()
 
         then:
-        javaFile.text.startsWith(generatedCopyright)
+        javaFile.text.startsWith(expected)
 
         where:
-        copyrightType | copyright    | lang
-        "bad"         | badCopyright | "java"
-        "bad"         | badCopyright | "groovy"
-        "missing"     | ''           | "java"
-        "missing"     | ''           | "groovy"
+        copyrightType | input        | expected               | lang
+        "bad"         | badCopyright | generatedCopyright2015 | "java"
+        "bad"         | badCopyright | generatedCopyright2015 | "groovy"
+        "missing"     | ''           | generatedCopyright     | "java"
+        "missing"     | ''           | generatedCopyright     | "groovy"
     }
 
     def 'check passes on correct #copyrightType copyright in #lang project'() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatCopyrightIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatCopyrightIntegrationTest.groovy
@@ -32,12 +32,12 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
         // Testing that an empty line is also OK, these can cause gotchas
         file(".baseline/copyright").deleteDir()
         file(".baseline/copyright/050-test") << '''
-            (c) Copyright $YEAR GoodCorp
+            (c) Copyright ${today.year} GoodCorp
             
             EXTRA
         '''.stripIndent()
         file(".baseline/copyright/000-also-works") << '''
-            (c) Copyright $YEAR OtherCorp
+            (c) Copyright ${today.year} OtherCorp
         '''.stripIndent()
     }
 


### PR DESCRIPTION
## Before this PR

@tusharnarayan got a PR to upgrade baseline on his project and it nuked all his existing license (which were pretty bonkers anyway) and replaced them with 2020 ones. This upsets legal, who prefer to preserve the original creation date of files where possible.

## After this PR
==COMMIT_MSG==
Auto-fixing license headers will attempt to preserve the existing year of creation.
==COMMIT_MSG==

I predict this will be ***incredibly useful*** when we want to open source an internal project, because we should be able to just swap out the license template it .baseline/copyright and then run `./gradlew format`.

Confirming I ran this on tushar's project and it did the right thing.

## Possible downsides?
- we diverge further from spotless' existing LicenseHeaderStep

