### PR TITLE
Enable check/refactorings for UnnecessaryBoxedVariable

### DIFF
--- a/changelog/@unreleased/pr-1316.v2.yml
+++ b/changelog/@unreleased/pr-1316.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enable ErrorProne check UnnecessaryBoxedVariable.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1316

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -55,6 +55,7 @@ public class BaselineErrorProneExtension {
 
             // Built-in checks
             "ArrayEquals",
+            "UnnecessaryBoxedVariable",
             "MissingOverride",
             "UnnecessaryParentheses",
             "PreferJavaTimeOverload");

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -212,6 +212,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.check(
                 "PreferJavaTimeOverload", CheckSeverity.OFF); // https://github.com/google/error-prone/issues/1435,
         // https://github.com/google/error-prone/issues/1437
+        errorProneOptions.check("UnnecessaryBoxedVariable", CheckSeverity.WARN);
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
         errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -212,7 +212,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.check(
                 "PreferJavaTimeOverload", CheckSeverity.OFF); // https://github.com/google/error-prone/issues/1435,
         // https://github.com/google/error-prone/issues/1437
-        errorProneOptions.check("UnnecessaryBoxedVariable", CheckSeverity.WARN);
         errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
         errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
         errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);


### PR DESCRIPTION
## Before this PR
I've found this in a few PRs recently, would be good to turn it on.

## After this PR
errorProneApply will rewrite code to use primitive types where possible.

## Possible downsides?
It's not clear to me if we should set this to WARN or ERROR, or not at all?

The refactoring is still applied whatever level, but it might not be a great UX for your compilation to succeed and then find out it's wrong later? Perhaps that's fine and we should leave it at the default SUGGESTION level?

