### PR TITLE
Strict unused variable enforces lambda parameters

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -508,7 +508,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             Symbol varSymbol, Symbol.MethodSymbol methodSymbol, List<TreePath> usagePaths, VisitorState state) {
         boolean isPrivateMethod = methodSymbol.getModifiers().contains(Modifier.PRIVATE);
         int index = methodSymbol.params.indexOf(varSymbol);
-        Preconditions.checkState(index != -1, "symbol {} must be a parameter to the owning method", varSymbol);
+        Preconditions.checkState(index != -1, "symbol %s must be a parameter to the owning method", varSymbol);
         SuggestedFix.Builder fix = SuggestedFix.builder();
         for (TreePath path : usagePaths) {
             fix.delete(path.getLeaf());

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -223,6 +223,8 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             if (symbol.getKind() == ElementKind.PARAMETER && !isEverUsed.contains(unusedSymbol)) {
                 Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) symbol.owner;
                 int index = methodSymbol.params.indexOf(symbol);
+                // If we can not find the parameter in the owning method, then it must be a parameter to a lambda
+                // defined within the method
                 if (index == -1) {
                     fixes = buildUnusedLambdaParameterFix(symbol, entry.getValue(), state);
                 } else {
@@ -506,7 +508,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             Symbol varSymbol, Symbol.MethodSymbol methodSymbol, List<TreePath> usagePaths, VisitorState state) {
         boolean isPrivateMethod = methodSymbol.getModifiers().contains(Modifier.PRIVATE);
         int index = methodSymbol.params.indexOf(varSymbol);
-        Preconditions.checkState(index != -1, "symbol must be a parameter to the owning method");
+        Preconditions.checkState(index != -1, "symbol {} must be a parameter to the owning method", varSymbol);
         SuggestedFix.Builder fix = SuggestedFix.builder();
         for (TreePath path : usagePaths) {
             fix.delete(path.getLeaf());

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -96,6 +96,24 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
+    void handles_lambdas() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.function.BiFunction;",
+                        "import java.util.Optional;",
+                        "class Test {",
+                        "  private static BiFunction<String, String, Integer> doStuff() {",
+                        "  // BUG: Diagnostic contains: Unused",
+                        "    BiFunction<String, String, Integer> first = (String value1, String value2) -> 1;",
+                        "  // BUG: Diagnostic contains: Unused",
+                        "    return first.andThen(value3 -> 2);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void renames_previous_suppression() {
         refactoringTestHelper
                 .addInputLines(
@@ -131,6 +149,30 @@ public class StrictUnusedVariableTest {
                         "  public void varArgs(String _value, String... _value2) { }",
                         "}")
                 .doTest(TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    void renames_unused_lambda_params() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "import java.util.function.BiFunction;",
+                        "class Test {",
+                        "  private static BiFunction<String, String, Integer> doStuff() {",
+                        "    BiFunction<String, String, Integer> first = (String value1, String value2) -> 1;",
+                        "    return first.andThen(value3 -> 2);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.util.function.BiFunction;",
+                        "class Test {",
+                        "  private static BiFunction<String, String, Integer> doStuff() {",
+                        "    BiFunction<String, String, Integer> first = (String _value1, String _value2) -> 1;",
+                        "    return first.andThen(_value3 -> 2);",
+                        "  }",
+                        "}")
+                .doTest();
     }
 
     @Test

--- a/changelog/@unreleased/pr-1355.v2.yml
+++ b/changelog/@unreleased/pr-1355.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`StrictUnusedVariable` checks for unused lambda parameters'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1355


### PR DESCRIPTION
## Before this PR
`StrictUnusedVariable` would not ensure that all lambda parameters were unused

## After this PR
==COMMIT_MSG==
`StrictUnusedVariable` checks for unused lambda parameters
==COMMIT_MSG==

## Possible downsides?
Some code bases may have had existing conventions for denoting unused lambda parameters. However the fix that comes along with the rule should prevent upgrades from being blocked

