### PR TITLE
Auto-fix ProtectedMembersInFinalClass

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -59,7 +59,8 @@ public class BaselineErrorProneExtension {
             "ArrayEquals",
             "MissingOverride",
             "UnnecessaryParentheses",
-            "PreferJavaTimeOverload");
+            "PreferJavaTimeOverload",
+            "ProtectedMembersInFinalClass");
 
     private final ListProperty<String> patchChecks;
 


### PR DESCRIPTION
This is a pretty niche check but I had found it in some code I wrote where halfway through the file I switched from private constructors to protected.

## Before this PR
```
/home/circleci/project/dataset-reader/src/main/java/com/palantir/preview/dataset/readers/parquet/ParquetArrowVectorHydrators.java:366: warning: [ProtectedMembersInFinalClass] Make members of final classes package-private: <init>
        protected VarCharHydrator(ColumnDescriptor desc, ColumnReader columnReader, VarCharVector arrowVector) {
                  ^
    (see https://errorprone.info/bugpattern/ProtectedMembersInFinalClass)
  Did you mean 'VarCharHydrator(ColumnDescriptor desc, ColumnReader columnReader, VarCharVector arrowVector) {'?
```
## After this PR
==COMMIT_MSG==
Auto-fix ProtectedMembersInFinalClass
==COMMIT_MSG==

## Possible downsides?
Shouldn't be an issue and mostly likely a review mistake

