### PR TITLE
checkClassUniqueness works with conjure

### DIFF
--- a/changelog/@unreleased/pr-1250.v2.yml
+++ b/changelog/@unreleased/pr-1250.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: checkClassUniqueness should now behave consistently when asked to analyze
+    configurations that are `builtBy` other tasks (e.g. gradle-conjure, gradle-atlas)
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1250

--- a/docs/best-practices/java-coding-guidelines/readme.md
+++ b/docs/best-practices/java-coding-guidelines/readme.md
@@ -86,7 +86,7 @@ topics:
     all offices)
 - Java Concurrency in Practice (copies exist in all offices)
 - [Writing Testable Code](http://misko.hevery.com/code-reviewers-guide/)
-- [How to Design a GoodAPI and Why it Matters (Bloch)](http://lcsd05.cs.tamu.edu/slides/keynote.pdf)
+- [How to Design a GoodAPI and Why it Matters (Bloch)](http://fwdinnovations.net/whitepaper/APIDesign.pdf)
 
 ## Miscellaneous
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIntegrationTest.groovy
@@ -43,6 +43,6 @@ class BaselineIntegrationTest extends AbstractPluginTest {
         with().withArguments('-s').withGradleVersion(gradleVersion).build()
 
         where:
-        gradleVersion << ['5.4', '6.0-20190904072820+0000']
+        gradleVersion << ['5.4', '6.2']
     }
 }


### PR DESCRIPTION
## Before this PR

@dsinghvi reported in #dev-foundry-infra some problems with checkClassUniqueness giving inconsistent results on CI and locally. (We've also had other complaints related to gradle-atlas).

Running the task locally, it seemed no conjure objects were being generated, so the lockfile would be different than if conjure objects did exist.

## After this PR
==COMMIT_MSG==
checkClassUniqueness should now behave consistently when asked to analyze configurations that are `builtBy` other tasks (e.g. gradle-conjure, gradle-atlas)
==COMMIT_MSG==

## Possible downsides?
- we don't really know why the current thing _isn't_ working, as it seems like we're doing the recommended thing.
<!-- Please describe any way users could be negatively affected by this PR. -->

