### PR TITLE
Improve gradle-baseline-java integration with IntelliJ import

### DIFF
--- a/gradle-baseline-java-config/resources/idea/codeStyles/Project.xml
+++ b/gradle-baseline-java-config/resources/idea/codeStyles/Project.xml
@@ -1,0 +1,407 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <GroovyCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+        </value>
+      </option>
+    </GroovyCodeStyleSettings>
+    <JavaCodeStyleSettings>
+      <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
+    <codeStyleSettings language="Groovy">
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+      <option name="SPACE_WITHIN_BRACES" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="THROWS_LIST_WRAP" value="1" />
+      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+      <option name="THROWS_KEYWORD_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="120" />
+      <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <option name="LINE_COMMENT_ADD_SPACE" value="true" />
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+      <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+      <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+      <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="RESOURCE_LIST_WRAP" value="5" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="THROWS_LIST_WRAP" value="1" />
+      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+      <option name="THROWS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="5" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="WRAP_COMMENTS" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="FIELD_ANNOTATION_WRAP" value="1" />
+      <option name="ENUM_CONSTANTS_WRAP" value="2" />
+      <option name="WRAP_ON_TYPING" value="1" />
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PUBLIC>true</PUBLIC>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PROTECTED>true</PROTECTED>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PRIVATE>true</PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PUBLIC>true</PUBLIC>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PROTECTED>true</PROTECTED>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PRIVATE>true</PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PUBLIC>true</PUBLIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PROTECTED>true</PROTECTED>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PRIVATE>true</PRIVATE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PUBLIC>true</PUBLIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PROTECTED>true</PROTECTED>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PRIVATE>true</PRIVATE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <FIELD>true</FIELD>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <CONSTRUCTOR>true</CONSTRUCTOR>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <METHOD>true</METHOD>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <METHOD>true</METHOD>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <ENUM>true</ENUM>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <INTERFACE>true</INTERFACE>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <CLASS>true</CLASS>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <CLASS>true</CLASS>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <ABSTRACT>true</ABSTRACT>
+                  <METHOD>true</METHOD>
+                  <PUBLIC>true</PUBLIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <ABSTRACT>true</ABSTRACT>
+                  <METHOD>true</METHOD>
+                  <PROTECTED>true</PROTECTED>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <METHOD>true</METHOD>
+                  <PUBLIC>true</PUBLIC>
+                  <SYNCHRONIZED>true</SYNCHRONIZED>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <METHOD>true</METHOD>
+                  <PROTECTED>true</PROTECTED>
+                  <SYNCHRONIZED>true</SYNCHRONIZED>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <METHOD>true</METHOD>
+                  <PRIVATE>true</PRIVATE>
+                  <SYNCHRONIZED>true</SYNCHRONIZED>
+                </AND>
+              </match>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/gradle-baseline-java-config/resources/idea/codeStyles/codeStyleConfig.xml
+++ b/gradle-baseline-java-config/resources/idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -150,17 +150,13 @@ class BaselineIdea extends AbstractBaselinePlugin {
 
             File destDir = project.file(".idea/codeStyles/");
 
-            try {
-                destDir.mkdirs()
+            destDir.mkdirs()
 
-                // Copy all files
-                styleFiles.each { File file ->
-                    def fileName = file.getName()
-                    def destFile = new File(destDir, fileName)
-                    destFile << file.text
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
+            // Copy all files
+            styleFiles.each { File file ->
+                def fileName = file.getName()
+                def destFile = new File(destDir, fileName)
+                destFile << file.text
             }
         } else {
             // Fall back to legacy style file for backwards compatibility

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.plugins
 
+import com.google.common.collect.ImmutableMap
 import com.palantir.baseline.util.GitUtils
 import groovy.transform.CompileStatic
 import groovy.xml.XmlUtil
@@ -24,6 +25,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.plugins.ide.idea.GenerateIdeaModule
 import org.gradle.plugins.ide.idea.GenerateIdeaProject
 import org.gradle.plugins.ide.idea.GenerateIdeaWorkspace
@@ -31,9 +33,11 @@ import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.plugins.ide.idea.model.ModuleDependency
 
+import javax.inject.Provider
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.function.Consumer
 
 class BaselineIdea extends AbstractBaselinePlugin {
 
@@ -92,6 +96,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             addGitHubIssueNavigation(node)
             ignoreCommonShadedPackages(node)
         }
+        configureProjectForIntellijImport(project)
 
         project.afterEvaluate {
             ideaRootModel.workspace.iws.withXml { provider ->
@@ -119,6 +124,15 @@ class BaselineIdea extends AbstractBaselinePlugin {
         { FileTreeElement details -> details.file == file } as Spec<FileTreeElement>
     }
 
+    private void configureProjectForIntellijImport(Project project) {
+        if (!Boolean.getBoolean("idea.active")) {
+            return
+        }
+        addCodeStyleIntellijImport()
+        addCheckstyleIntellijImport(project)
+        addCopyrightIntellijImport()
+    }
+
     /**
      * Extracts IDEA formatting configurations from Baseline directory and adds it to the Idea project XML node.
      */
@@ -127,37 +141,120 @@ class BaselineIdea extends AbstractBaselinePlugin {
         node.append(new XmlParser().parse(ideaStyleFile).component)
     }
 
+    private void addCodeStyleIntellijImport() {
+        def ideaStyleDir = project.file("${configDir}/idea/codeStyles/")
+
+        if (ideaStyleDir.exists()) {
+            def styleFiles = project.fileTree(ideaStyleDir).include("*")
+            assert styleFiles.iterator().hasNext(), "${ideaStyleDir} must contain one or more style files"
+
+            File destDir = project.file(".idea/codeStyles/");
+
+            try {
+                destDir.mkdirs()
+
+                // Copy all files
+                styleFiles.each { File file ->
+                    def fileName = file.getName()
+                    def destFile = new File(destDir, fileName)
+                    destFile << file.text
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            // Fall back to legacy style file for backwards compatibility
+            // This unfortunately requires to close and reopen IntelliJ after import
+            def ideaStyleFile = project.file("${configDir}/idea/intellij-java-palantir-style.xml")
+            project.file(".idea/codeStyleSettings.xml") << ideaStyleFile.text
+        }
+    }
+
     /**
      * Extracts copyright headers from Baseline directory and adds them to Idea project XML node.
      */
     private void addCopyright(node) {
         def copyrightManager = node.component.find { it.'@name' == 'CopyrightManager' }
         def copyrightDir = Paths.get("${configDir}/copyright/")
-        assert Files.exists(copyrightDir), "${copyrightDir} must exist"
-        def copyrightFiles = project.fileTree(copyrightDir.toFile()).include("*")
-        assert copyrightFiles.iterator().hasNext(), "${copyrightDir} must contain one or more copyright file"
+        def copyrightFiles = getCopyrightFiles(copyrightDir)
         copyrightFiles.each { File file ->
             def fileName = copyrightDir.relativize(file.toPath())
             def copyrightNode = copyrightManager.copyright.find {
                 it.option.find { it.@name == "myName" }?.@value == fileName
             }
             if (copyrightNode == null) {
-                    def copyrightText = XmlUtil.escapeControlCharacters(XmlUtil.escapeXml(file.text.trim()))
-                    copyrightManager.append(new XmlParser().parseText("""
-                        <copyright>
-                            <option name="notice" value="${copyrightText}" />
-                            <option name="keyword" value="Copyright" />
-                            <option name="allowReplaceKeyword" value="" />
-                            <option name="myName" value="${fileName}" />
-                            <option name="myLocal" value="true" />
-                        </copyright>
-                        """.stripIndent()
-                    ))
+                addCopyrightFile(copyrightManager, file, fileName.toString())
             }
         }
 
         def lastFileName = copyrightDir.relativize(copyrightFiles.iterator().toList().sort().last().toPath())
         copyrightManager.@default = lastFileName
+    }
+
+    private void addCopyrightIntellijImport() {
+        def copyrightDir = Paths.get("${configDir}/copyright/")
+        def copyrightFiles = getCopyrightFiles(copyrightDir)
+
+        Provider<Node> copyrightManagerNode = new Provider<Node>() {
+            @Override
+            Node get() {
+                return new Node(null, "component", ImmutableMap.of("name", "CopyrightManager"))
+            }
+        }
+
+        copyrightFiles.each { File file ->
+            def fileName = copyrightDir.relativize(file.toPath()).toString()
+            def extensionIndex = fileName.lastIndexOf(".")
+            if (extensionIndex == -1) {
+                extensionIndex = fileName.length()
+            }
+            def xmlFileName = fileName.substring(0, extensionIndex) + ".xml"
+
+            XmlUtils.createOrUpdateXmlFile(
+                    // Replace the extension by xml for the actual file
+                    project.file(".idea/copyright/" + xmlFileName),
+                    new Consumer<Node>() {
+                        @Override
+                        void accept(Node node) {
+                            addCopyrightFile(node, file, fileName)
+                        }
+                    },
+                    copyrightManagerNode)
+        }
+
+        def lastFileName = copyrightDir.relativize(copyrightFiles.iterator().toList().sort().last().toPath())
+
+        XmlUtils.createOrUpdateXmlFile(
+                project.file(".idea/copyright/profiles_settings.xml"),
+                new Consumer<Node>() {
+                    @Override
+                    void accept(Node node) {
+                        node.append(new Node(null, "settings", ImmutableMap.of("default", lastFileName)))
+                    }
+                },
+                copyrightManagerNode)
+    }
+
+    private PatternFilterable getCopyrightFiles(copyrightDir) {
+        assert Files.exists(copyrightDir), "${copyrightDir} must exist"
+        def copyrightFiles = project.fileTree(copyrightDir.toFile()).include("*")
+        assert copyrightFiles.iterator().hasNext(), "${copyrightDir} must contain one or more copyright file"
+
+        return copyrightFiles
+    }
+
+    private static void addCopyrightFile(node, File file, String fileName) {
+        def copyrightText = XmlUtil.escapeControlCharacters(XmlUtil.escapeXml(file.text.trim()))
+        node.append(new XmlParser().parseText("""
+            <copyright>
+                <option name="notice" value="${copyrightText}" />
+                <option name="keyword" value="Copyright" />
+                <option name="allowReplaceKeyword" value="" />
+                <option name="myName" value="${fileName}" />
+                <option name="myLocal" value="true" />
+            </copyright>
+            """.stripIndent()
+        ))
     }
 
     private void addEclipseFormat(node) {
@@ -203,6 +300,29 @@ class BaselineIdea extends AbstractBaselinePlugin {
         }
 
         project.logger.debug "Baseline: Configuring Checkstyle for Idea"
+
+        addCheckstyleNode(node)
+        addCheckstyleExternalDependencies(node)
+    }
+
+    private static void addCheckstyleIntellijImport(project) {
+        def checkstyle = project.plugins.findPlugin(BaselineCheckstyle)
+        if (checkstyle == null) {
+            project.logger.debug "Baseline: Skipping IDEA checkstyle configuration since baseline-checkstyle not applied"
+            return
+        }
+
+        project.logger.debug "Baseline: Configuring Checkstyle for Idea"
+
+        XmlUtils.createOrUpdateXmlFile(
+                project.file(".idea/checkstyle-idea.xml"),
+                BaselineIdea.&addCheckstyleNode)
+        XmlUtils.createOrUpdateXmlFile(
+                project.file(".idea/externalDependencies.xml"),
+                BaselineIdea.&addCheckstyleExternalDependencies)
+    }
+
+    private static void addCheckstyleNode(node) {
         def checkstyleFile = "LOCAL_FILE:\$PROJECT_DIR\$/.baseline/checkstyle/checkstyle.xml"
         node.append(new XmlParser().parseText("""
             <component name="CheckStyle-IDEA">
@@ -220,6 +340,9 @@ class BaselineIdea extends AbstractBaselinePlugin {
               </option>
             </component>
             """.stripIndent()))
+    }
+
+    private static void addCheckstyleExternalDependencies(node) {
         def externalDependencies = GroovyXmlUtils.matchOrCreateChild(node, 'component', [name: 'ExternalDependencies'])
         GroovyXmlUtils.matchOrCreateChild(externalDependencies, 'plugin', [id: 'CheckStyle-IDEA'])
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/XmlUtils.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/XmlUtils.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
+import javax.inject.Provider;
 import javax.xml.parsers.ParserConfigurationException;
 import org.xml.sax.SAXException;
 
@@ -34,6 +35,12 @@ final class XmlUtils {
     private XmlUtils() {}
 
     static void createOrUpdateXmlFile(File configurationFile, Consumer<Node> configure) {
+        createOrUpdateXmlFile(
+                configurationFile, configure, () -> new Node(null, "project", ImmutableMap.of("version", "4")));
+    }
+
+    static void createOrUpdateXmlFile(
+            File configurationFile, Consumer<Node> configure, Provider<Node> defaultRootNode) {
         Node rootNode;
         if (configurationFile.isFile()) {
             try {
@@ -42,10 +49,12 @@ final class XmlUtils {
                 throw new RuntimeException("Couldn't parse existing configuration file: " + configurationFile, e);
             }
         } else {
-            rootNode = new Node(null, "project", ImmutableMap.of("version", "4"));
+            rootNode = defaultRootNode.get();
         }
 
         configure.accept(rootNode);
+
+        configurationFile.getParentFile().mkdirs();
 
         try (BufferedWriter writer = Files.newWriter(configurationFile, StandardCharsets.UTF_8);
                 PrintWriter printWriter = new PrintWriter(writer)) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -21,6 +21,7 @@ import com.google.common.io.Files
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.util.environment.RestoreSystemProperties
 
 class BaselineIdeaIntegrationTest extends AbstractPluginTest {
     def standardBuildFile = '''
@@ -86,13 +87,14 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         rootIpr.contains('<component name="CopyrightManager" default="999_palantir.txt">')
     }
 
+    @RestoreSystemProperties
     def 'Idea project has copyright configuration when importing'() {
         when:
         buildFile << standardBuildFile
         System.setProperty("idea.active", "true")
 
         then:
-        with('idea').build()
+        with().build()
         def copyrightDir = new File(projectDir, ".idea/copyright")
         copyrightDir.exists()
         copyrightDir.isDirectory()
@@ -107,13 +109,14 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         copyrightSettings.contains('<settings default="999_palantir.txt"/>')
     }
 
+    @RestoreSystemProperties
     def 'Idea project has style configuration when importing'() {
         when:
         buildFile << standardBuildFile
         System.setProperty("idea.active", "true")
 
         then:
-        with('idea').build()
+        with().build()
         def stylesDir = new File(projectDir, ".idea/codeStyles")
         stylesDir.exists()
         stylesDir.isDirectory()
@@ -340,6 +343,7 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         !ipr.component.find { it.@name == "SaveActionSettings" }
     }
 
+    @RestoreSystemProperties
     def "idea configures the save-action plugin for IntelliJ import"() {
         buildFile << standardBuildFile
         multiProject.addSubproject('formatted-project', """
@@ -348,7 +352,7 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
 
         when:
         System.setProperty("idea.active", "true")
-        with('idea').build()
+        with().build()
 
         then:
         def saveActionsSettingsFile = new File(projectDir, ".idea/saveactions_settings.xml")


### PR DESCRIPTION
## Before this PR
When directly importing the gradle project in IntelliJ, neither checkstyle nor copyright would be set up properly

## After this PR
==COMMIT_MSG==
Adds the proper configuration files upon IntelliJ import of a gradle project for checkstyle and copyright.

This generates the following additional files:
- .idea/copyright/profiles_settings.xml
- an xml file under .idea/copyright/ per copyright file under .baseline/copyright
- .idea/checkstyle-idea.xml (and adds Checkstyle-IDEA to the external dependencies) if baseline-checkstyle is applied
- Either .idea/codeStyleSettings.xml or a .idea/codeStyles/ folder with the contents being copied from .baseline/idea
  - If .baseline/idea/codeStyles is present, it will copy its contents, otherwise, it will fall back to .baseline/idea/intellij-java-palantir-style.xml as currently
  - The fallback is using a legacy IntelliJ format and requires closing and reopening the project to be taken into account

==COMMIT_MSG==

## Possible downsides?
- Small changes to the existing code structure for non-import code paths, which shouldn't change the output
- Not impossible this would override or conflict with other setups people have manually done
