### PR TITLE
fix: logsafe argname is resilient to static final identifiers

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
@@ -72,7 +72,8 @@ public final class LogsafeArgName extends BugChecker implements MethodInvocation
 
         List<? extends ExpressionTree> args = tree.getArguments();
         ExpressionTree argNameExpression = args.get(0);
-        if (compileTimeConstExpressionMatcher.matches(argNameExpression, state)) {
+        if (compileTimeConstExpressionMatcher.matches(argNameExpression, state)
+                && argNameExpression instanceof JCTree.JCLiteral) {
             String argName = (String) ((JCTree.JCLiteral) argNameExpression).getValue();
             if (unsafeParamNames.stream().anyMatch(unsafeArgName -> unsafeArgName.equalsIgnoreCase(argName))) {
                 SuggestedFix.Builder builder = SuggestedFix.builder();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
@@ -95,6 +95,22 @@ public final class LogsafeArgNameTest {
                 .doTest();
     }
 
+    @Test
+    void ignores_identifiers() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "class Test {",
+                        "  private static final String ARG_NAME = \"foo\";",
+                        "  void f() {",
+                        "    SafeArg.of(ARG_NAME, 1);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
     private static RefactoringValidator getRefactoringHelper() {
         return RefactoringValidator.of(
                 new LogsafeArgName(ErrorProneFlags.builder()

--- a/changelog/@unreleased/pr-1464.v2.yml
+++ b/changelog/@unreleased/pr-1464.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: logsafe argname is resilient to static final identifiers
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1464


### PR DESCRIPTION
Closes #1463 
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
logsafe argname is resilient to static final identifiers
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

