### PR TITLE
fix #1431: Avoid rewriting lambdas into ambiguous references

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
@@ -42,12 +42,11 @@ import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.parser.Tokens;
-
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 @AutoService(BugChecker.class)
 @BugPattern(

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
@@ -42,11 +42,12 @@ import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.parser.Tokens;
+
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -58,8 +59,6 @@ import javax.annotation.Nullable;
         summary = "Lambda should be a method reference")
 @SuppressWarnings("checkstyle:CyclomaticComplexity")
 public final class LambdaMethodReference extends BugChecker implements BugChecker.LambdaExpressionTreeMatcher {
-
-    private static final String MESSAGE = "Lambda should be a method reference";
 
     @Override
     public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
@@ -150,8 +149,7 @@ public final class LambdaMethodReference extends BugChecker implements BugChecke
             return Description.NO_MATCH;
         }
         return buildFix(methodSymbol, methodInvocation, root, state, isLocal(methodInvocation))
-                .map(fix ->
-                        buildDescription(root).setMessage(MESSAGE).addFix(fix).build())
+                .map(fix -> buildDescription(root).addFix(fix).build())
                 .orElse(Description.NO_MATCH);
     }
 
@@ -170,8 +168,8 @@ public final class LambdaMethodReference extends BugChecker implements BugChecke
         }
 
         return buildFix(methodSymbol, methodInvocation, root, state, isLocal(methodInvocation))
-                .map(fix ->
-                        buildDescription(root).setMessage(MESSAGE).addFix(fix).build())
+                .filter(fix -> SuggestedFixes.compilesWithFix(fix, state))
+                .map(fix -> buildDescription(root).addFix(fix).build())
                 .orElse(Description.NO_MATCH);
     }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LambdaMethodReferenceTest.java
@@ -727,4 +727,29 @@ public class LambdaMethodReferenceTest {
                 .expectUnchanged()
                 .doTest();
     }
+
+    @Test
+    public void testSuperAmbiguous() {
+        refactor()
+                .addInputLines(
+                        "Test.java",
+                        "import java.util.function.BiConsumer;",
+                        "import java.util.function.Consumer;",
+                        "class Test {",
+                        "  interface One {",
+                        "    void call(Consumer<String> a);",
+                        "    void call(BiConsumer<String, String> a);",
+                        "  }",
+                        "  interface Two {",
+                        "    void apply(String a, String b);",
+                        "    void apply(String a);",
+                        "  }",
+                        "  void f(One one, Two two) {",
+                        // Lambda conversion requires a cast which wouldn't necessarily be cleaner.
+                        "    one.call(value -> two.apply(value));",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
 }

--- a/changelog/@unreleased/pr-1432.v2.yml
+++ b/changelog/@unreleased/pr-1432.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid rewriting lambdas into ambiguous references
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1432


### PR DESCRIPTION
## Before this PR
Produced code that did not work in some scenarios.

## After this PR
==COMMIT_MSG==
Avoid rewriting lambdas into ambiguous references
==COMMIT_MSG==

## Possible downsides?
Note that this uses the expensive `SuggestedFixes.compilesWithFix`
check which can result in poor performance, particularly on large
projects.
Fortunately this case isn't very common (no occurrences in a
very large internal project).
