### PR TITLE
Fix typo in TooManyArguments check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TooManyArguments.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TooManyArguments.java
@@ -56,7 +56,7 @@ public final class TooManyArguments extends BugChecker implements BugChecker.Met
         if (tree.getParameters().size() > MAX_NUM_ARGS) {
             return buildDescription(tree)
                     .setMessage("Interfaces can take at most " + MAX_NUM_ARGS
-                            + " arguments. Consider the following ways of soling the problem:\n"
+                            + " arguments. Consider the following ways of solving the problem:\n"
                             + "- Define an object with Immutables that contains all of the arguments\n"
                             + "- Expose smaller interfaces by refactorings concepts into separate interfaces")
                     .build();

--- a/changelog/@unreleased/pr-1449.v2.yml
+++ b/changelog/@unreleased/pr-1449.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix typo in TooManyArguments check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1449


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The error message for TooManyArguments had a typo in it.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix typo in TooManyArguments check
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

