### PR TITLE
Check unused dependencies task can be up to date

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ apply plugin: 'com.palantir.baseline'
 
 allprojects {
     repositories {
+        mavenCentral()
         jcenter()
         gradlePluginPortal()
         maven { url  'https://palantir.bintray.com/releases'}

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ apply plugin: 'com.palantir.baseline'
 
 allprojects {
     repositories {
-        mavenCentral()
         jcenter()
         gradlePluginPortal()
         maven { url  'https://palantir.bintray.com/releases'}

--- a/changelog/@unreleased/pr-1426.v2.yml
+++ b/changelog/@unreleased/pr-1426.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Check unused dependencies task can be up to date
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1426

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -59,6 +59,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         sourceClasses = getProject().getObjects().property(FileCollection.class);
         ignore = getProject().getObjects().setProperty(String.class);
         ignore.set(Collections.emptySet());
+        getOutputs().upToDateWhen(_task -> true);
     }
 
     @TaskAction

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -235,10 +235,10 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
     def 'check results can be up to date'() {
         when:
         setupMultiProject()
-        with(":checkUnusedDependencies").build();
+        with(":sub-project-no-deps:checkUnusedDependencies").build();
 
         then:
-        BuildResult result = with(":checkUnusedDependencies").build();
+        BuildResult result = with(":sub-project-no-deps:checkUnusedDependencies").build();
         result.task(':checkUnusedDependencies').outcome == TaskOutcome.UP_TO_DATE
     }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -239,7 +239,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
 
         then:
         BuildResult result = with(":sub-project-no-deps:checkUnusedDependencies").build();
-        result.task(':checkUnusedDependencies').outcome == TaskOutcome.UP_TO_DATE
+        result.task(':sub-project-no-deps:checkUnusedDependencies').outcome == TaskOutcome.UP_TO_DATE
     }
 
     def 'checkUnusedDependencies fails when a redundant project dep is present'() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -232,6 +232,16 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         result.task(':sub-project-no-deps:checkImplicitDependencies').getOutcome() == TaskOutcome.SUCCESS
     }
 
+    def 'check results can be up to date'() {
+        when:
+        setupMultiProject()
+        with(":checkUnusedDependencies").build();
+
+        then:
+        BuildResult result = with(":checkUnusedDependencies").build();
+        result.task(':checkUnusedDependencies').outcome == TaskOutcome.UP_TO_DATE
+    }
+
     def 'checkUnusedDependencies fails when a redundant project dep is present'() {
         when:
         setupMultiProject()


### PR DESCRIPTION
Declare check unused dependencies as having no outputs. This means that
it should be up to date provided that inputs have not changed.

RIght now because there are no outputs declared, gradle refuses to cache this task.

