### PR TITLE
Disable catch specificity by default

### DIFF
--- a/changelog/@unreleased/pr-1292.v2.yml
+++ b/changelog/@unreleased/pr-1292.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable `CatchSpecificity` errorprone check by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1292

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -207,6 +207,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         String separator = Pattern.quote(Paths.get(projectPath).getFileSystem().getSeparator());
         errorProneOptions.setExcludedPaths(String.format(
                 "%s%s(build|src%sgenerated.*)%s.*", Pattern.quote(projectPath), separator, separator, separator));
+        errorProneOptions.check("CatchSpecificity", CheckSeverity.OFF);
         errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);
         errorProneOptions.check(
                 "PreferJavaTimeOverload", CheckSeverity.OFF); // https://github.com/google/error-prone/issues/1435,


### PR DESCRIPTION
## Before this PR
`CatchSpecificity` did not fail builds by default, but did result in a lot of output at compile time making it hard to quickly see the errors.

## After this PR
==COMMIT_MSG==
Disable `CatchSpecificity` errorprone check by default
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

