### PR TITLE
Fix configuration used for check junit dependencies

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -80,7 +80,7 @@ public class CheckJUnitDependencies extends DefaultTask {
         // org.junit.jupiter.api.Test annotation, but as JUnit4 knows nothing about these, they'll silently not run
         // unless the user has wired up the dependency correctly.
         if (sourceSetMentionsJUnit5Api(ss)) {
-            String implementation = ss.getImplementationConfigurationName();
+            String implementation = ss.getRuntimeClasspathConfigurationName();
             Preconditions.checkState(
                     junitPlatformEnabled,
                     "Some tests mention JUnit5, but the '"


### PR DESCRIPTION
At present, the 'implementation' configuration is used in order to
figure out if junit 5 is on the classpath. This is a bit bogus because
the implementation configuration is not resolved to indicate whether
junit5 is present at runtime - it's more a statement around what is
available at compile time. This PR changes the configuration used to
be the testRuntimeClasspath configuration instead.

I hit this when I wanted to set up a project that exports some generic
test utilities to downstream projects (all internal, obviously); depends
on JUnit, depends on AssertJ, depends on Mockito, sets up
mock-maker-inline globally, has a FakeClock in, sets up Mockito's
default answers to return smart nulls instead of nulls for better error
messages - and found that this code was rejecting transitive
dependencies.