### PR TITLE
Add an id for @VisibleForTesting annotation checks.

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -19,6 +19,7 @@
         <property name="lineSeparator" value="lf"/>
     </module>
     <module name="RegexpMultiline"> <!-- Development Practices: Writing good unit tests -->
+        <property name="id" value="VisibleForTestingPackagePrivate"/>
         <property name="fileExtensions" value="java"/>
         <property name="format" value="@VisibleForTesting\s+(protected|public)"/>
         <property name="message" value="@VisibleForTesting members should be package-private."/>

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -19,7 +19,6 @@
         <property name="lineSeparator" value="lf"/>
     </module>
     <module name="RegexpMultiline"> <!-- Development Practices: Writing good unit tests -->
-        <property name="id" value="VisibleForTestingPackagePrivate"/>
         <property name="fileExtensions" value="java"/>
         <property name="format" value="@VisibleForTesting\s+(protected|public)"/>
         <property name="message" value="@VisibleForTesting members should be package-private."/>

--- a/changelog/@unreleased/pr-1252.v2.yml
+++ b/changelog/@unreleased/pr-1252.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '@VisibleForTesting annotation has an id.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1252

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -19,6 +19,7 @@
         <property name="lineSeparator" value="lf"/>
     </module>
     <module name="RegexpMultiline"> <!-- Development Practices: Writing good unit tests -->
+        <property name="id" value="VisibleForTestingPackagePrivate"/>
         <property name="fileExtensions" value="java"/>
         <property name="format" value="@VisibleForTesting\s+(protected|public)"/>
         <property name="message" value="@VisibleForTesting members should be package-private."/>


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Cannot selectively turn this check off.

## After this PR
==COMMIT_MSG==
@VisibleForTesting annotation has an id.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

