### PR TITLE
Provider implicit toString

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleProviderToString.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleProviderToString.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.AbstractToString;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.predicates.TypePredicate;
+import com.google.errorprone.predicates.TypePredicates;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.Tree;
+import java.util.Optional;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "GradleProviderToString",
+        summary = "Calling toString on a Provider does not render the contained value",
+        severity = BugPattern.SeverityLevel.ERROR)
+public final class GradleProviderToString extends AbstractToString {
+
+    private static final TypePredicate IS_PROVIDER = TypePredicates.isDescendantOf("org.gradle.api.provider.Provider");
+
+    @Override
+    protected TypePredicate typePredicate() {
+        return IS_PROVIDER;
+    }
+
+    @Override
+    protected Optional<Fix> implicitToStringFix(ExpressionTree tree, VisitorState state) {
+        // We could automatically call Provider#get, but is that always right?
+        return Optional.empty();
+    }
+
+    @Override
+    protected Optional<Fix> toStringFix(Tree parent, ExpressionTree expression, VisitorState state) {
+        return Optional.empty();
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleProviderToString.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleProviderToString.java
@@ -22,6 +22,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.AbstractToString;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.predicates.TypePredicate;
 import com.google.errorprone.predicates.TypePredicates;
 import com.sun.source.tree.ExpressionTree;
@@ -44,8 +45,8 @@ public final class GradleProviderToString extends AbstractToString {
 
     @Override
     protected Optional<Fix> implicitToStringFix(ExpressionTree tree, VisitorState state) {
-        // We could automatically call Provider#get, but is that always right?
-        return Optional.empty();
+        // Note that this might not always be the right thing to do, but it's right in enough cases we should do it.
+        return Optional.of(SuggestedFix.postfixWith(tree, ".get()"));
     }
 
     @Override

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleProviderToStringTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleProviderToStringTest.java
@@ -41,7 +41,7 @@ public class GradleProviderToStringTest {
                         "import org.gradle.api.provider.Provider;",
                         "class Foo implements Plugin<Project> {",
                         "  public final void apply(Project project) {",
-                        "    String nonProvider = \"foo\"",
+                        "    String nonProvider = \"foo\";",
                         "    Provider<String> provider = project.provider(() -> \"hello\");",
                         "    // BUG: Diagnostic contains: Calling toString on a Provider",
                         "    String value = \"My bad provider value: \" + provider + nonProvider;",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleProviderToStringTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleProviderToStringTest.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GradleProviderToStringTest {
+
+    private CompilationTestHelper compilationHelper;
+
+    @BeforeEach
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(GradleProviderToString.class, getClass());
+    }
+
+    @Test
+    public void failsUsedInStringConcatenation() {
+        compilationHelper
+                .addSourceLines(
+                        "Foo.java",
+                        "import org.gradle.api.Project;",
+                        "import org.gradle.api.Plugin;",
+                        "import org.gradle.api.provider.Provider;",
+                        "class Foo implements Plugin<Project> {",
+                        "  public final void apply(Project project) {",
+                        "    Provider<String> provider = project.provider(() -> \"hello\");",
+                        "    // BUG: Diagnostic contains: Calling toString on a Provider",
+                        "    String value = \"My bad provider value: \" + provider;",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+}

--- a/changelog/@unreleased/pr-1322.v2.yml
+++ b/changelog/@unreleased/pr-1322.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Forbid implicit toString of Gradle Providers.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1322


### PR DESCRIPTION
## Before this PR
I was refactoring a Gradle plugin to start using Providers and got hit by this too many times.

## After this PR
Implicit use of a Provider as a String is forbidden.

## Possible downsides?
No auto-fix

