### PR TITLE
BaselineExactDependencies applies to all source sets

### DIFF
--- a/changelog/@unreleased/pr-1262.v2.yml
+++ b/changelog/@unreleased/pr-1262.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: BaselineExactDependencies applies to all source sets
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1262

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -86,8 +86,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                     conf.setVisible(false);
                     conf.setCanBeConsumed(false);
                     conf.extendsFrom(compileOnly);
-                    // Important! this ensures we resolve 'compile' variants rather than
-                    // 'runtime'
+                    // Important! this ensures we resolve 'compile' variants rather than 'runtime'
                     // This is the same attribute that's being set on compileClasspath
                     conf.getAttributes()
                             .attribute(

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -19,8 +19,6 @@ package com.palantir.baseline.plugins;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
 import com.palantir.baseline.tasks.CheckImplicitDependenciesTask;
 import com.palantir.baseline.tasks.CheckUnusedDependenciesTask;
 import java.io.File;
@@ -147,18 +145,6 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             task.ignore("org.slf4j", "slf4j-api");
                         });
         checkImplicitDependencies.configure(task -> task.dependsOn(sourceSetCheckImplicitDependencies));
-    }
-
-    private static Configuration makeInternalCompileConfiguration(Project project, Configuration compileOnly) {
-        return project.getConfigurations().create("baseline-exact-dependencies-" + compileOnly.getName(), conf -> {
-            conf.setVisible(false);
-            conf.setCanBeConsumed(false);
-            conf.extendsFrom(compileOnly);
-            // Important! this ensures we resolve 'compile' variants rather than 'runtime'
-            // This is the same attribute that's being set on compileClasspath
-            conf.getAttributes()
-                    .attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_API));
-        });
     }
 
     /** Given a {@code com/palantir/product/Foo.class} file, what other classes does it import/reference. */

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -43,7 +43,6 @@ import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
@@ -99,7 +98,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                         GUtil.toLowerCamelCase("checkUnusedDependencies " + sourceSet.getName()),
                         CheckUnusedDependenciesTask.class,
                         task -> {
-                            task.dependsOn(JavaPlugin.CLASSES_TASK_NAME);
+                            task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
                             task.dependenciesConfiguration(compileClasspath);
                             task.sourceOnlyConfiguration(resolvableCompileOnly);
@@ -113,7 +112,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                         GUtil.toLowerCamelCase("checkImplicitDependencies " + sourceSet.getName()),
                         CheckImplicitDependenciesTask.class,
                         task -> {
-                            task.dependsOn(JavaPlugin.CLASSES_TASK_NAME);
+                            task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
                             task.dependenciesConfiguration(compileClasspath);
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -107,9 +107,14 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         //  \-- testCompile       extendsFrom(compile)
         // We therefore want to look at only the dependencies _directly_ declared in the implementation and compile
         // configurations (belonging to our source set)
-        project.afterEvaluate(p -> {
+        explicitCompile.withDependencies(deps -> {
             Configuration implCopy = implementation.copy();
             Configuration compileCopy = compile.copy();
+            // Without these, explicitCompile will successfully resolve 0 files and you'll waste 1 hour trying
+            // to figure out why.
+            project.getConfigurations().add(implCopy);
+            project.getConfigurations().add(compileCopy);
+
             explicitCompile.extendsFrom(implCopy, compileCopy);
             // Mirror the transitive constraints form compileClasspath in order to pick up GCV locks.
             // We should really do this with an addAllLater but that would require Gradle 6, or a hacky workaround.

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.tasks;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.palantir.baseline.plugins.BaselineExactDependencies;
@@ -190,6 +191,11 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
     }
 
     public final void sourceOnlyConfiguration(Configuration configuration) {
+        Preconditions.checkNotNull(configuration);
+        Preconditions.checkArgument(
+                configuration.isCanBeResolved(),
+                "May only add sourceOnlyConfiguration if it is resolvable: %s",
+                configuration);
         this.sourceOnlyConfigurations.add(Objects.requireNonNull(configuration));
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -191,7 +191,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
     }
 
     public final void sourceOnlyConfiguration(Configuration configuration) {
-        Preconditions.checkNotNull(configuration);
+        Preconditions.checkNotNull(configuration, "This method requires a non-null configuration");
         Preconditions.checkArgument(
                 configuration.isCanBeResolved(),
                 "May only add sourceOnlyConfiguration if it is resolvable: %s",

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -112,6 +112,31 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.task(':checkUnusedDependenciesMain').getOutcome() == TaskOutcome.SUCCESS
     }
 
+    def 'checkUnusedDependenciesTest passes if dependency from main source set is not referenced in test'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << """
+        repositories {
+            mavenCentral()
+        }
+        dependencies {
+            compile 'com.google.guava:guava:28.0-jre'
+        }
+        """
+        file('src/main/java/pkg/Foo.java') << '''
+        package pkg;
+        public class Foo {
+            void foo() {
+                com.google.common.collect.ImmutableList.of();
+            }
+        }
+        '''.stripIndent()
+
+        then:
+        def result = with('checkUnusedDependencies', '--stacktrace').build()
+        result.task(':checkUnusedDependenciesTest').getOutcome() == TaskOutcome.SUCCESS
+    }
+
     def 'checkImplicitDependencies fails when a class is imported without being declared as a dependency'() {
         when:
         buildFile << standardBuildFile

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -87,7 +87,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         then:
         BuildResult result = with('checkUnusedDependencies', '--stacktrace').buildAndFail()
         result.task(':classes').getOutcome() == TaskOutcome.SUCCESS
-        result.task(':checkUnusedDependencies').getOutcome() == TaskOutcome.FAILED
+        result.task(':checkUnusedDependenciesMain').getOutcome() == TaskOutcome.FAILED
         result.output.contains("Found 1 dependencies unused during compilation")
     }
 
@@ -109,6 +109,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         BuildResult result = with('checkUnusedDependencies', '--stacktrace').build()
         result.task(':classes').getOutcome() == TaskOutcome.SUCCESS
         result.task(':checkUnusedDependencies').getOutcome() == TaskOutcome.SUCCESS
+        result.task(':checkUnusedDependenciesMain').getOutcome() == TaskOutcome.SUCCESS
     }
 
     def 'checkImplicitDependencies fails when a class is imported without being declared as a dependency'() {
@@ -134,7 +135,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         then:
         BuildResult result = with('checkImplicitDependencies', '--stacktrace').buildAndFail()
         result.task(':classes').getOutcome() == TaskOutcome.SUCCESS
-        result.task(':checkImplicitDependencies').getOutcome() == TaskOutcome.FAILED
+        result.task(':checkImplicitDependenciesMain').getOutcome() == TaskOutcome.FAILED
         result.output.contains("Found 1 implicit dependencies")
     }
 
@@ -156,7 +157,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         then:
         BuildResult result = with('checkImplicitDependencies', '--stacktrace').withDebug(true).buildAndFail()
         result.task(':classes').getOutcome() == TaskOutcome.SUCCESS
-        result.task(':checkImplicitDependencies').getOutcome() == TaskOutcome.FAILED
+        result.task(':checkImplicitDependenciesMain').getOutcome() == TaskOutcome.FAILED
         result.output.contains("Found 1 implicit dependencies")
         result.output.contains("implementation project(':sub-project-no-deps')")
     }


### PR DESCRIPTION
## Before this PR
BaselineExactDependencies only applied to the main source set

## After this PR
==COMMIT_MSG==
BaselineExactDependencies applies to all source sets
==COMMIT_MSG==

## Possible downsides?
This will flag even more unused dependencies (including in tests), and could block upgrades
