### PR TITLE
Disable broken rule on switch expressions

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessaryParenthesesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessaryParenthesesTest.java
@@ -1,3 +1,18 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.baseline.errorprone;
 
 import com.google.common.collect.ImmutableList;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessaryParenthesesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessaryParenthesesTest.java
@@ -1,0 +1,33 @@
+package com.palantir.baseline.errorprone;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.bugpatterns.UnnecessaryParentheses;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+public class UnnecessaryParenthesesTest {
+
+    @Test
+    @DisabledForJreRange(max = JRE.JAVA_13)
+    public void testSwitchExpression() {
+        CompilationTestHelper compilationHelper = CompilationTestHelper.newInstance(
+                        UnnecessaryParentheses.class, getClass())
+                .setArgs(ImmutableList.of("--enable-preview", "--release", "14"));
+
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "  static int foo(String value) {",
+                        "    // BUG: Diagnostic contains: These grouping parentheses are unnecessary",
+                        "    return switch (value) {",
+                        "      case \"Foo\" -> 10;",
+                        "      default -> 0;",
+                        "    };",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+}

--- a/changelog/@unreleased/pr-1413.v2.yml
+++ b/changelog/@unreleased/pr-1413.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable `UnnecessaryParentheses` on Java 14 source to avoid false positives
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1413

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -213,7 +213,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // UnnecessaryParentheses does not currently work with switch expressions
         errorProneOptions.check("UnnecessaryParentheses", project.provider(() -> {
             JavaPluginExtension ext = project.getExtensions().getByType(JavaPluginExtension.class);
-            return ext.getSourceCompatibility().compareTo(JavaVersion.valueOf("14")) < 0
+            return ext.getSourceCompatibility().compareTo(JavaVersion.toVersion(14)) < 0
                     ? CheckSeverity.DEFAULT
                     : CheckSeverity.OFF;
         }));

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -210,18 +210,18 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 .set(String.format(
                         "%s%s(build|src%sgenerated.*)%s.*",
                         Pattern.quote(projectPath), separator, separator, separator));
-        errorProneOptions.check("CatchSpecificity", CheckSeverity.OFF);
-        errorProneOptions.check("UnusedVariable", CheckSeverity.OFF);
-        errorProneOptions.check("EqualsHashCode", CheckSeverity.ERROR);
-        errorProneOptions.check("EqualsIncompatibleType", CheckSeverity.ERROR);
-        errorProneOptions.check("StreamResourceLeak", CheckSeverity.ERROR);
-        errorProneOptions.check("InputStreamSlowMultibyteRead", CheckSeverity.ERROR);
-        errorProneOptions.check("JavaDurationGetSecondsGetNano", CheckSeverity.ERROR);
-        errorProneOptions.check("URLEqualsHashCode", CheckSeverity.ERROR);
 
+        errorProneOptions.disable("UnnecessaryParentheses", "CatchSpecificity", "UnusedVariable");
+        errorProneOptions.error(
+                "EqualsHashCode",
+                "EqualsIncompatibleType",
+                "StreamResourceLeak",
+                "InputStreamSlowMultibyteRead",
+                "JavaDurationGetSecondsGetNano",
+                "URLEqualsHashCode");
         // Relax some checks for test code
         if (errorProneOptions.getCompilingTestOnlyCode().get()) {
-            errorProneOptions.check("UnnecessaryLambda", CheckSeverity.OFF);
+            errorProneOptions.disable("UnnecessaryLambda");
         }
 
         if (javaCompile.equals(compileRefaster)) {


### PR DESCRIPTION
## Before this PR
There was a false negative with `UnnecessaryParentheses` rule


## After this PR
==COMMIT_MSG==
Disable `UnnecessaryParentheses` by default
==COMMIT_MSG==

We still don't fully support Java 14 switch expressions because of checkstyle: https://github.com/checkstyle/checkstyle/issues/6615

## Possible downsides?
Short term we will lose some validation without any clear upside. We could just move forward to demonstrate the failure and hope it and checkstyle get fixed up stream

