### PR TITLE
Fix check dependencies

### DIFF
--- a/changelog/@unreleased/pr-1267.v2.yml
+++ b/changelog/@unreleased/pr-1267.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix `checkUnusedDependencies` regression introduced in 3.7.0 where
+    it was failing when finding a dependency on another project that applies `java-library`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1267

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -46,6 +46,7 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
@@ -100,6 +101,13 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                     conf.getAttributes()
                             .attribute(
                                     Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_API));
+                    // Without this, the 'checkUnusedDependencies correctly picks up project dependency on java-library'
+                    // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
+                    // than to the classes directory), which then doesn't exist.
+                    conf.getAttributes()
+                            .attribute(
+                                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                                    project.getObjects().named(LibraryElements.class, LibraryElements.CLASSES));
                 });
 
         // Figure out what our compile dependencies are while ignoring dependencies we've inherited from other source

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -52,6 +52,7 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.util.GUtil;
+import org.gradle.util.GradleVersion;
 
 /** Validates that java projects declare exactly the dependencies they rely on, no more and no less. */
 public final class BaselineExactDependencies implements Plugin<Project> {
@@ -63,9 +64,14 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     // contained in a particular jar are immutable.
     public static final Indexes INDEXES = new Indexes();
     public static final ImmutableSet<String> VALID_ARTIFACT_EXTENSIONS = ImmutableSet.of("jar", "");
+    private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.3");
 
     @Override
     public void apply(Project project) {
+        Preconditions.checkState(
+                GradleVersion.current().compareTo(MINIMUM_GRADLE_VERSION) >= 0,
+                "Must use at least %s when using baseline-exact-dependencies",
+                MINIMUM_GRADLE_VERSION);
         project.getPluginManager().withPlugin("java", plugin -> {
             TaskProvider<Task> checkUnusedDependencies = project.getTasks().register("checkUnusedDependencies");
             TaskProvider<Task> checkImplicitDependencies = project.getTasks().register("checkImplicitDependencies");

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -149,9 +149,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
 
         TaskProvider<CheckUnusedDependenciesTask> sourceSetUnusedDependencies = project.getTasks()
                 .register(
-                        GUtil.toLowerCamelCase("checkUnusedDependencies " + sourceSet.getName()),
-                        CheckUnusedDependenciesTask.class,
-                        task -> {
+                        checkUnusedDependenciesNameForSourceSet(sourceSet), CheckUnusedDependenciesTask.class, task -> {
                             task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
                             task.dependenciesConfiguration(explicitCompile);
@@ -172,6 +170,10 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             task.ignore("org.slf4j", "slf4j-api");
                         });
         checkImplicitDependencies.configure(task -> task.dependsOn(sourceSetCheckImplicitDependencies));
+    }
+
+    static String checkUnusedDependenciesNameForSourceSet(SourceSet sourceSet) {
+        return GUtil.toLowerCamelCase("checkUnusedDependencies " + sourceSet.getName());
     }
 
     private static Map<String, String> excludeRuleAsMap(ExcludeRule rule) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.plugins;
 
 import com.palantir.baseline.tasks.CheckJUnitDependencies;
+import com.palantir.baseline.tasks.CheckUnusedDependenciesTask;
 import java.util.Objects;
 import java.util.Optional;
 import org.gradle.api.Plugin;
@@ -27,6 +28,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
@@ -73,6 +75,15 @@ public final class BaselineTesting implements Plugin<Project> {
                                     "Detected 'org:junit.jupiter:junit-jupiter', enabling useJUnitPlatform() on {}",
                                     maybeTestTask.get().getName());
                             enableJunit5ForTestTask(maybeTestTask.get());
+
+                            // Also wire up a test ignore for this source set
+                            project.getPlugins().withType(BaselineExactDependencies.class, exactDeps -> {
+                                TaskContainer tasks = project.getTasks();
+                                tasks.named(
+                                        BaselineExactDependencies.checkUnusedDependenciesNameForSourceSet(ss),
+                                        CheckUnusedDependenciesTask.class,
+                                        task -> task.ignore("org.junit.jupiter", "junit-jupiter"));
+                            });
                         });
             });
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -125,7 +125,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
 
         then:
         def result = with('checkUnusedDependencies', '--stacktrace').build()
-        result.task(':prerequisite').getOutcome() == TaskOutcome.SUCCESS
+        result.task(':prerequisite').getOutcome() == TaskOutcome.UP_TO_DATE
     }
 
     def 'checkUnusedDependenciesTest passes if dependency from main source set is not referenced in test'() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -112,20 +112,34 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.task(':checkUnusedDependenciesMain').getOutcome() == TaskOutcome.SUCCESS
     }
 
-    def 'checkUnusedDependencies wires up other task dependencies'() {
+    def 'checkUnusedDependencies correctly picks up project dependency on java-library'() {
         when:
         buildFile << standardBuildFile
         buildFile << """
-        task prerequisite
         dependencies {
-            compile project.files().builtBy('prerequisite')
+            compile project(':needs-building-first')
         }
         """
-        file('src/main/java/pkg/Foo.java') << minimalJavaFile
+
+        multiProject.addSubproject('needs-building-first', """
+            apply plugin: 'java-library'
+        """.stripIndent())
+
+        file('needs-building-first/src/main/java/pkg/Bar.java') << """
+            package pkg;
+            public class Bar {}
+        """.stripIndent()
+        file('src/main/java/pkg/Foo.java') << """
+            package pkg;
+            class Foo {
+                // Just reference something from the other project
+                void test() { new Bar(); }
+            }
+        """.stripIndent()
 
         then:
         def result = with('checkUnusedDependencies', '--stacktrace').build()
-        result.task(':prerequisite').getOutcome() == TaskOutcome.UP_TO_DATE
+        assert result.task(':needs-building-first:compileJava').getOutcome() != null
     }
 
     def 'checkUnusedDependenciesTest passes if dependency from main source set is not referenced in test'() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -112,6 +112,22 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.task(':checkUnusedDependenciesMain').getOutcome() == TaskOutcome.SUCCESS
     }
 
+    def 'checkUnusedDependencies wires up other task dependencies'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << """
+        task prerequisite
+        dependencies {
+            compile project.files().builtBy('prerequisite')
+        }
+        """
+        file('src/main/java/pkg/Foo.java') << minimalJavaFile
+
+        then:
+        def result = with('checkUnusedDependencies', '--stacktrace').build()
+        result.task(':prerequisite').getOutcome() == TaskOutcome.SUCCESS
+    }
+
     def 'checkUnusedDependenciesTest passes if dependency from main source set is not referenced in test'() {
         when:
         buildFile << standardBuildFile


### PR DESCRIPTION
## Before this PR

Sadly merged #1262 too quickly and it's missing some inter-project task dependencies if you depend on a project which applies `java-library`.

## After this PR
==COMMIT_MSG==
Fix `checkUnusedDependencies` regression introduced in 3.7.0 where it was failing when finding a dependency on another project that applies `java-library`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

