### PR TITLE
Fix for method references with type parameters

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
@@ -138,7 +138,9 @@ public final class LambdaMethodReference extends BugChecker implements BugChecke
         if (receiverType == null || receiverType.getLowerBound() != null || receiverType.getUpperBound() != null) {
             return SuggestedFixes.qualifyType(state, builder, symbol);
         }
-        return SuggestedFixes.qualifyType(state, builder, receiverType) + '.' + symbol.name.toString();
+        return SuggestedFixes.qualifyType(state, builder, state.getTypes().erasure(receiverType))
+                + '.'
+                + symbol.name.toString();
     }
 
     private static Optional<String> toMethodReference(String qualifiedMethodName) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
@@ -154,6 +154,28 @@ public class LambdaMethodReferenceTest {
     }
 
     @Test
+    void testAutoFix_specificInstanceMethod_withTypeParameters() {
+        refactoringValidator
+                .addInputLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<String> foo(Optional<Optional<Test>> optional) {",
+                        "    return optional.map(v -> v.toString());",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import " + Optional.class.getName() + ';',
+                        "class Test {",
+                        "  public Optional<String> foo(Optional<Optional<Test>> optional) {",
+                        "    return optional.map(Optional::toString);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testNegative_block_localMethod() {
         compilationHelper
                 .addSourceLines(


### PR DESCRIPTION
`Optional<String>::toString` does not compile