### PR TITLE
Fix strict unused lambda

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -253,15 +253,15 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
     private void checkUsedVariables(VisitorState state, VariableFinder variableFinder) {
         VariableUsage variableUsage = new VariableUsage();
         variableUsage.scan(state.getPath(), null);
-        variableFinder.exemptedVariables.entrySet().forEach(entry -> {
-            List<TreePath> usageSites = variableUsage.usageSites.get(entry.getKey());
+        variableFinder.exemptedVariables.forEach((key, value) -> {
+            List<TreePath> usageSites = variableUsage.usageSites.get(key);
             if (usageSites.size() <= 1) {
                 return;
             }
-            state.reportMatch(buildDescription(entry.getValue())
+            state.reportMatch(buildDescription(value)
                     .setMessage(String.format(
                             "The %s '%s' is read but has 'StrictUnusedVariable' suppressed because of its name.",
-                            describeVariable((Symbol.VarSymbol) entry.getKey()), entry.getKey().name))
+                            describeVariable((Symbol.VarSymbol) key), key.name))
                     .addFix(constructUsedVariableSuggestedFix(usageSites, state))
                     .build());
         });

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -260,7 +260,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             }
             state.reportMatch(buildDescription(entry.getValue())
                     .setMessage(String.format(
-                            "The %s '%s' is read but has 'StrictUnusedVariable' " + "suppressed because of its name.",
+                            "The %s '%s' is read but has 'StrictUnusedVariable' suppressed because of its name.",
                             describeVariable((Symbol.VarSymbol) entry.getKey()), entry.getKey().name))
                     .addFix(constructUsedVariableSuggestedFix(usageSites, state))
                     .build());

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -176,6 +176,44 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
+    void renames_used_lambda_params() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "import java.util.List;",
+                        "import java.util.stream.Collectors;",
+                        "import java.util.stream.IntStream;",
+                        "import java.util.stream.Stream;",
+                        "",
+                        "public final class Test {",
+                        "    private Test() {}",
+                        "    private static String randomEvent() { return null; }",
+                        "    public static List<?> work() {",
+                        "        return IntStream.iterate(0, _i -> _i + 1).mapToObj(_i -> randomEvent())",
+                        "                .limit(1)",
+                        "                .collect(Collectors.toList());",
+                        "    }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.util.List;",
+                        "import java.util.stream.Collectors;",
+                        "import java.util.stream.IntStream;",
+                        "import java.util.stream.Stream;",
+                        "",
+                        "public final class Test {",
+                        "    private Test() {}",
+                        "    private static String randomEvent() { return null; }",
+                        "    public static List<?> work() {",
+                        "        return IntStream.iterate(0, i -> i + 1).mapToObj(_i -> randomEvent())",
+                        "                .limit(1)",
+                        "                .collect(Collectors.toList());",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void fails_suppressed_but_used_variables() {
         compilationHelper
                 .addSourceLines(

--- a/changelog/@unreleased/pr-1358.v2.yml
+++ b/changelog/@unreleased/pr-1358.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Correctly handle converting lambda parameters from unused (`_param`)
+    to used (param`), fixing a regression from 5.18.0.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1358


### PR DESCRIPTION
## Before this PR

The suggested fix from #1355 failed for some lambdas where a seemingly unused parameter (starting with `_`) was actually used, and would end up deleting a bunch of code.

## After this PR
==COMMIT_MSG==
Correctly handle converting lambda parameters from unused (`_param`) to used (param`).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

