### PR TITLE
Insert inner class imports in Intellij

### DIFF
--- a/changelog/@unreleased/pr-1341.v2.yml
+++ b/changelog/@unreleased/pr-1341.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Intellij is now configured to import inner classes.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1341

--- a/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
+++ b/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
@@ -100,6 +100,7 @@
           <option name="FOR_BRACE_FORCE" value="3" />
           <option name="FOR_STATEMENT_WRAP" value="1" />
           <option name="IF_BRACE_FORCE" value="3" />
+          <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
           <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
           <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
           <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />


### PR DESCRIPTION
I find myself manually enabling this frequently. It's particularly useful for things like AtlasDB generated tables in which the row and column classes are nested classes like:
- `MyAtlasTable`
- `MyAtlasTable.MyAtlasRow`
- `MyAtlasTable.MyAtlasRowResult`
- etc.

