### PR TITLE
Rewrite lambdas to method references for instance methods

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
@@ -138,7 +138,9 @@ public final class LambdaMethodReference extends BugChecker implements BugChecke
         if (receiverType == null || receiverType.getLowerBound() != null || receiverType.getUpperBound() != null) {
             return SuggestedFixes.qualifyType(state, builder, symbol);
         }
-        return SuggestedFixes.qualifyType(state, builder, receiverType) + '.' + symbol.name.toString();
+        return SuggestedFixes.qualifyType(state, builder, state.getTypes().erasure(receiverType))
+                + '.'
+                + symbol.name.toString();
     }
 
     private static Optional<String> toMethodReference(String qualifiedMethodName) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
@@ -115,7 +115,7 @@ public final class LambdaMethodReference extends BugChecker implements BugChecke
             }
             return true;
         }
-        return false;
+        return !root.getParameters().isEmpty();
     }
 
     private static Optional<SuggestedFix> buildFix(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
@@ -132,6 +132,28 @@ public class LambdaMethodReferenceTest {
     }
 
     @Test
+    void testAutoFix_specificInstanceMethod() {
+        refactoringValidator
+                .addInputLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<String> foo(Optional<Test> optional) {",
+                        "    return optional.map(v -> v.toString());",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<String> foo(Optional<Test> optional) {",
+                        "    return optional.map(Test::toString);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testNegative_block_localMethod() {
         compilationHelper
                 .addSourceLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
@@ -154,6 +154,28 @@ public class LambdaMethodReferenceTest {
     }
 
     @Test
+    void testAutoFix_specificInstanceMethod_withTypeParameters() {
+        refactoringValidator
+                .addInputLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<String> foo(Optional<Optional<Test>> optional) {",
+                        "    return optional.map(v -> v.toString());",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<String> foo(Optional<Optional<Test>> optional) {",
+                        "    return optional.map(Optional::toString);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testNegative_block_localMethod() {
         compilationHelper
                 .addSourceLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
@@ -264,6 +264,21 @@ public class LambdaMethodReferenceTest {
     }
 
     @Test
+    public void testNegative_expression_staticMethod() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import " + ImmutableList.class.getName() + ';',
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<String> foo(Optional<String> optional) {",
+                        "    return optional.flatMap(value -> Optional.empty());",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testAutoFix_expression_localMethod() {
         refactoringValidator
                 .addInputLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
@@ -27,10 +27,12 @@ import org.junit.jupiter.api.Test;
 public class LambdaMethodReferenceTest {
 
     private CompilationTestHelper compilationHelper;
+    private RefactoringValidator refactoringValidator;
 
     @BeforeEach
     public void before() {
         compilationHelper = CompilationTestHelper.newInstance(LambdaMethodReference.class, getClass());
+        refactoringValidator = RefactoringValidator.of(new LambdaMethodReference(), getClass());
     }
 
     @Test
@@ -44,6 +46,21 @@ public class LambdaMethodReferenceTest {
                         "class Test {",
                         "  public List<Object> foo(Optional<List<Object>> optional) {",
                         "    return optional.orElseGet(ImmutableList::of);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testFunction() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<Integer> foo(Optional<String> optional) {",
+                        "    // BUG: Diagnostic contains: Lambda should be a method reference",
+                        "    return optional.map(v -> v.length());",
                         "  }",
                         "}")
                 .doTest();
@@ -68,7 +85,7 @@ public class LambdaMethodReferenceTest {
 
     @Test
     public void testAutoFix_block() {
-        RefactoringValidator.of(new LambdaMethodReference(), getClass())
+        refactoringValidator
                 .addInputLines(
                         "Test.java",
                         "import " + ImmutableList.class.getName() + ';',
@@ -93,6 +110,28 @@ public class LambdaMethodReferenceTest {
     }
 
     @Test
+    void testAutoFix_instanceMethod() {
+        refactoringValidator
+                .addInputLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<Integer> foo(Optional<String> optional) {",
+                        "    return optional.map(v -> v.length());",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<Integer> foo(Optional<String> optional) {",
+                        "    return optional.map(String::length);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testNegative_block_localMethod() {
         compilationHelper
                 .addSourceLines(
@@ -114,7 +153,7 @@ public class LambdaMethodReferenceTest {
 
     @Test
     public void testAutoFix_block_localMethod() {
-        RefactoringValidator.of(new LambdaMethodReference(), getClass())
+        refactoringValidator
                 .addInputLines(
                         "Test.java",
                         "import " + ImmutableList.class.getName() + ';',
@@ -180,7 +219,7 @@ public class LambdaMethodReferenceTest {
 
     @Test
     public void testAutoFix_expression() {
-        RefactoringValidator.of(new LambdaMethodReference(), getClass())
+        refactoringValidator
                 .addInputLines(
                         "Test.java",
                         "import " + ImmutableList.class.getName() + ';',
@@ -226,7 +265,7 @@ public class LambdaMethodReferenceTest {
 
     @Test
     public void testAutoFix_expression_localMethod() {
-        RefactoringValidator.of(new LambdaMethodReference(), getClass())
+        refactoringValidator
                 .addInputLines(
                         "Test.java",
                         "import " + ImmutableList.class.getName() + ';',

--- a/changelog/@unreleased/pr-1359.v2.yml
+++ b/changelog/@unreleased/pr-1359.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Rewrite single parameter lambdas that only invoke an zero param instance
+    method to a method reference
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1359


### PR DESCRIPTION
## Before this PR
We would only re-write lambdas with zero parameters that invoked static methods to method references

## After this PR
==COMMIT_MSG==
Rewrite single parameter lambdas that only invoke an zero param instance method to a method reference
==COMMIT_MSG==

## Possible downsides?
N/A

