### PR TITLE
Don't apply BaselineFixGradleJava by default

### DIFF
--- a/changelog/@unreleased/pr-1274.v2.yml
+++ b/changelog/@unreleased/pr-1274.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix regression in 3.5.0 where people's idea{} configuration code would
+    now crash, by not applying `com.palantir.baseline-fix-gradle-java` by default.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1274

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -45,7 +45,10 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineExactDependencies.class);
             proj.getPluginManager().apply(BaselineReleaseCompatibility.class);
             proj.getPluginManager().apply(BaselineTesting.class);
-            proj.getPluginManager().apply(BaselineFixGradleJava.class);
+            
+            // TODO(dsanduleac): enable this when people's idea{} blocks no longer reference things like
+            //    configurations.integrationTestCompile
+            // proj.getPluginManager().apply(BaselineFixGradleJava.class);
 
             // TODO(dfox): enable this when it has been validated on a few real projects
             // proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -45,7 +45,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineExactDependencies.class);
             proj.getPluginManager().apply(BaselineReleaseCompatibility.class);
             proj.getPluginManager().apply(BaselineTesting.class);
-            
+
             // TODO(dsanduleac): enable this when people's idea{} blocks no longer reference things like
             //    configurations.integrationTestCompile
             // proj.getPluginManager().apply(BaselineFixGradleJava.class);


### PR DESCRIPTION
## Before this PR

3.5.0 (#1254) was breaking a lot of code that was resolving the bad configurations which we banned from resolving.

## After this PR
==COMMIT_MSG==
Fix regression in 3.5.0 where people's idea{} configuration code would now crash, by not applying `com.palantir.baseline-fix-gradle-java` by default.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

