### PR TITLE
Ignore non-literal arg names in LogsafeArgName

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
@@ -73,15 +73,17 @@ public final class LogsafeArgName extends BugChecker implements MethodInvocation
         List<? extends ExpressionTree> args = tree.getArguments();
         ExpressionTree argNameExpression = args.get(0);
         if (compileTimeConstExpressionMatcher.matches(argNameExpression, state)) {
-            String argName = (String) ((JCTree.JCLiteral) argNameExpression).getValue();
-            if (unsafeParamNames.stream().anyMatch(unsafeArgName -> unsafeArgName.equalsIgnoreCase(argName))) {
-                SuggestedFix.Builder builder = SuggestedFix.builder();
-                String unsafeArg = SuggestedFixes.qualifyType(state, builder, "com.palantir.logsafe.UnsafeArg");
-                return buildDescription(tree)
-                        .setMessage("Arguments with name '" + argName + "' must be marked as unsafe.")
-                        .addFix(builder.replace(tree.getMethodSelect(), unsafeArg + ".of")
-                                .build())
-                        .build();
+            if (argNameExpression instanceof JCTree.JCLiteral) {
+                String argName = (String) ((JCTree.JCLiteral) argNameExpression).getValue();
+                if (unsafeParamNames.stream().anyMatch(unsafeArgName -> unsafeArgName.equalsIgnoreCase(argName))) {
+                    SuggestedFix.Builder builder = SuggestedFix.builder();
+                    String unsafeArg = SuggestedFixes.qualifyType(state, builder, "com.palantir.logsafe.UnsafeArg");
+                    return buildDescription(tree)
+                            .setMessage("Arguments with name '" + argName + "' must be marked as unsafe.")
+                            .addFix(builder.replace(tree.getMethodSelect(), unsafeArg + ".of")
+                                    .build())
+                            .build();
+                }
             }
         }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
@@ -26,7 +26,6 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
-import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -49,8 +48,6 @@ public final class LogsafeArgName extends BugChecker implements MethodInvocation
 
     private static final Matcher<ExpressionTree> SAFE_ARG_OF =
             Matchers.staticMethod().onClass("com.palantir.logsafe.SafeArg").named("of");
-    private final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
-            new CompileTimeConstantExpressionMatcher();
 
     private final Set<String> unsafeParamNames;
 
@@ -72,8 +69,7 @@ public final class LogsafeArgName extends BugChecker implements MethodInvocation
 
         List<? extends ExpressionTree> args = tree.getArguments();
         ExpressionTree argNameExpression = args.get(0);
-        if (compileTimeConstExpressionMatcher.matches(argNameExpression, state)
-                && argNameExpression instanceof JCTree.JCLiteral) {
+        if (argNameExpression instanceof JCTree.JCLiteral) {
             String argName = (String) ((JCTree.JCLiteral) argNameExpression).getValue();
             if (unsafeParamNames.stream().anyMatch(unsafeArgName -> unsafeArgName.equalsIgnoreCase(argName))) {
                 SuggestedFix.Builder builder = SuggestedFix.builder();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeArgName.java
@@ -72,18 +72,17 @@ public final class LogsafeArgName extends BugChecker implements MethodInvocation
 
         List<? extends ExpressionTree> args = tree.getArguments();
         ExpressionTree argNameExpression = args.get(0);
-        if (compileTimeConstExpressionMatcher.matches(argNameExpression, state)) {
-            if (argNameExpression instanceof JCTree.JCLiteral) {
-                String argName = (String) ((JCTree.JCLiteral) argNameExpression).getValue();
-                if (unsafeParamNames.stream().anyMatch(unsafeArgName -> unsafeArgName.equalsIgnoreCase(argName))) {
-                    SuggestedFix.Builder builder = SuggestedFix.builder();
-                    String unsafeArg = SuggestedFixes.qualifyType(state, builder, "com.palantir.logsafe.UnsafeArg");
-                    return buildDescription(tree)
-                            .setMessage("Arguments with name '" + argName + "' must be marked as unsafe.")
-                            .addFix(builder.replace(tree.getMethodSelect(), unsafeArg + ".of")
-                                    .build())
-                            .build();
-                }
+        if (compileTimeConstExpressionMatcher.matches(argNameExpression, state)
+                && argNameExpression instanceof JCTree.JCLiteral) {
+            String argName = (String) ((JCTree.JCLiteral) argNameExpression).getValue();
+            if (unsafeParamNames.stream().anyMatch(unsafeArgName -> unsafeArgName.equalsIgnoreCase(argName))) {
+                SuggestedFix.Builder builder = SuggestedFix.builder();
+                String unsafeArg = SuggestedFixes.qualifyType(state, builder, "com.palantir.logsafe.UnsafeArg");
+                return buildDescription(tree)
+                        .setMessage("Arguments with name '" + argName + "' must be marked as unsafe.")
+                        .addFix(builder.replace(tree.getMethodSelect(), unsafeArg + ".of")
+                                .build())
+                        .build();
             }
         }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeArgNameTest.java
@@ -95,6 +95,23 @@ public final class LogsafeArgNameTest {
                 .doTest();
     }
 
+    @Test
+    public void ignores_identifier_arg_names() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import java.lang.String;",
+                        "class Test {",
+                        "  static final String NAME = \"name\";",
+                        "  void f() {",
+                        "    SafeArg.of(NAME, 1);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
     private static RefactoringValidator getRefactoringHelper() {
         return RefactoringValidator.of(
                 new LogsafeArgName(ErrorProneFlags.builder()

--- a/changelog/@unreleased/pr-1465.v2.yml
+++ b/changelog/@unreleased/pr-1465.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: The `LogsafeArgName` now ignores arg names that are not literals.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1465


### PR DESCRIPTION
## Before this PR
The `LogsafeArgName` check would fail if using a compile time constant identifier (static final variables) for args names.

This fails with the following exception:
```
java.lang.AssertionError: An unhandled exception was thrown by the Error Prone static analysis plugin.
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.4.0
     BugPattern: LogsafeArgName
     Stack Trace:
     java.lang.ClassCastException: class com.sun.tools.javac.tree.JCTree$JCIdent cannot be cast to class com.sun.tools.javac.tree.JCTree$JCLiteral (com.sun.tools.javac.tree.JCTree$JCIdent and com.sun.tools.javac.tree.JCTree$JCLiteral are in module jdk.compiler of loader 'app')
  	at com.palantir.baseline.errorprone.LogsafeArgName.matchMethodInvocation(LogsafeArgName.java:77)
  	at com.google.errorprone.scanner.ErrorProneScanner.processMatchers(ErrorProneScanner.java:451)
```

## After this PR
The `LogsafeArgName` ignores arg names that are not literals.

