### PR TITLE
Fix checkstyle even if com.palantir.java-format is not applied directly

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
@@ -92,7 +92,7 @@ class BaselineConfig extends AbstractBaselinePlugin {
 
             // Disable some checkstyle rules that clash with PJF
             if (BaselineFormat.palantirJavaFormatterState(rootProject) != FormatterState.OFF
-                    || project.getPluginManager().hasPlugin("com.palantir.java-format")) {
+                    || project.getPluginManager().hasPlugin("com.palantir.java-format-provider")) {
                 Path checkstyleXml = configDir.resolve("checkstyle/checkstyle.xml");
 
                 try {


### PR DESCRIPTION
## Before this PR

If applying `com.palantir.java-format` only to java projects, baseline doesn't detect that the formatter is being used, and doesn't fix checkstyle accordingly.

## After this PR
==COMMIT_MSG==
Fix checkstyle if any formatter plugin is applied anywhere.
==COMMIT_MSG==

## Possible downsides?

By accepting that you can apply PJF only to certain subprojects, we make it harder to support configure-on-demand, because the logic now changes depending on whether any java subprojects have been evaluated or not.

One is be able to apply `com.palantir.java-format` on all projects even if they are not all java, so that's the preferrable route forward I think.