### PR TITLE
Add explicit asm dep

### DIFF
--- a/changelog/@unreleased/pr-1374.v2.yml
+++ b/changelog/@unreleased/pr-1374.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add an explicit dependency on `org.ow2.asm:asm` to ensure consumers
+    can use JDK14 source compat
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1374

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile 'org.apache.maven.shared:maven-dependency-analyzer'
     compile 'org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11'
     implementation 'com.palantir.javaformat:palantir-java-format-spi'
+    // Add an explicit dependency to ensure consumers can use JDK14 source compat
     implementation 'org.ow2.asm:asm'
 
     runtimeOnly 'com.palantir.javaformat:gradle-palantir-java-format'

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile 'org.apache.maven.shared:maven-dependency-analyzer'
     compile 'org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11'
     implementation 'com.palantir.javaformat:palantir-java-format-spi'
+    implementation 'org.ow2.asm:asm'
 
     runtimeOnly 'com.palantir.javaformat:gradle-palantir-java-format'
 


### PR DESCRIPTION
## Before this PR
We had tried to bump the version of asm we pulled in transitively in #1367, however this did not fix the issue for consumers

## After this PR
==COMMIT_MSG==
Add an explicit dependency on `org.ow2.asm:asm` to ensure consumers can use JDK14 source compat
==COMMIT_MSG==

## Possible downsides?
N/A

