### PR TITLE
Separate additional copyright

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/MultiLicenseHeaderStep.java
@@ -12,7 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
  * Original copyright:
  *
  * Copyright 2016 DiffPlug


### PR DESCRIPTION
This is so that the baseline upgrade doesn't wreck this copyright: https://github.com/palantir/gradle-baseline/pull/1226/files#diff-2af2d7d420ba264ba87a226b91e207c1