### PR TITLE
Fix unused dependencies breaking with gradle 6.4

### DIFF
--- a/changelog/@unreleased/pr-1338.v2.yml
+++ b/changelog/@unreleased/pr-1338.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix task dependencies onto other subprojects for `com.palantir.baseline-exact-dependencies`
+    tasks (`checkUnusedDependencies`, `checkImplicitDependencies`), so they work with
+    gradle 6.4.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1338

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -48,7 +48,8 @@ import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.Usage;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
@@ -99,11 +100,13 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             compile.toString(), implementation.toString()));
                     conf.setVisible(false);
                     conf.setCanBeConsumed(false);
-                    // Important! this ensures we resolve 'compile' variants rather than 'runtime'
-                    // This is the same attribute that's being set on compileClasspath
-                    conf.getAttributes()
-                            .attribute(
-                                    Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_API));
+                    // Important! this ensures we resolve 'compile' variants rather than 'runtime', and that we
+                    // resolve a classes directory rather than the 'jar' file.
+                    copyAttributes(
+                            project.getConfigurations()
+                                    .getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+                                    .getAttributes(),
+                            conf.getAttributes());
 
                     // Without this, the 'checkUnusedDependencies correctly picks up project dependency on java-library'
                     // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
@@ -182,6 +185,12 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             task.ignore(checkImplicitDependencies.get().getIgnore());
                         });
         checkImplicitDependencies.configure(task -> task.dependsOn(sourceSetCheckImplicitDependencies));
+    }
+
+    private static void copyAttributes(AttributeContainer source, AttributeContainer target) {
+        for (Attribute attribute : source.keySet()) {
+            target.attribute(attribute, source.getAttribute(attribute));
+        }
     }
 
     static String checkUnusedDependenciesNameForSourceSet(SourceSet sourceSet) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -48,12 +48,13 @@ import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.attributes.LibraryElements;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.util.GUtil;
+import org.gradle.util.GradleVersion;
 
 /** Validates that java projects declare exactly the dependencies they rely on, no more and no less. */
 public final class BaselineExactDependencies implements Plugin<Project> {
@@ -100,13 +101,20 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             compile.toString(), implementation.toString()));
                     conf.setVisible(false);
                     conf.setCanBeConsumed(false);
-                    // Important! this ensures we resolve 'compile' variants rather than 'runtime', and that we
-                    // resolve a classes directory rather than the 'jar' file.
-                    copyAttributes(
-                            project.getConfigurations()
-                                    .getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-                                    .getAttributes(),
-                            conf.getAttributes());
+
+                    conf.attributes(attributes -> {
+                        // This ensures we resolve 'compile' variants rather than 'runtime'
+                        // This is the same attribute that's being set on compileClasspath
+                        attributes.attribute(
+                                Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_API));
+                        // Ensure we resolve the classes directory for local projects where possible, rather than the
+                        // 'jar' file. We can only do this on Gradle 5.6+, otherwise do nothing.
+                        if (GradleVersion.current().compareTo(GradleVersion.version("5.6")) >= 0) {
+                            attributes.attribute(
+                                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                                    project.getObjects().named(LibraryElements.class, LibraryElements.CLASSES));
+                        }
+                    });
 
                     // Without this, the 'checkUnusedDependencies correctly picks up project dependency on java-library'
                     // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
@@ -185,12 +193,6 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             task.ignore(checkImplicitDependencies.get().getIgnore());
                         });
         checkImplicitDependencies.configure(task -> task.dependsOn(sourceSetCheckImplicitDependencies));
-    }
-
-    private static void copyAttributes(AttributeContainer source, AttributeContainer target) {
-        for (Attribute attribute : source.keySet()) {
-            target.attribute(attribute, source.getAttribute(attribute));
-        }
     }
 
     static String checkUnusedDependenciesNameForSourceSet(SourceSet sourceSet) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -142,7 +142,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
         return ignore.get().contains(BaselineExactDependencies.asString(artifact));
     }
 
-    @Input
+    @InputFiles
     public final Provider<List<Configuration>> getDependenciesConfigurations() {
         return dependenciesConfigurations;
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -38,6 +38,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
@@ -151,7 +152,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
         this.dependenciesConfigurations.add(Objects.requireNonNull(dependenciesConfiguration));
     }
 
-    @InputFiles
+    @Classpath
     public final Provider<FileCollection> getSourceClasses() {
         return sourceClasses;
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -40,7 +40,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 
 public class CheckImplicitDependenciesTask extends DefaultTask {
@@ -143,7 +142,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
         return ignore.get().contains(BaselineExactDependencies.asString(artifact));
     }
 
-    @InputFiles
+    @Classpath
     public final Provider<List<Configuration>> getDependenciesConfigurations() {
         return dependenciesConfigurations;
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -176,7 +176,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         return ignore.get().contains(BaselineExactDependencies.asString(artifact));
     }
 
-    @Input
+    @InputFiles
     public final Provider<List<Configuration>> getDependenciesConfigurations() {
         return dependenciesConfigurations;
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -38,6 +38,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
@@ -206,7 +207,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         this.sourceOnlyConfigurations.add(Objects.requireNonNull(configuration));
     }
 
-    @InputFiles
+    @Classpath
     public final Provider<FileCollection> getSourceClasses() {
         return sourceClasses;
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -40,7 +40,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 
 public class CheckUnusedDependenciesTask extends DefaultTask {
@@ -177,7 +176,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         return ignore.get().contains(BaselineExactDependencies.asString(artifact));
     }
 
-    @InputFiles
+    @Classpath
     public final Provider<List<Configuration>> getDependenciesConfigurations() {
         return dependenciesConfigurations;
     }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -19,6 +19,7 @@ package com.palantir.baseline
 import java.nio.file.Files
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
 
 class BaselineExactDependenciesTest extends AbstractPluginTest {
 
@@ -113,7 +114,8 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.task(':checkUnusedDependenciesMain').getOutcome() == TaskOutcome.SUCCESS
     }
 
-    def 'checkUnusedDependencies correctly picks up project dependency on java-library'() {
+    @Unroll
+    def '#task correctly picks up project dependency on java-library'() {
         when:
         buildFile << standardBuildFile
         buildFile << """
@@ -139,8 +141,11 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         """.stripIndent()
 
         then:
-        def result = with('checkUnusedDependencies', '--stacktrace').build()
+        def result = with(":${task}", '--stacktrace').build()
         assert result.task(':needs-building-first:compileJava').getOutcome() != null
+
+        where:
+        task << ['checkUnusedDependencies', 'checkImplicitDependencies']
     }
 
     def 'checkUnusedDependenciesTest passes if dependency from main source set is not referenced in test'() {


### PR DESCRIPTION
## Before this PR

`checkUnusedDependencies` would break on gradle 6.4, because it tried to find the jars of other subprojects rather than the `classes` directories, but the plugin didn't wire up task dependencies onto the jars.

## After this PR
==COMMIT_MSG==
Fix task dependencies onto other subprojects for `com.palantir.baseline-exact-dependencies` tasks (`checkUnusedDependencies`, `checkImplicitDependencies`), so they work with gradle 6.4.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

