### PR TITLE
Disable FallThrough on Java 14 for switch expressions

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FallThroughTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FallThroughTest.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.errorprone;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.bugpatterns.FallThrough;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+public class FallThroughTest {
+
+    @Test
+    @DisabledForJreRange(max = JRE.JAVA_13)
+    public void testSwitchExpression() {
+        CompilationTestHelper compilationHelper = CompilationTestHelper.newInstance(FallThrough.class, getClass())
+                .setArgs(ImmutableList.of("--enable-preview", "--release", "14"));
+
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "  static void foo(int value) {",
+                        "    switch (value) {",
+                        "      case 42 -> {}",
+                        "      // BUG: Diagnostic matches: X",
+                        "      default -> {}",
+                        "    };",
+                        "  }",
+                        "}")
+                .expectErrorMessage("X", input -> input.contains("Execution may fall through from the previous case"))
+                .doTest();
+    }
+}

--- a/changelog/@unreleased/pr-1442.v2.yml
+++ b/changelog/@unreleased/pr-1442.v2.yml
@@ -1,14 +1,5 @@
 type: improvement
 improvement:
-  description: |-
-    Disable FallThrough on Java 14 for switch expressions
-
-    ## Before this PR
-    There is a false negative with `FallThrough` on Java 14 when using switch expressions where the case arms are statements (as opposed to expressions).
-
-    See https://github.com/google/error-prone/issues/1649.
-
-    ## After this PR
-    Disable `FallThrough` on Java 14 source to avoid false positives
+  description: Disable `FallThrough` on Java 14 source to avoid false positives
   links:
   - https://github.com/palantir/gradle-baseline/pull/1442

--- a/changelog/@unreleased/pr-1442.v2.yml
+++ b/changelog/@unreleased/pr-1442.v2.yml
@@ -1,0 +1,14 @@
+type: improvement
+improvement:
+  description: |-
+    Disable FallThrough on Java 14 for switch expressions
+
+    ## Before this PR
+    There is a false negative with `FallThrough` on Java 14 when using switch expressions where the case arms are statements (as opposed to expressions).
+
+    See https://github.com/google/error-prone/issues/1649.
+
+    ## After this PR
+    Disable `FallThrough` on Java 14 source to avoid false positives
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1442

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -210,6 +210,14 @@ public final class BaselineErrorProne implements Plugin<Project> {
                         "%s%s(build|src%sgenerated.*)%s.*",
                         Pattern.quote(projectPath), separator, separator, separator));
 
+        // FallThrough does not currently work with switch expressions
+        // See https://github.com/google/error-prone/issues/1649
+        errorProneOptions.check("FallThrough", project.provider(() -> {
+            JavaPluginExtension ext = project.getExtensions().getByType(JavaPluginExtension.class);
+            return ext.getSourceCompatibility().compareTo(JavaVersion.toVersion(14)) < 0
+                    ? CheckSeverity.DEFAULT
+                    : CheckSeverity.OFF;
+        }));
         // UnnecessaryParentheses does not currently work with switch expressions
         errorProneOptions.check("UnnecessaryParentheses", project.provider(() -> {
             JavaPluginExtension ext = project.getExtensions().getByType(JavaPluginExtension.class);


### PR DESCRIPTION
Related to https://github.com/palantir/gradle-baseline/pull/1413

## Before this PR
There is a false negative with `FallThrough` on Java 14 when using switch expressions where the case arms are statements (as opposed to expressions).

See https://github.com/google/error-prone/issues/1649.

## After this PR
Disable `FallThrough` on Java 14.