### PR TITLE
Disable left curl when using palantir-java-format

### DIFF
--- a/changelog/@unreleased/pr-1278.v2.yml
+++ b/changelog/@unreleased/pr-1278.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Disable `LeftCurly` CheckStyle rule when Palantir-Java-Format is applied
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1278

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
@@ -107,6 +107,9 @@ class BaselineConfig extends AbstractBaselinePlugin {
                             .replace(
                                     "        <module name=\"ParenPad\"/> <!-- Java Style Guide: Horizontal whitespace"
                                             + " -->\n",
+                                    "")
+                            .replace(
+                                    "        <module name=\"LeftCurly\"/> <!-- Java Style Guide: Nonempty blocks: K & R style -->\n",
                                     "");
                     Preconditions.checkState(!contents.equals(replaced), "Patching checkstyle.xml must make a change");
                     Files.write(checkstyleXml, replaced.getBytes(StandardCharsets.UTF_8));

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
@@ -109,7 +109,8 @@ class BaselineConfig extends AbstractBaselinePlugin {
                                             + " -->\n",
                                     "")
                             .replace(
-                                    "        <module name=\"LeftCurly\"/> <!-- Java Style Guide: Nonempty blocks: K & R style -->\n",
+                                    "        <module name=\"LeftCurly\"/> "
+                                            + "<!-- Java Style Guide: Nonempty blocks: K & R style -->\n",
                                     "");
                     Preconditions.checkState(!contents.equals(replaced), "Patching checkstyle.xml must make a change");
                     Files.write(checkstyleXml, replaced.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## Before this PR
@mglazer flagged an issue where PJF and checkstyle were fighting where a scope was defined within a switch statement

## After this PR
==COMMIT_MSG==
Disable `LeftCurly` CheckStyle rule when Palantir-Java-Format is applied
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

