### PR TITLE
Ignore case in checkstyle TODO rule

### DIFF
--- a/changelog/@unreleased/pr-1456.v2.yml
+++ b/changelog/@unreleased/pr-1456.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make TODO checkstyle rule case insensitive to catch lowercase TODO comments
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1456

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -367,6 +367,7 @@
         <module name="RegexpSinglelineJava">
             <property name="format" value="\/\/TODO|\/\/ TODO(?!\([^()\s]+\): )"/>
             <property name="message" value="TODO format: // TODO(#issue): explanation"/>
+            <property name="ignoreCase" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>


### PR DESCRIPTION
## Before this PR
TODO comments of the form `// TODO: something` are disallowed, but the rule is case sensitive so `// todo: something` doesn't get caught.

## After this PR
==COMMIT_MSG==
Make TODO checkstyle rule case insensitive
==COMMIT_MSG==

I found 19 results in our product repos that would be blocked by this change based on a simple (incomplete) regex.

An alternative approach would be to leave it case sensitive and add a separate rule that disallows lower-case TODO rules, but that would affect more repos.

==MERGE_WHEN_READY==