### PR TITLE
Don't include SUGGESTION checks in default checks

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
@@ -20,6 +20,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -53,7 +54,7 @@ import javax.annotation.Nullable;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = SeverityLevel.WARNING,
         summary = "Lambda should be a method reference")
 @SuppressWarnings("checkstyle:CyclomaticComplexity")
 public final class LambdaMethodReference extends BugChecker implements BugChecker.LambdaExpressionTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferBuiltInConcurrentKeySet.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferBuiltInConcurrentKeySet.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -34,7 +35,7 @@ import com.sun.source.tree.MethodInvocationTree;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = SeverityLevel.WARNING,
         summary = "Prefer Java's built-in Concurrent Set implementation over Guava's ConcurrentHashSet, as it does "
                 + "the same thing with less indirection and doesn't rely on Guava")
 public final class PreferBuiltInConcurrentKeySet extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantMethodReference.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -35,7 +36,7 @@ import javax.lang.model.element.Modifier;
         name = "RedundantMethodReference",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = SeverityLevel.WARNING,
         summary = "Redundant method reference to the same type")
 public final class RedundantMethodReference extends BugChecker implements BugChecker.MemberReferenceTreeMatcher {
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/RedundantModifier.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -41,7 +42,7 @@ import javax.lang.model.element.Modifier;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = SeverityLevel.WARNING,
         summary = "Avoid using redundant modifiers")
 public final class RedundantModifier extends BugChecker
         implements BugChecker.ClassTreeMatcher, BugChecker.MethodTreeMatcher, BugChecker.VariableTreeMatcher {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamOfEmpty.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamOfEmpty.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -33,7 +34,7 @@ import java.util.stream.Stream;
         name = "StreamOfEmpty",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = SeverityLevel.WARNING,
         summary = "Stream.of() should be replaced with Stream.empty() to avoid unnecessary varargs allocation.")
 public final class StreamOfEmpty extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamOfEmpty.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamOfEmpty.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
         name = "StreamOfEmpty",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = SeverityLevel.WARNING,
+        severity = SeverityLevel.ERROR,
         summary = "Stream.of() should be replaced with Stream.empty() to avoid unnecessary varargs allocation.")
 public final class StreamOfEmpty extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 

--- a/changelog/@unreleased/pr-1380.v2.yml
+++ b/changelog/@unreleased/pr-1380.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `baseline-error-prone` plugin no longer applies `SUGGESTION` checks
+    by default.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1380

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -21,6 +21,11 @@ import org.gradle.api.Project;
 import org.gradle.api.provider.ListProperty;
 
 public class BaselineErrorProneExtension {
+
+    /*
+     * Do not add SUGGESTION checks here. Instead either increase the severity to WARNING or do not apply them by
+     * default.
+     */
     private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
             "BracesRequired",


### PR DESCRIPTION
When new `SUGGESTION` checks are added, it adds noise to the compiler output.

Even if these checks have suggested fixes, there is nothing that enforces `SUGGESTION` checks. So subsequent changes can introduce regressions that clutter the compiler output.

As a result I've found myself adding the config like this to all our repos to ensure that we enforce the default patch checks when new `SUGGESTION` checks are added.
```
options.errorprone.errorproneArgs += [
    '-Xep:AssertjRefactoring:WARN',
    '-Xep:CatchSpecificity:WARN',
    '-Xep:LambdaMethodReference:WARN',
    '-Xep:PreferAssertj:WARN',
    '-Xep:PreferCollectionConstructors:WARN',
    '-Xep:PreferBuiltInConcurrentKeySet:WARN',
    '-Xep:RedundantMethodReference:WARN',
    '-Xep:RedundantModifier:WARN',
    '-Xep:StreamOfEmpty:WARN',
    '-Xep:ThrowSpecificity:WARN']
```

Relying on excavator upgrades to fix these results in code churn and doesn't seem like the right approach. I'd would strongly prefer to either:
1. Enforce these checks at the warning level so projects can opt-in to failing at compile time for all new checks using `-Werror`.
2. Don't include `SUGGESTION` checks in default checks.

This PR takes approach (1), but I'm indifferent between these two options (or some mix of them depending on the check).