### PR TITLE
auto-fix PublicConstructorForAbstractClass

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -39,6 +39,7 @@ public class BaselineErrorProneExtension {
             "PreferListsPartition",
             "PreferSafeLoggableExceptions",
             "PreferSafeLoggingPreconditions",
+            "PublicConstructorForAbstractClass",
             "ReadReturnValueIgnored",
             "RedundantMethodReference",
             "RedundantModifier",


### PR DESCRIPTION
Seems very non-scary https://github.com/google/error-prone/blob/master/core/src/main/java/com/google/errorprone/bugpatterns/PublicConstructorForAbstractClass.java

```
> Task :build2-ete:compileJava FAILED
/home/circleci/project/build2-ete/src/main/java/com/palantir/foundry/build2/ete/worker/EteWorkerBase.java:52: warning: [PublicConstructorForAbstractClass] Constructors of on an abstract class can be declared protected as there is never a need for them to be public
    public EteWorkerBase(WorkerReportingService workerReportingService) {
           ^
    (see https://errorprone.info/bugpattern/PublicConstructorForAbstractClass)
  Did you mean 'protected EteWorkerBase(WorkerReportingService workerReportingService) {'?
error: warnings found and -Werror specified
1 error
1 warning
```