### PR TITLE
StrictUnusedVariable handles Java 14 records

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -768,6 +768,9 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
         @Override
         public Void visitMethod(MethodTree tree, Void unused) {
+            if (state.getEndPosition(tree) < 0) {
+                return null;
+            }
             return isSuppressed(tree) ? null : super.visitMethod(tree, unused);
         }
     }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -768,6 +768,11 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
         @Override
         public Void visitMethod(MethodTree tree, Void unused) {
+            // From the perspective of an errorprone rule there are two standalone trees for a single `record`
+            // definition; A MethodTree which looks like a void function and a ClassTree which has the record fields.
+            //
+            // Its unclear why both trees are emitted, but we can identify and ignore a record's MethodTree by checking
+            // if it does not have any associated source.
             if (state.getEndPosition(tree) < 0) {
                 return null;
             }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.errorprone;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,18 +24,18 @@ import org.junit.jupiter.api.Test;
 
 public class StrictUnusedVariableTest {
 
-    private CompilationTestHelper compilationHelper;
+    private CompilationTestHelper previewCompilationHelper;
     private RefactoringValidator refactoringTestHelper;
 
     @BeforeEach
     public void before() {
-        compilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass());
+        previewCompilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass());
         refactoringTestHelper = RefactoringValidator.of(new StrictUnusedVariable(), getClass());
     }
 
     @Test
     public void handles_interface() {
-        compilationHelper
+        previewCompilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.Optional;",
@@ -48,7 +49,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     public void handles_abstract_classes() {
-        compilationHelper
+        previewCompilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.Optional;",
@@ -64,7 +65,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     public void handles_classes() {
-        compilationHelper
+        previewCompilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.Optional;",
@@ -81,7 +82,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     public void handles_enums() {
-        compilationHelper
+        previewCompilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.Optional;",
@@ -97,7 +98,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     void handles_lambdas() {
-        compilationHelper
+        previewCompilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.function.BiFunction;",
@@ -215,7 +216,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     public void fails_suppressed_but_used_variables() {
-        compilationHelper
+        previewCompilationHelper
                 .addSourceLines(
                         "Test.java",
                         "class Test {",
@@ -293,6 +294,21 @@ public class StrictUnusedVariableTest {
                 .addOutputLines(
                         "Test.java", "class Test {", "  public static void privateMethod(int _value) {", "  }", "}")
                 .doTest(TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testRecord() {
+        previewCompilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass())
+                .setArgs(ImmutableList.of("--enable-preview", "--release", "14"));
+
+        previewCompilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "@SuppressWarnings(\"StrictUnusedVariable\")",
+                        " record Foo(int foo) {}",
+                        "}")
+                .doTest();
     }
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -26,18 +26,18 @@ import org.junit.jupiter.api.condition.JRE;
 
 public class StrictUnusedVariableTest {
 
-    private CompilationTestHelper previewCompilationHelper;
+    private CompilationTestHelper compilationHelper;
     private RefactoringValidator refactoringTestHelper;
 
     @BeforeEach
     public void before() {
-        previewCompilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass());
+        compilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass());
         refactoringTestHelper = RefactoringValidator.of(new StrictUnusedVariable(), getClass());
     }
 
     @Test
     public void handles_interface() {
-        previewCompilationHelper
+        compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.Optional;",
@@ -51,7 +51,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     public void handles_abstract_classes() {
-        previewCompilationHelper
+        compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.Optional;",
@@ -67,7 +67,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     public void handles_classes() {
-        previewCompilationHelper
+        compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.Optional;",
@@ -84,7 +84,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     public void handles_enums() {
-        previewCompilationHelper
+        compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.Optional;",
@@ -100,7 +100,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     void handles_lambdas() {
-        previewCompilationHelper
+        compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "import java.util.function.BiFunction;",
@@ -218,7 +218,7 @@ public class StrictUnusedVariableTest {
 
     @Test
     public void fails_suppressed_but_used_variables() {
-        previewCompilationHelper
+        compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "class Test {",
@@ -301,10 +301,10 @@ public class StrictUnusedVariableTest {
     @Test
     @DisabledForJreRange(max = JRE.JAVA_13)
     public void testRecord() {
-        previewCompilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass())
+        compilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass())
                 .setArgs(ImmutableList.of("--enable-preview", "--release", "14"));
 
-        previewCompilationHelper
+        compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "class Test {",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -21,6 +21,8 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 public class StrictUnusedVariableTest {
 
@@ -297,6 +299,7 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
+    @DisabledForJreRange(max = JRE.JAVA_13)
     public void testRecord() {
         previewCompilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass())
                 .setArgs(ImmutableList.of("--enable-preview", "--release", "14"));

--- a/changelog/@unreleased/pr-1412.v2.yml
+++ b/changelog/@unreleased/pr-1412.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: StrictUnusedVariable handles Java 14 records
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1412


### PR DESCRIPTION
Partially addresses https://github.com/palantir/gradle-baseline/issues/1405
## Before this PR
We would incorrectly identify any record definition as a violation of `StrictUnusedVariable` due to some peculiarities with how the record definition was interpreted by errorprone.

## After this PR
==COMMIT_MSG==
StrictUnusedVariable handles Java 14 records
==COMMIT_MSG==

## Possible downsides?
N/A

