### PR TITLE
Remove configuration name in exact dependencies suggestions

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -102,7 +102,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
                         "'%s:%s'",
                         artifact.getModuleVersion().getId().getGroup(),
                         artifact.getModuleVersion().getId().getName());
-        return String.format("        implementation %s", artifactNameString);
+        return String.format("        %s", artifactNameString);
     }
 
     /**

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -129,7 +129,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
                     didYouMean.stream()
                             .map(BaselineExactDependencies::asDependencyStringWithoutName)
                             .sorted()
-                            .forEach(dependencyString -> builder.append("\t\t\timplementation ")
+                            .forEach(dependencyString -> builder.append("\t\t\t")
                                     .append(dependencyString)
                                     .append("\n"));
                 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -215,7 +215,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.task(':classes').getOutcome() == TaskOutcome.SUCCESS
         result.task(':checkImplicitDependenciesMain').getOutcome() == TaskOutcome.FAILED
         result.output.contains("Found 1 implicit dependencies")
-        result.output.contains("implementation project(':sub-project-no-deps')")
+        result.output.contains("project(':sub-project-no-deps')")
     }
 
     def 'checkImplicitDependencies should not report circular dependency on current project'() {
@@ -234,7 +234,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         then:
         BuildResult result = with(':checkUnusedDependencies', '--stacktrace').withDebug(true).buildAndFail()
         result.output.contains "project(':sub-project-with-deps') (sub-project-with-deps.jar (project :sub-project-with-deps))"
-        result.output.contains "implementation project(':sub-project-no-deps')"
+        result.output.contains "project(':sub-project-no-deps')"
     }
 
     def 'plugin does not cause GCV checkUnusedConstraints to fail'() {


### PR DESCRIPTION
Since #1262 `BaselineExactDependencies` applies to all source sets so it can be confusing to see the `implementation` configuration in the suggestions when the task fails for other source sets. 
