### PR TITLE
feature: add LogsafeArgName errorprone rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `ImmutablesStyleCollision`: Prevent unintentionally voiding immutables Style meta-annotations through the introduction of inline style annotations.
 - `TooManyArguments`: Prefer Interface that take few arguments rather than many.
 - `PreferStaticLoggers`: Prefer static loggers over instance loggers.
+- `LogsafeArgName`: Prevent certain named arguments as being logged as safe. Specify unsafe argument names using `LogsafeArgName:UnsafeArgNames` errorProne flag.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
@@ -25,6 +25,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
@@ -74,11 +75,11 @@ public final class LogsafeArgName extends BugChecker implements MethodInvocation
         if (compileTimeConstExpressionMatcher.matches(argNameExpression, state)) {
             String argName = (String) ((JCTree.JCLiteral) argNameExpression).getValue();
             if (unsafeParamNames.stream().anyMatch(unsafeArgName -> unsafeArgName.equalsIgnoreCase(argName))) {
+                SuggestedFix.Builder builder = SuggestedFix.builder();
+                String unsafeArg = SuggestedFixes.qualifyType(state, builder, "com.palantir.logsafe.UnsafeArg");
                 return buildDescription(tree)
                         .setMessage("Arguments with name '" + argName + "' must be marked as unsafe.")
-                        .addFix(SuggestedFix.builder()
-                                .replace(tree.getMethodSelect(), "UnsafeArg.of")
-                                .addImport("com.palantir.logsafe.UnsafeArg")
+                        .addFix(builder.replace(tree.getMethodSelect(), unsafeArg + ".of")
                                 .build())
                         .build();
             }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.ErrorProneFlags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.List;
+import java.util.Set;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "LogsafeArgName",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
+        severity = SeverityLevel.ERROR,
+        summary = "Prevent certain argument names from being logged as safe.")
+public final class LogsafeArgName extends BugChecker implements MethodInvocationTreeMatcher {
+    static final String UNSAFE_ARG_NAMES_FLAG = "LogsafeArgName:UnsafeArgNames";
+
+    private static final Matcher<ExpressionTree> SAFE_ARG_OF =
+            Matchers.staticMethod().onClass("com.palantir.logsafe.SafeArg").named("of");
+    private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
+            new CompileTimeConstantExpressionMatcher();
+
+    private final Set<String> unsafeParamNames;
+
+    // Must have default constructor for service loading to work correctly
+    public LogsafeArgName() {
+        this.unsafeParamNames = ImmutableSet.of();
+    }
+
+    public LogsafeArgName(ErrorProneFlags flags) {
+        this.unsafeParamNames =
+                flags.getList(UNSAFE_ARG_NAMES_FLAG).map(ImmutableSet::copyOf).orElseGet(ImmutableSet::of);
+    }
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (unsafeParamNames.isEmpty() || !SAFE_ARG_OF.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        List<? extends ExpressionTree> args = tree.getArguments();
+        ExpressionTree argNameExpression = args.get(0);
+        if (compileTimeConstExpressionMatcher.matches(argNameExpression, state)) {
+            String argName = (String) ((JCTree.JCLiteral) argNameExpression).getValue();
+            if (unsafeParamNames.stream().anyMatch(unsafeArgName -> unsafeArgName.equalsIgnoreCase(argName))) {
+                return buildDescription(tree)
+                        .setMessage("Arguments with name '" + argName + "' must be marked as unsafe.")
+                        .addFix(SuggestedFix.builder()
+                                .replace(tree.getMethodSelect(), "UnsafeArg.of")
+                                .addImport("com.palantir.logsafe.UnsafeArg")
+                                .build())
+                        .build();
+            }
+        }
+
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
@@ -19,27 +19,13 @@ package com.palantir.baseline.errorprone;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.ErrorProneFlags;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class LogsafeArgNameTest {
-    private CompilationTestHelper compilationHelper;
-    private RefactoringValidator refactoringHelper;
-
-    @BeforeEach
-    public void before() {
-        compilationHelper = CompilationTestHelper.newInstance(LogsafeArgName.class, getClass())
-                .setArgs(ImmutableList.of("-XepOpt:" + LogsafeArgName.UNSAFE_ARG_NAMES_FLAG + "=foo,bar"));
-        refactoringHelper = RefactoringValidator.of(
-                new LogsafeArgName(ErrorProneFlags.builder()
-                        .putFlag(LogsafeArgName.UNSAFE_ARG_NAMES_FLAG, "foo,bar")
-                        .build()),
-                getClass());
-    }
 
     @Test
     public void catches_unsafe_arg_name() {
-        compilationHelper
+        getCompilationHelper()
                 .addSourceLines(
                         "Test.java",
                         "import com.palantir.logsafe.SafeArg;",
@@ -55,7 +41,7 @@ public final class LogsafeArgNameTest {
 
     @Test
     public void catches_case_insensitive_unsafe_arg_name() {
-        compilationHelper
+        getCompilationHelper()
                 .addSourceLines(
                         "Test.java",
                         "import com.palantir.logsafe.SafeArg;",
@@ -71,7 +57,7 @@ public final class LogsafeArgNameTest {
 
     @Test
     public void fixes_unsafe_arg_name() {
-        refactoringHelper
+        getRefactoringHelper()
                 .addInputLines(
                         "Test.java",
                         "import com.palantir.logsafe.SafeArg;",
@@ -96,7 +82,7 @@ public final class LogsafeArgNameTest {
 
     @Test
     public void ignores_safe_arg_names() {
-        compilationHelper
+        getCompilationHelper()
                 .addSourceLines(
                         "Test.java",
                         "import com.palantir.logsafe.SafeArg;",
@@ -107,5 +93,18 @@ public final class LogsafeArgNameTest {
                         "",
                         "}")
                 .doTest();
+    }
+
+    private static RefactoringValidator getRefactoringHelper() {
+        return RefactoringValidator.of(
+                new LogsafeArgName(ErrorProneFlags.builder()
+                        .putFlag(LogsafeArgName.UNSAFE_ARG_NAMES_FLAG, "foo,bar")
+                        .build()),
+                LogsafeArgNameTest.class);
+    }
+
+    private static CompilationTestHelper getCompilationHelper() {
+        return CompilationTestHelper.newInstance(LogsafeArgName.class, LogsafeArgNameTest.class)
+                .setArgs(ImmutableList.of("-XepOpt:" + LogsafeArgName.UNSAFE_ARG_NAMES_FLAG + "=foo,bar"));
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.ErrorProneFlags;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class LogsafeArgNameTest {
+    private CompilationTestHelper compilationHelper;
+    private RefactoringValidator refactoringHelper;
+
+    @BeforeEach
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(LogsafeArgName.class, getClass())
+                .setArgs(ImmutableList.of("-XepOpt:" + LogsafeArgName.UNSAFE_ARG_NAMES_FLAG + "=foo,bar"));
+        refactoringHelper = RefactoringValidator.of(
+                new LogsafeArgName(ErrorProneFlags.builder()
+                        .putFlag(LogsafeArgName.UNSAFE_ARG_NAMES_FLAG, "foo,bar")
+                        .build()),
+                getClass());
+    }
+
+    @Test
+    public void catches_unsafe_arg_name() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "class Test {",
+                        "  void f() {",
+                        "    // BUG: Diagnostic contains: must be marked as unsafe",
+                        "    SafeArg.of(\"foo\", 1);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void catches_case_insensitive_unsafe_arg_name() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "class Test {",
+                        "  void f() {",
+                        "    // BUG: Diagnostic contains: must be marked as unsafe",
+                        "    SafeArg.of(\"Foo\", 1);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void fixes_unsafe_arg_name() {
+        refactoringHelper
+                .addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "class Test {",
+                        "  void f() {",
+                        "    SafeArg.of(\"Foo\", 1);",
+                        "  }",
+                        "",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.logsafe.UnsafeArg;",
+                        "class Test {",
+                        "  void f() {",
+                        "    UnsafeArg.of(\"Foo\", 1);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void ignores_safe_arg_names() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "class Test {",
+                        "  void f() {",
+                        "    SafeArg.of(\"baz\", 1);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+}

--- a/changelog/@unreleased/pr-1459.v2.yml
+++ b/changelog/@unreleased/pr-1459.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: add LogsafeArgName errorprone rule which allows users to specify a
+    list of argument names that must always be tagged as unsafe.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1459

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -30,14 +30,15 @@ public class BaselineErrorProneExtension {
             // Baseline checks
             "BracesRequired",
             "CatchBlockLogException",
-            "CollectionStreamForEach",
             // TODO(ckozak): re-enable pending scala check
             // "CatchSpecificity",
-            "ExtendsErrorOrThrowable",
+            "CollectionStreamForEach",
             "ExecutorSubmitRunnableFutureIgnored",
+            "ExtendsErrorOrThrowable",
             "FinalClass",
             "LambdaMethodReference",
             "LoggerEnclosingClass",
+            "LogsafeArgName",
             "OptionalFlatMapOfNullable",
             "OptionalOrElseMethodInvocation",
             "PreferBuiltInConcurrentKeySet",


### PR DESCRIPTION
## Before this PR
Occasionally developers would incorrectly tag a known unsafe parameter (ex. branch, username) as safe. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
add LogsafeArgName errorprone rule which allows users to specify a list of argument names that must always be tagged as unsafe.
==COMMIT_MSG==

This isn't a perfect solution since developers may use a different name for an unsafe value, but this should help catch some cases.

The expectation is that we will configure the set of unsafe arg names internally.

## Possible downsides?
N/A

