### PR TITLE
Fix regression in baseline-exact-dependencies causing CME

### DIFF
--- a/changelog/@unreleased/pr-1275.v2.yml
+++ b/changelog/@unreleased/pr-1275.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix baseline 3.7.0-3.7.2 regression in baseline-exact-dependencies
+    causing ConcurrentModificationException.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1275

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -125,7 +125,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         //  \-- testCompile       extendsFrom(compile)
         // We therefore want to look at only the dependencies _directly_ declared in the implementation and compile
         // configurations (belonging to our source set)
-        explicitCompile.withDependencies(deps -> {
+        project.afterEvaluate(p -> {
             Configuration implCopy = implementation.copy();
             Configuration compileCopy = compile.copy();
             // Without these, explicitCompile will successfully resolve 0 files and you'll waste 1 hour trying
@@ -134,6 +134,9 @@ public final class BaselineExactDependencies implements Plugin<Project> {
             project.getConfigurations().add(compileCopy);
 
             explicitCompile.extendsFrom(implCopy, compileCopy);
+        });
+
+        explicitCompile.withDependencies(deps -> {
             // Mirror the transitive constraints form compileClasspath in order to pick up GCV locks.
             // We should really do this with an addAllLater but that would require Gradle 6, or a hacky workaround.
             explicitCompile.getDependencyConstraints().addAll(compileClasspath.getAllDependencyConstraints());

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -242,6 +242,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         buildFile << """
             apply plugin: 'com.palantir.consistent-versions'
         """.stripIndent()
+        file('versions.props').text = ''
 
         expect:
         with(':checkUnusedConstraints', '--stacktrace', '--write-locks').withDebug(true).build()

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -27,6 +27,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
             id 'java'
             id 'com.palantir.baseline-exact-dependencies'
             id 'com.palantir.baseline' apply false
+            id 'com.palantir.consistent-versions' version '1.17.3' apply false
         }
     '''.stripIndent()
 
@@ -234,6 +235,16 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         BuildResult result = with(':checkUnusedDependencies', '--stacktrace').withDebug(true).buildAndFail()
         result.output.contains "project(':sub-project-with-deps') (sub-project-with-deps.jar (project :sub-project-with-deps))"
         result.output.contains "implementation project(':sub-project-no-deps')"
+    }
+
+    def 'plugin does not cause GCV checkUnusedConstraints to fail'() {
+        setupMultiProject()
+        buildFile << """
+            apply plugin: 'com.palantir.consistent-versions'
+        """.stripIndent()
+
+        expect:
+        with(':checkUnusedConstraints', '--stacktrace', '--write-locks').withDebug(true).build()
     }
 
     /**


### PR DESCRIPTION
## Before this PR

ConcurrentModificationException when running GCV's `checkUnusedConstraints` task, or any sort of iteration over all configurations which also triggers the resolution of said configurations, because our code would then alter the set of configurations while it was being iterated on.

## After this PR
==COMMIT_MSG==
Fix baseline 3.7.0-3.7.2 regression in baseline-exact-dependencies causing ConcurrentModificationException.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

