### PR TITLE
Revert "Strict unused variable enforces lambda parameters (#1355)"

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -96,24 +96,6 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
-    void handles_lambdas() {
-        compilationHelper
-                .addSourceLines(
-                        "Test.java",
-                        "import java.util.function.BiFunction;",
-                        "import java.util.Optional;",
-                        "class Test {",
-                        "  private static BiFunction<String, String, Integer> doStuff() {",
-                        "  // BUG: Diagnostic contains: Unused",
-                        "    BiFunction<String, String, Integer> first = (String value1, String value2) -> 1;",
-                        "  // BUG: Diagnostic contains: Unused",
-                        "    return first.andThen(value3 -> 2);",
-                        "  }",
-                        "}")
-                .doTest();
-    }
-
-    @Test
     public void renames_previous_suppression() {
         refactoringTestHelper
                 .addInputLines(
@@ -149,30 +131,6 @@ public class StrictUnusedVariableTest {
                         "  public void varArgs(String _value, String... _value2) { }",
                         "}")
                 .doTest(TestMode.TEXT_MATCH);
-    }
-
-    @Test
-    void renames_unused_lambda_params() {
-        refactoringTestHelper
-                .addInputLines(
-                        "Test.java",
-                        "import java.util.function.BiFunction;",
-                        "class Test {",
-                        "  private static BiFunction<String, String, Integer> doStuff() {",
-                        "    BiFunction<String, String, Integer> first = (String value1, String value2) -> 1;",
-                        "    return first.andThen(value3 -> 2);",
-                        "  }",
-                        "}")
-                .addOutputLines(
-                        "Test.java",
-                        "import java.util.function.BiFunction;",
-                        "class Test {",
-                        "  private static BiFunction<String, String, Integer> doStuff() {",
-                        "    BiFunction<String, String, Integer> first = (String _value1, String _value2) -> 1;",
-                        "    return first.andThen(_value3 -> 2);",
-                        "  }",
-                        "}")
-                .doTest();
     }
 
     @Test

--- a/changelog/@unreleased/pr-1357.v2.yml
+++ b/changelog/@unreleased/pr-1357.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Revert recent regression #1355 from 5.18.0 which broke some consumers.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1357


### PR DESCRIPTION
This reverts commit 620c65b288d234b721d311ccac3f301635d8b35e.

## Before this PR

#1355 broke some consumers.

## After this PR
==COMMIT_MSG==
Revert recent regression #1355 from 5.18.0 which broke some consumers.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

