### PR TITLE
Don't trim license template lines

### DIFF
--- a/changelog/@unreleased/pr-1228.v2.yml
+++ b/changelog/@unreleased/pr-1228.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Copyright header enforcement now includes any leading and trailing
+    whitespace on lines
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1228

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
@@ -103,7 +103,7 @@ final class MultiLicenseHeaderStep implements Serializable {
 
         static LicenseHeader fromTemplate(String template) {
             String unixEndings = LineEnding.toUnix(template.trim());
-            Iterable<String> lines = Splitter.on('\n').trimResults().split(unixEndings);
+            Iterable<String> lines = Splitter.on('\n').split(unixEndings);
             String javadocHeader = Streams.stream(lines)
                     .map(line -> line.isEmpty() ? " *" : " * " + line)
                     .collect(Collectors.joining("\n"));

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatCopyrightIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineFormatCopyrightIntegrationTest.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://url-to-some-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
         file(".baseline/copyright/050-test") << '''
             (c) Copyright ${today.year} GoodCorp
             
-            EXTRA
+                http://url-to-some-license
         '''.stripIndent()
         file(".baseline/copyright/000-also-works") << '''
             (c) Copyright ${today.year} OtherCorp
@@ -46,7 +46,7 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
         /*
          * (c) Copyright ${LocalDate.now().year} GoodCorp
          *
-         * EXTRA
+         *     http://url-to-some-license
          */
     """.stripIndent()
 
@@ -54,7 +54,7 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
         /*
          * (c) Copyright 2015 GoodCorp
          *
-         * EXTRA
+         *     http://url-to-some-license
          */
     """.stripIndent()
 
@@ -62,7 +62,7 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
         /*
          * (c) Copyright 2019 GoodCorp
          *
-         * EXTRA
+         *     http://url-to-some-license
          */
     """.stripIndent()
 
@@ -70,7 +70,7 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
         /*
          * (c) Copyright 2015-2019 GoodCorp
          *
-         * EXTRA
+         *     http://url-to-some-license
          */
     """.stripIndent()
 
@@ -84,7 +84,7 @@ class BaselineFormatCopyrightIntegrationTest extends AbstractPluginTest {
         /*
          * (c) Copyright 2015 EvilCorp
          *
-         * EXTRA
+         *     http://url-to-some-license
          */
     """.stripIndent()
 


### PR DESCRIPTION
## Before this PR

PRs were being made to helpfully chop the whitespace off the front of lines:

```diff
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
```

We don't want this as the authoritative license has the whitespace prefix: https://github.com/palantir/gradle-baseline/blob/e1f9438658eb01b2cd3338424b54b2c6ce39f84c/gradle-baseline-java-config/resources/copyright/001_apache-2.0.txt#L7

## After this PR
==COMMIT_MSG==
Copyright header enforcement now includes any leading and trailing whitespace on lines
==COMMIT_MSG==

## Possible downsides?
- trailing whitespace is generally considered a _bad thing_. If a template has trailing whitespace, it'll be propagated everywhere. solution is to just not have trailing whitespace in your templates I think.

