### PR TITLE
Tidy duplicate method types

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-migrationsupport'
 
     annotationProcessor 'com.google.auto.service:auto-service'
+    annotationProcessor 'org.immutables:value'
     compileOnly 'com.google.auto.service:auto-service'
 }
 

--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     annotationProcessor 'com.google.auto.service:auto-service'
     annotationProcessor 'org.immutables:value'
     compileOnly 'com.google.auto.service:auto-service'
+    compileOnly 'org.immutables:value::annotations'
 }
 
 // Incorrectly identifies tests as junit4 usage

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
@@ -22,8 +22,10 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
+import com.sun.tools.javac.tree.JCTree;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -62,16 +64,23 @@ public final class DuplicateArgumentTypes extends BugChecker implements BugCheck
             Tree type = param.getType();
             tree.getParameters().forEach(param2 -> {
                 if (!param.equals(param2)) {
-                    Tree type2 = param.getType();
-                    bad.set((isSubtypeOf(type.getClass(), type2, state) || isSubtypeOf(type2.getClass(), type, state)));
+                    Tree type2 = param2.getType();
+                    // Matcher<Tree> m = Matchers.isSubtypeOf($ -> ASTHelpers.getType(type));
+                    bad.set(bad.get() || (isSubtypeOf(type, type2, state) || isSubtypeOf(type2,
+                            type, state)));
                 }
             });
         });
 
+        System.out.println(bad.get());
         return Description.NO_MATCH;
     }
 
-    private boolean isSubtypeOf(Class clazz, Tree tree, VisitorState state) {
-        return Matchers.isSubtypeOf(clazz).matches(tree, state);
+    private boolean isSubtypeOf(Tree clazz, Tree tree, VisitorState state) {
+        boolean x = Matchers.isSubtypeOf($ -> ASTHelpers.getType(clazz)).matches(tree, state);
+        if(x) {
+            System.out.println("madness abides");
+        }
+        return x;
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.MethodTree;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Development Practices: Writing good unit tests.
+ */
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "DuplicateArgumentTypes",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.WARNING,
+        summary = "Duplicate argument types")
+public final class DuplicateArgumentTypes extends BugChecker implements BugChecker.MethodTreeMatcher {
+
+    @Override
+    public Description matchMethod(MethodTree tree, VisitorState state) {
+        Set<String> types = new HashSet<>();
+        AtomicInteger counter = new AtomicInteger(0);
+        tree.getParameters().forEach(la -> {
+            types.add(la.getType().toString());
+            counter.incrementAndGet();
+        });
+        if (counter.get() > types.size()) {
+            return buildDescription(tree).build();
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
@@ -37,16 +37,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
         name = "DuplicateArgumentTypes",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = BugPattern.SeverityLevel.WARNING,
+        severity = BugPattern.SeverityLevel.SUGGESTION,
         summary = "Duplicate argument types")
 public final class DuplicateArgumentTypes extends BugChecker implements BugChecker.MethodTreeMatcher {
 
     // TODO (jshah) - sort out how to deal with multiple suppliers, even if the type params are not
-    //  subtypes of each other (maybe do type.getTypeParameters() and recurse?)
-    // how to check that arbitrary Tree type2 is a subtype of a fixed Class...
-    // or can just do Matchers.isSubtypeOf(Integer.class)... lol oops
-    // actually cannot when trying the other way around
-    // ASTHelpers.isSubtype(Suppliers.typeFromClass(Integer.class).get(state), ASTHelpers.getType(type2), state)
+    //  subtypes of each other (maybe do type.getTypeParameters() (to that effect) and recurse?)
 
     @Override
     public Description matchMethod(MethodTree tree, VisitorState state) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
@@ -20,7 +20,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
@@ -59,7 +58,9 @@ public final class DuplicateArgumentTypes extends BugChecker implements BugCheck
         });
 
         if (bad.get()) {
-            return buildDescription(tree).setMessage("Consider using a builder instead").build();
+            return buildDescription(tree)
+                    .setMessage("Consider using a builder instead")
+                    .build();
         }
 
         return Description.NO_MATCH;
@@ -99,6 +100,7 @@ public final class DuplicateArgumentTypes extends BugChecker implements BugCheck
         return Suppliers.typeFromClass(clazz).get(state);
     }
 
+    // todo (jshah) - rather ironic to use duplicate types when this is what we are trying to detect!
     private boolean isSubType(Tree tree1, Tree tree2, VisitorState state) {
         return ASTHelpers.isSubtype(getType(tree1, state), getType(tree2, state), state);
     }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
@@ -49,12 +49,14 @@ public final class DuplicateArgumentTypes extends BugChecker implements BugCheck
 
         tree.getParameters().forEach(param1 -> {
             Tree type1 = param1.getType();
-            tree.getParameters().forEach(param2 -> {
-                if (!param1.equals(param2)) {
-                    Tree type2 = param2.getType();
-                    bad.set(bad.get() || isSubType(type1, type2, state));
-                }
-            });
+            if(getType(type1, state).allparams().isEmpty()) {
+                tree.getParameters().forEach(param2 -> {
+                    if (!param1.equals(param2)) {
+                        Tree type2 = param2.getType();
+                        bad.set(bad.get() || isSubType(type1, type2, state));
+                    }
+                });
+            }
         });
 
         if (bad.get()) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
@@ -38,7 +38,7 @@ import org.immutables.value.Value;
         name = "DuplicateArgumentTypes",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = BugPattern.SeverityLevel.WARNING,
         summary = "Some argument types are equal or are subtypes of each other. Consider using a builder instead.")
 public final class DuplicateArgumentTypes extends BugChecker implements BugChecker.MethodTreeMatcher {
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
@@ -87,25 +87,23 @@ public final class DuplicateArgumentTypes extends BugChecker implements BugCheck
 
     private Type getType(Tree type, VisitorState state) {
         if (isPrimitive(type, state)) {
-            switch (type.toString()) {
+            switch (state.getSourceForNode(type)) {
                 case "int":
-                    return extractType(Integer.class, state);
+                    return Suppliers.typeFromClass(Integer.class).get(state);
                 case "byte":
-                    return extractType(Byte.class, state);
+                    return Suppliers.typeFromClass(Byte.class).get(state);
                 case "char":
-                    return extractType(Character.class, state);
+                    return Suppliers.typeFromClass(Character.class).get(state);
                 case "double":
-                    return extractType(Double.class, state);
+                    return Suppliers.typeFromClass(Double.class).get(state);
                 case "long":
-                    return extractType(Long.class, state);
+                    return Suppliers.typeFromClass(Long.class).get(state);
                 case "short":
-                    return extractType(Short.class, state);
+                    return Suppliers.typeFromClass(Short.class).get(state);
                 case "float":
-                    return extractType(Float.class, state);
+                    return Suppliers.typeFromClass(Float.class).get(state);
                 case "boolean":
-                    return extractType(Boolean.class, state);
-                default:
-                    break;
+                    return Suppliers.typeFromClass(Boolean.class).get(state);
             }
         }
         return ASTHelpers.getType(type);
@@ -113,9 +111,5 @@ public final class DuplicateArgumentTypes extends BugChecker implements BugCheck
 
     private boolean isPrimitive(Tree type, VisitorState state) {
         return Matchers.isPrimitiveType().matches(type, state);
-    }
-
-    private Type extractType(Class clazz, VisitorState state) {
-        return Suppliers.typeFromClass(clazz).get(state);
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DuplicateArgumentTypes.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = BugPattern.SeverityLevel.SUGGESTION,
-        summary = "Duplicate argument types")
+        summary = "Some argument types are equal or are subtypes of each other. Consider using a builder instead.")
 public final class DuplicateArgumentTypes extends BugChecker implements BugChecker.MethodTreeMatcher {
 
     @Override
@@ -56,10 +56,7 @@ public final class DuplicateArgumentTypes extends BugChecker implements BugCheck
         });
 
         if (badMethod.get()) {
-            return buildDescription(tree)
-                    .setMessage("Some argument types are equal or are subtypes of each other. Consider using a "
-                            + "builder instead.")
-                    .build();
+            return buildDescription(tree).build();
         }
 
         return Description.NO_MATCH;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+public final class DuplicateArgumentTypesTest {
+
+    @Test
+    void testType() {
+        fix().addInputLines(
+                "Test.java",
+                "import com.google.common.annotations.VisibleForTesting;",
+                "public class Test {",
+                "  public void myah(int a, Integer b) {}",
+                "  public void myah2(int a, String b) {}",
+                "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(new DuplicateArgumentTypes(), getClass());
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
@@ -28,7 +28,10 @@ public final class DuplicateArgumentTypesTest {
     void testSameType() {
         validator()
                 .addInputLines(
-                        "Test.java", "public class Test {", "  public void badMethod(Integer a, Integer b) {}", "}")
+                        "Test.java", //
+                        "public class Test {",
+                        "  public void badMethod(Integer a, Integer b) {}",
+                        "}")
                 .expectUnchanged()
                 .doTestExpectingFailure(TEST_MODE);
     }
@@ -37,7 +40,10 @@ public final class DuplicateArgumentTypesTest {
     void testInheritedType() {
         validator()
                 .addInputLines(
-                        "Test.java", "public class Test {", "  public void badMethod(Integer a, Number b) {}", "}")
+                        "Test.java", //
+                        "public class Test {",
+                        "  public void badMethod(Integer a, Number b) {}",
+                        "}")
                 .expectUnchanged()
                 .doTestExpectingFailure(TEST_MODE);
     }
@@ -46,7 +52,10 @@ public final class DuplicateArgumentTypesTest {
     void testInheritedTypeOtherOrdering() {
         validator()
                 .addInputLines(
-                        "Test.java", "public class Test {", "  public void badMethod(Number a, Integer b) {}", "}")
+                        "Test.java", //
+                        "public class Test {",
+                        "  public void badMethod(Number a, Integer b) {}",
+                        "}")
                 .expectUnchanged()
                 .doTestExpectingFailure(TEST_MODE);
     }
@@ -66,7 +75,11 @@ public final class DuplicateArgumentTypesTest {
     @Test
     void testPrimitives() {
         validator()
-                .addInputLines("Test.java", "public class Test {", "  public void badMethod(byte a, Number b) {}", "}")
+                .addInputLines(
+                        "Test.java", //
+                        "public class Test {",
+                        "  public void badMethod(byte a, Number b) {}",
+                        "}")
                 .expectUnchanged()
                 .doTestExpectingFailure(TEST_MODE);
     }
@@ -145,7 +158,10 @@ public final class DuplicateArgumentTypesTest {
     void testMethodWithNoSubTypes() {
         validator()
                 .addInputLines(
-                        "Test.java", "public class Test {", "  public void goodMethod(Number a, String b) {}", "}")
+                        "Test.java", //
+                        "public class Test {",
+                        "  public void goodMethod(Number a, String b) {}",
+                        "}")
                 .expectUnchanged()
                 .doTest();
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
@@ -22,18 +22,54 @@ import org.junit.jupiter.api.Test;
 public final class DuplicateArgumentTypesTest {
 
     @Test
-    void testType() {
+    void testParameterizedTypes() {
         fix().addSourceLines(
-                "Test.java",
-                "import com.google.common.annotations.VisibleForTesting;",
-                "import java.util.function.Supplier;",
-                "public class Test {",
-                "  public void myah3(Supplier<Number> a, Supplier<String> b) {}",
-                "  public void myah0(Number a, Integer b) {}",
-                "  public void myah(byte a, Number b) {}",
-                "  public void myah(byte a, int b) {}",
-                "  public void myah2(int a, String b) {}",
-                "}")
+                        "Test.java",
+                        "import java.util.function.Supplier;",
+                        "public class Test {",
+                        "  public void myah3(Supplier<Number> a, Supplier<String> b) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testSameType() {
+        fix().addSourceLines(
+                        "Test.java", "public class Test {", "  public void badMethod(Integer a, Integer b) {}", "}")
+                .doTest();
+    }
+
+    @Test
+    void testInheritedType() {
+        fix().addSourceLines("Test.java", "public class Test {", "  public void badMethod(Integer a, Number b) {}", "}")
+                .doTest();
+    }
+
+    @Test
+    void testInheritedTypeOtherOrdering() {
+        fix().addSourceLines("Test.java", "public class Test {", "  public void badMethod(Number a, Integer b) {}", "}")
+                .doTest();
+    }
+
+    @Test
+    void testMultipleArguments() {
+        fix().addSourceLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  public void badMethod(Number a, String b, Double c) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testNoProblems() {
+        fix().addSourceLines("Test.java", "public class Test {", "  public void badMethod(Number a, String b) {}", "}")
+                .doTest();
+    }
+
+    @Test
+    void testPrimitives() {
+        fix().addSourceLines("Test.java", "public class Test {", "  public void badMethod(byte a, Number b) {}", "}")
                 .doTest();
     }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
@@ -26,6 +26,7 @@ public final class DuplicateArgumentTypesTest {
                 "Test.java",
                 "import com.google.common.annotations.VisibleForTesting;",
                 "public class Test {",
+                "  public void myah0(Number a, Integer b) {}",
                 "  public void myah(int a, Integer b) {}",
                 "  public void myah2(int a, String b) {}",
                 "}")

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
@@ -25,10 +25,12 @@ public final class DuplicateArgumentTypesTest {
         fix().addInputLines(
                 "Test.java",
                 "import com.google.common.annotations.VisibleForTesting;",
+                "import java.util.function.Supplier;",
                 "public class Test {",
-                "  public void myah0(Number a, Integer b) {}",
-                "  public void myah(int a, Integer b) {}",
+                // "  public void myah0(Number a, Integer b) {}",
+                "  public void myah(int a, Number b) {}",
                 "  public void myah2(int a, String b) {}",
+                // "  public void myah3(Supplier<Number> a, Supplier<String> b) {}",
                 "}")
                 .expectUnchanged()
                 .doTest();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
@@ -29,16 +29,14 @@ public final class DuplicateArgumentTypesTest {
                 "import java.util.function.Supplier;",
                 "public class Test {",
                 "  public void myah3(Supplier<Number> a, Supplier<String> b) {}",
-                // "  public void myah0(Number a, Integer b) {}",
+                "  public void myah0(Number a, Integer b) {}",
                 "  public void myah(byte a, Number b) {}",
+                "  public void myah(byte a, int b) {}",
                 "  public void myah2(int a, String b) {}",
                 "}")
                 .doTest();
     }
 
-    // private RefactoringValidator fix() {
-    //     return RefactoringValidator.of(new DuplicateArgumentTypes(), getClass());
-    // }
     private CompilationTestHelper fix() {
         return CompilationTestHelper.newInstance(DuplicateArgumentTypes.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
@@ -33,6 +33,17 @@ public final class DuplicateArgumentTypesTest {
     }
 
     @Test
+    void testParameterizedTypes2() {
+        fix().addSourceLines(
+                "Test.java",
+                "import java.util.function.Supplier;",
+                "public class Test {",
+                "  public <T> void myah3(Supplier<T> a, Supplier<T> b) {}",
+                "}")
+                .doTest();
+    }
+
+    @Test
     void testSameType() {
         fix().addSourceLines(
                         "Test.java", "public class Test {", "  public void badMethod(Integer a, Integer b) {}", "}")
@@ -60,6 +71,7 @@ public final class DuplicateArgumentTypesTest {
                         "}")
                 .doTest();
     }
+
 
     @Test
     void testNoProblems() {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DuplicateArgumentTypesTest.java
@@ -16,27 +16,30 @@
 
 package com.palantir.baseline.errorprone;
 
+import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
 
 public final class DuplicateArgumentTypesTest {
 
     @Test
     void testType() {
-        fix().addInputLines(
+        fix().addSourceLines(
                 "Test.java",
                 "import com.google.common.annotations.VisibleForTesting;",
                 "import java.util.function.Supplier;",
                 "public class Test {",
+                "  public void myah3(Supplier<Number> a, Supplier<String> b) {}",
                 // "  public void myah0(Number a, Integer b) {}",
-                "  public void myah(int a, Number b) {}",
+                "  public void myah(byte a, Number b) {}",
                 "  public void myah2(int a, String b) {}",
-                // "  public void myah3(Supplier<Number> a, Supplier<String> b) {}",
                 "}")
-                .expectUnchanged()
                 .doTest();
     }
 
-    private RefactoringValidator fix() {
-        return RefactoringValidator.of(new DuplicateArgumentTypes(), getClass());
+    // private RefactoringValidator fix() {
+    //     return RefactoringValidator.of(new DuplicateArgumentTypes(), getClass());
+    // }
+    private CompilationTestHelper fix() {
+        return CompilationTestHelper.newInstance(DuplicateArgumentTypes.class, getClass());
     }
 }


### PR DESCRIPTION
## Before this PR
Methods with multiple arguments with the same types (or some types that are subtypes of others) are prone to mistakes.

## After this PR
==COMMIT_MSG==
Errorprone warning when methods have some arguments that have the same type or are subtypes of other arguments.
==COMMIT_MSG==

## Possible downsides?
Pretty aggressive check that could cause some code bloat from argument interfaces.
