### PR TITLE
Auto-fix BadImport

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -63,6 +63,7 @@ public class BaselineErrorProneExtension {
 
             // Built-in checks
             "ArrayEquals",
+            "BadImport",
             "MissingOverride",
             "UnnecessaryParentheses",
             "PreferJavaTimeOverload",


### PR DESCRIPTION
I ran into this a bunch when upgrading, specifically because of these commits which flag a lot of commonly used inner imports:
https://github.com/google/error-prone/blame/7037696f4b00c8137394b10d143e37072b6048f6/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java#L63-L71