### PR TITLE
Checkstyle: PreferInclusiveLanguage regex

### DIFF
--- a/changelog/@unreleased/pr-1436.v2.yml
+++ b/changelog/@unreleased/pr-1436.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: A new checkstyle regex 'PreferInclusiveLanguage' spots usages of the
+    words 'whitelist', 'blacklist', 'slave' and suggests words that don't have any
+    racial undertones. This check is intended to guide users when names are initially
+    chosen (as this is often easier than renaming things later) - users can add `@SuppressWarnings("PreferInclusiveLanguage")`
+    if it's not practical to fix these straight away.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1436

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -353,6 +353,11 @@
             <property name="ignoreComments" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="id" value="PreferInclusiveLanguage"/>
+            <property name="format" value="(whitelist|blacklist|slave)"/>
+            <property name="message" value="Prefer choosing names that don't have racial undertones, e.g. 'blocklist/allowlist' or 'server/client'"/>
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="\bCharsets\."/>
             <property name="message" value="Use JDK StandardCharsets instead of alternatives."/>
         </module>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -355,7 +355,7 @@
         <module name="RegexpSinglelineJava">
             <property name="id" value="PreferInclusiveLanguage"/>
             <property name="format" value="(whitelist|blacklist|slave)"/>
-            <property name="message" value="Prefer choosing names that don't have racial undertones, e.g. 'blocklist/allowlist' or 'server/client'"/>
+            <property name="message" value="Prefer choosing names that don't have racial undertones, e.g. 'allowlist/blocklist', 'server/client', 'leader/follower', 'primary/secondary', 'replica', 'allow/deny'"/>
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="\bCharsets\."/>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -355,7 +355,7 @@
         <module name="RegexpSinglelineJava">
             <property name="id" value="PreferInclusiveLanguage"/>
             <property name="format" value="(whitelist|blacklist|slave)"/>
-            <property name="message" value="Prefer choosing names that don't have racial undertones, e.g. 'allowlist/blocklist', 'server/client', 'leader/follower', 'primary/secondary', 'replica', 'allow/deny'"/>
+            <property name="message" value="Prefer choosing names that don't have racial undertones, e.g. 'allowlist/blocklist', 'server/client', 'leader/follower', 'primary/secondary', 'replica', 'allow/deny', 'approved/banned'"/>
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="\bCharsets\."/>


### PR DESCRIPTION
## Before this PR

As per @samrogerson's "Improving internal language" email from this morning, the industry is reflecting on the terminology we all use, how it affects members of our community and, in particular, how it can be made more inclusive.
- https://www.drupal.org/node/2275877
- https://twitter.com/natfriedman/status/1271253144442253312
- https://go-review.googlesource.com/c/go/+/236857/

Useful reference: https://developers.google.com/style/word-list

## After this PR
==COMMIT_MSG==
A new checkstyle regex 'PreferInclusiveLanguage' spots usages of the words 'whitelist', 'blacklist', 'slave' and suggests words that don't have any racial undertones. This check is intended to guide users when names are initially chosen (as this is often easier than renaming things later) - users can add `@SuppressWarnings("PreferInclusiveLanguage")` if it's not practical to fix these straight away.
==COMMIT_MSG==

This is obviously not a complete list - people will still need to be thoughtful about how their naming choices affect other people (e.g. ableist language).

## Possible downsides?
- this will likely block baseline upgrades from automerging in a few repos, as humans will need to make changes/suppress