### PR TITLE
Stop IntelliJ suggesting commonly shaded packages

### DIFF
--- a/changelog/@unreleased/pr-1350.v2.yml
+++ b/changelog/@unreleased/pr-1350.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Classes in common shaded packages are no longer for autocompletion/auto-import
+    recommended by IntelliJ.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1350

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -19,9 +19,6 @@ package com.palantir.baseline.plugins
 import com.palantir.baseline.util.GitUtils
 import groovy.transform.CompileStatic
 import groovy.xml.XmlUtil
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -33,6 +30,10 @@ import org.gradle.plugins.ide.idea.GenerateIdeaWorkspace
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.plugins.ide.idea.model.ModuleDependency
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 class BaselineIdea extends AbstractBaselinePlugin {
 
@@ -89,6 +90,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             addInspectionProjectProfile(node)
             addJavacSettings(node)
             addGitHubIssueNavigation(node)
+            ignoreCommonShadedPackages(node)
         }
 
         project.afterEvaluate {
@@ -284,6 +286,20 @@ class BaselineIdea extends AbstractBaselinePlugin {
              </component>
             """.stripIndent()))
         }
+    }
+
+    private static void ignoreCommonShadedPackages(Node node) {
+        // language=xml
+        node.append(new XmlParser().parseText('''
+            <component name="JavaProjectCodeInsightSettings">
+              <excluded-names>
+                <name>shadow</name><!-- from gradle-shadow-jar -->
+                <name>org.gradle.internal.impldep</name>
+                <name>autovalue.shaded</name>
+                <name>org.inferred.freebuilder.shaded</name>
+              </excluded-names>
+            </component>
+        '''.stripIndent()))
     }
 
     private static void configureSaveActionsForIntellijImport(Project project) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -297,6 +297,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 <name>org.gradle.internal.impldep</name>
                 <name>autovalue.shaded</name>
                 <name>org.inferred.freebuilder.shaded</name>
+                <name>org.immutables.value.internal</name>
               </excluded-names>
             </component>
         '''.stripIndent()))


### PR DESCRIPTION
## Before this PR
Jars commonly contain shaded dependencies - you should never use them, but they end up polluting your autocomplete suggestions:

![Screen Shot 2020-05-20 at 5 13 36 PM](https://user-images.githubusercontent.com/397795/82470877-d1f1c280-9abd-11ea-977c-b0a6cf5a5c69.png)

Internally, someone was confused why their code wasn't compiling because they were using a shaded version of an interface that was generated by `gradle-shadow-jar`.

## After this PR
==COMMIT_MSG==
Classes in common shaded packages are no longer for autocompletion/auto-import recommended by IntelliJ.
==COMMIT_MSG==

![Screen Shot 2020-05-20 at 5 27 48 PM](https://user-images.githubusercontent.com/397795/82471990-64469600-9abf-11ea-84d4-cf44420de67e.png)

![Screen Shot 2020-05-20 at 5 28 39 PM](https://user-images.githubusercontent.com/397795/82471996-67418680-9abf-11ea-989c-3c58e2f7963f.png)


## Possible downsides?
I can't really think of any. It's only "bad" if people want to use this shaded classes (they shouldn't) and would perhaps be annoying they're not suggested? Even then, this just stops suggestions, you can still find them/use them:

![Screen Shot 2020-05-20 at 5 30 30 PM](https://user-images.githubusercontent.com/397795/82472147-9fe16000-9abf-11ea-942f-e96ecfdc3a1e.png)
