### PR TITLE
Fix class uniqueness non-deterministic ordering

### DIFF
--- a/changelog/@unreleased/pr-1283.v2.yml
+++ b/changelog/@unreleased/pr-1283.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: The `checkClassUniqueness` will no longer spuriously fail due to inconsistent
-    ordering in the `baseline-class-uniqueness.lock` file.
+  description: The `checkClassUniqueness` task will no longer spuriously fail due
+    to inconsistent ordering in the `baseline-class-uniqueness.lock` file.
   links:
   - https://github.com/palantir/gradle-baseline/pull/1283

--- a/changelog/@unreleased/pr-1283.v2.yml
+++ b/changelog/@unreleased/pr-1283.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The `checkClassUniqueness` will no longer spuriously fail due to inconsistent
+    ordering in the `baseline-class-uniqueness.lock` file.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1283

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.tasks;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
 import java.io.File;
 import java.util.Collection;
 import java.util.Comparator;
@@ -94,12 +95,13 @@ public class CheckClassUniquenessLockTask extends DefaultTask {
                         return Optional.empty();
                     }
 
-                    Map<String, String> clashingHeadersToClasses = problemJars.stream()
-                            .collect(Collectors.toMap(
-                                    this::clashingJarHeader, clashingJars -> clashingClasses(analyzer, clashingJars)));
+                    ImmutableSortedMap<String, String> clashingHeadersToClasses = problemJars.stream()
+                            .collect(ImmutableSortedMap.toImmutableSortedMap(
+                                    Comparator.naturalOrder(),
+                                    this::clashingJarHeader,
+                                    clashingJars -> clashingClasses(analyzer, clashingJars)));
 
                     return Optional.of(clashingHeadersToClasses.entrySet().stream()
-                            .sorted(Comparator.comparing(Map.Entry::getKey))
                             .flatMap(entry -> {
                                 String clashingJarHeader = entry.getKey();
                                 String clashingClasses = entry.getValue();

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -18,7 +18,12 @@ package com.palantir.baseline.tasks;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
-import java.util.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.api.DefaultTask;


### PR DESCRIPTION
## Before this PR
There isn't a deterministic ordering on various parts of the `baseline-class-uniqueness.lock` file that's produced. This can cause failures as the generated file is different from the one on disk, despite having the same information.

## After this PR
==COMMIT_MSG==
The `checkClassUniqueness` will no longer spuriously fail due to inconsistent ordering in the `baseline-class-uniqueness.lock` file.
==COMMIT_MSG==
