### PR TITLE
 Disable HTML test reports by default

### DIFF
--- a/changelog/@unreleased/pr-1349.v2.yml
+++ b/changelog/@unreleased/pr-1349.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The `baseline-circle` plugin no longer enables HTML test reports.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1349

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
@@ -64,7 +64,7 @@ public final class BaselineCircleCi implements Plugin<Project> {
         }
 
         project.getRootProject().allprojects(proj -> proj.getTasks().withType(Test.class, test -> {
-            test.getReports().getHtml().setEnabled(true);
+            test.getReports().getHtml().setEnabled(false);
             test.getReports().getHtml().setDestination(junitPath(circleArtifactsDir, test.getPath()));
         }));
     }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineCircleCiIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineCircleCiIntegrationTest.groovy
@@ -34,6 +34,10 @@ class BaselineCircleCiIntegrationTest extends AbstractPluginTest {
         dependencies {
             testCompile 'junit:junit:4.12'
         }
+        
+        test {
+            reports.html.enabled = true
+        }
     '''.stripIndent()
 
     def javaFile = '''


### PR DESCRIPTION
## Before this PR
The `baseline-circle` enabled HTML test reports. Uploading these HTML test reports can take quite a while (nearly 2 minutes) on large projects because these files are not compressed and are uploaded individually.

## After this PR
The `baseline-circle` plugin does not enable HTML test reports.

The plugin still enables the XML test reports, to ensure tests results are displayed nicely in CircleCI. Test artifacts are compressed before uploading and don't suffer the same problem.