### PR TITLE
RedundantModifier check validates and fixes final parameters in abstract methods

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
@@ -79,6 +79,12 @@ public final class RedundantModifier extends BugChecker
                     MoreMatchers.hasExplicitModifier(Modifier.STATIC),
                     MoreMatchers.hasExplicitModifier(Modifier.FINAL)));
 
+    // Applies to both abstract class abstract methods and interface methods.
+    private static final Matcher<VariableTree> ABSTRACT_METHOD_MODIFIERS = Matchers.allOf(
+            Matchers.enclosingNode(
+                    Matchers.allOf(Matchers.kindIs(Tree.Kind.METHOD), Matchers.hasModifier(Modifier.ABSTRACT))),
+            MoreMatchers.hasExplicitModifier(Modifier.FINAL));
+
     private static final Matcher<ClassTree> INTERFACE_NESTED_CLASS_MODIFIERS = Matchers.allOf(
             MoreMatchers.classEnclosingClass(Matchers.kindIs(Tree.Kind.INTERFACE)),
             Matchers.anyOf(
@@ -155,6 +161,12 @@ public final class RedundantModifier extends BugChecker
                             + "These modifiers are unnecessary to specify.")
                     .addFix(SuggestedFixes.removeModifiers(
                             tree, state, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL))
+                    .build();
+        }
+        if (ABSTRACT_METHOD_MODIFIERS.matches(tree, state)) {
+            return buildDescription(tree)
+                    .setMessage("The final modifier has no impact on abstract methods.")
+                    .addFix(SuggestedFixes.removeModifiers(tree, state, Modifier.FINAL))
                     .build();
         }
         return Description.NO_MATCH;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RedundantModifierTest.java
@@ -298,6 +298,42 @@ class RedundantModifierTest {
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
+    @Test
+    void fixInterfaceFinalParameters() {
+        fix().addInputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  void foo(int a, final int b, final int c);",
+                        "  public void foo(final int a);",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "public interface Test {",
+                        "  void foo(int a, int b, int c);",
+                        "  void foo(int a);",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    void fixAbstractClassFinalParameters() {
+        fix().addInputLines(
+                        "Test.java",
+                        "public abstract class Test {",
+                        "  abstract void foo(int a, final int b, final int c);",
+                        "  public abstract void foo(final int a);",
+                        "  public void bar(final int a) {}",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "public abstract class Test {",
+                        "  abstract void foo(int a, int b, int c);",
+                        "  public abstract void foo(int a);",
+                        "  public void bar(final int a) {}",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
     private RefactoringValidator fix() {
         return RefactoringValidator.of(new RedundantModifier(), getClass());
     }

--- a/changelog/@unreleased/pr-1303.v2.yml
+++ b/changelog/@unreleased/pr-1303.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: RedundantModifier check validates and fixes final parameters in abstract
+    methods
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1303

--- a/docs/best-practices/code-reviews/readme.md
+++ b/docs/best-practices/code-reviews/readme.md
@@ -35,7 +35,7 @@ This guide covers the following topics:
 
 We perform code reviews (CRs) in order to improve code quality and benefit from
 [positive effects on team and company
-culture](https://blog.fullstory.com/what-we-learned-from-google-code-reviews-arent-just-for-catching-bugs).
+culture](https://blog.fullstory.com/what-we-learned-from-google-code-reviews-arent-just-for-catching-bugs/).
 For example:
 
 - **Committers are motivated** by the notion of a set

--- a/docs/best-practices/java-coding-guidelines/readme.md
+++ b/docs/best-practices/java-coding-guidelines/readme.md
@@ -1023,7 +1023,7 @@ Furthermore, suppose that:
     new features.
 
 As an example (inspired by this
-[dzone](http://java.dzone.com/articles/design-patterns-visitor)
+[dzone](https://dzone.com/articles/design-patterns-visitor)
 article), assume As a concrete example, we may have various Feeds
 message types such as DocumentFeedMessage, ObjectFeedMessage, or
 ObjectWatchMessage, all of which are implementations of the Message


### PR DESCRIPTION
## Before this PR
```java
interface Foo {
  void f(final int value); // final modifier doesn't do anything!
}
```

## After this PR
==COMMIT_MSG==
RedundantModifier check validates and fixes final parameters in abstract methods
==COMMIT_MSG==

## Possible downsides?
A bit of code churn places that use final params unnecessarily. Potential to introduce bugs.

