### PR TITLE
add TooManyArguments errorprone rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `OptionalFlatMapOfNullable`: Optional.map functions may return null to safely produce an empty result.
 - `ExtendsErrorOrThrowable`: Avoid extending Error (or subclasses of it) or Throwable directly.
 - `ImmutablesStyleCollision`: Prevent unintentionally voiding immutables Style meta-annotations through the introduction of inline style annotations.
+- `TooManyArguments`: Prefer Interface that take few arguments rather than many.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TooManyArguments.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TooManyArguments.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.LinkType;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "TooManyArguments",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = LinkType.CUSTOM,
+        providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
+        severity = SeverityLevel.WARNING,
+        summary = "Prefer Interface that take few arguments rather than many.")
+public final class TooManyArguments extends BugChecker implements BugChecker.MethodTreeMatcher {
+    private static final int MAX_NUM_ARGS = 10;
+    public static final Matcher<Tree> IS_OVERRIDE = Matchers.hasAnnotation(Override.class);
+
+    @Override
+    public Description matchMethod(MethodTree tree, VisitorState state) {
+        if (IS_OVERRIDE.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+        Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(tree);
+        if (symbol == null || symbol.isConstructor()) {
+            return Description.NO_MATCH;
+        }
+
+        if (tree.getParameters().size() > MAX_NUM_ARGS) {
+            return buildDescription(tree)
+                    .setMessage("Interfaces can take at most " + MAX_NUM_ARGS + " arguments.")
+                    .build();
+        }
+
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TooManyArguments.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TooManyArguments.java
@@ -55,7 +55,10 @@ public final class TooManyArguments extends BugChecker implements BugChecker.Met
 
         if (tree.getParameters().size() > MAX_NUM_ARGS) {
             return buildDescription(tree)
-                    .setMessage("Interfaces can take at most " + MAX_NUM_ARGS + " arguments.")
+                    .setMessage("Interfaces can take at most " + MAX_NUM_ARGS
+                            + " arguments. Consider the following ways of soling the problem:\n"
+                            + "- Define an object with Immutables that contains all of the arguments\n"
+                            + "- Expose smaller interfaces by refactorings concepts into separate interfaces")
                     .build();
         }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TooManyArguments.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TooManyArguments.java
@@ -41,7 +41,7 @@ import com.sun.tools.javac.code.Symbol;
         summary = "Prefer Interface that take few arguments rather than many.")
 public final class TooManyArguments extends BugChecker implements BugChecker.MethodTreeMatcher {
     private static final int MAX_NUM_ARGS = 10;
-    public static final Matcher<Tree> IS_OVERRIDE = Matchers.hasAnnotation(Override.class);
+    private static final Matcher<Tree> IS_OVERRIDE = Matchers.hasAnnotation(Override.class);
 
     @Override
     public Description matchMethod(MethodTree tree, VisitorState state) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/TooManyArgumentsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/TooManyArgumentsTest.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+class TooManyArgumentsTest {
+
+    @Test
+    void detects_large_method() {
+        compilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "  // BUG: Diagnostic contains: [TooManyArguments] Interfaces can take at most",
+                        "  public void foo(int a1, int a2, int a3, int a4, int a5, int a6, "
+                                + "int a7, int a8, int a9, int a10, int a11) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void ignores_regular_method() {
+        compilationHelper()
+                .addSourceLines("Test.java", "class Test {", "  public void foo(int a1) {}", "}")
+                .doTest();
+    }
+
+    @Test
+    void ignores_constructor() {
+        compilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "  public Test(int a1, int a2, int a3, int a4, int a5, int a6, "
+                                + "int a7, int a8, int a9, int a10, int a11) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void ignores_implementations() {
+        compilationHelper()
+                .addSourceLines(
+                        "BadInterface.java",
+                        "interface BadInterface {",
+                        "  // BUG: Diagnostic contains: [TooManyArguments] Interfaces can take at most",
+                        "  void foo(int a1, int a2, int a3, int a4, int a5, int a6, "
+                                + "int a7, int a8, int a9, int a10, int a11);",
+                        "}")
+                .addSourceLines(
+                        "Test.java",
+                        "import " + Override.class.getName() + ";",
+                        "class Test implements BadInterface {",
+                        "  @Override",
+                        "  public void foo(int a1, int a2, int a3, int a4, int a5, int a6, "
+                                + "int a7, int a8, int a9, int a10, int a11) {}",
+                        "}")
+                .doTest();
+    }
+
+    private CompilationTestHelper compilationHelper() {
+        return CompilationTestHelper.newInstance(TooManyArguments.class, getClass());
+    }
+}

--- a/changelog/@unreleased/pr-1447.v2.yml
+++ b/changelog/@unreleased/pr-1447.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add `TooManyArguments` errorprone rule which prevents interfaces from
+    having more than 10 arguments
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1447


### PR DESCRIPTION
## Before this PR
Users could define unwieldy interfaces that took a large number of parameters.

## After this PR
==COMMIT_MSG==
Add `TooManyArguments` errorprone rule which prevents interfaces from having more than 10 arguments
==COMMIT_MSG==

## Possible downsides?
There are definitely cases of people with larger interfaces so upgrades will be blocked and manual action will be required

