### PR TITLE
--write-locks no longer implicitly runs checkClassUniqueness task

### DIFF
--- a/changelog/@unreleased/pr-1389.v2.yml
+++ b/changelog/@unreleased/pr-1389.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Running `./gradlew --write-locks` should be faster now, as it doesn't
+    update your `baseline-class-uniqueness.lock` file implicitly anymore. To update
+    this, you need to run `./gradlew checkClassUniqueness --write-locks`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1389

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineClassUniquenessPlugin.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineClassUniquenessPlugin.java
@@ -16,10 +16,7 @@
 
 package com.palantir.baseline.plugins;
 
-import com.google.common.collect.ImmutableList;
 import com.palantir.baseline.tasks.CheckClassUniquenessLockTask;
-import java.util.List;
-import org.gradle.StartParameter;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
@@ -53,16 +50,5 @@ public class BaselineClassUniquenessPlugin extends AbstractBaselinePlugin {
                 t.dependsOn(runtimeClasspath);
             });
         });
-
-        // Wire up dependencies so running `./gradlew --write-locks` will update the lock file
-        StartParameter startParam = project.getGradle().getStartParameter();
-        if (startParam.isWriteDependencyLocks()
-                && !startParam.getTaskNames().contains(checkClassUniqueness.getName())) {
-            List<String> taskNames = ImmutableList.<String>builder()
-                    .addAll(startParam.getTaskNames())
-                    .add(checkClassUniqueness.getName())
-                    .build();
-            startParam.setTaskNames(taskNames);
-        }
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
@@ -57,7 +57,7 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
         result.getOutput().contains("javax.el.ArrayELResolver");
         !lockfile.exists()
 
-        with("--write-locks").build()
+        with("checkClassUniqueness", "--write-locks").build()
         lockfile.exists()
 
         File expected = new File("src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock")


### PR DESCRIPTION
## Before this PR

I've become frustrated with how the local experience of writing `./gradlew --write-locks` has become very slow. This is often because checkClassUniqueness is a pretty meaty task, which ends up analyzing all jars on the classpath.

## After this PR
==COMMIT_MSG==
Running `./gradlew --write-locks` should be faster now, as it doesn't update your `baseline-class-uniqueness.lock` file implicitly anymore. To update this, you need to run `./gradlew checkClassUniqueness --write-locks`.
==COMMIT_MSG==

## Possible downsides?
A big downside here is: if we just merge this PR, then a bunch of excavators will probably start opening PRs with out of date baseline-class-uniqueness.lock files, leading to frustrated devs.

