### PR TITLE
Don't allow compileCopy to be resolvable

### DIFF
--- a/changelog/@unreleased/pr-1469.v2.yml
+++ b/changelog/@unreleased/pr-1469.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`baseline-exact-dependencies` ensures `compileCopy` configuration
+    it creates is not resolvable, so it can''t be resolved accidentally.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1469

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -139,6 +139,11 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         project.afterEvaluate(p -> {
             Configuration implCopy = implementation.copy();
             Configuration compileCopy = compile.copy();
+            // Ensure it's not resolvable, otherwise plugins that resolve all configurations might have
+            // a bad time resolving this with GCV, if you have direct dependencies without corresponding entries in
+            // versions.props, but instead rely on getting a version for them from the lock file.
+            compileCopy.setCanBeResolved(false);
+            compileCopy.setCanBeConsumed(false);
             // Without these, explicitCompile will successfully resolve 0 files and you'll waste 1 hour trying
             // to figure out why.
             project.getConfigurations().add(implCopy);


### PR DESCRIPTION
## Before this PR

`baseline-exact-dependencies` creates a configuration `compileCopy` which is resolvable, but might not actually successfully resolve when using GCV in certain circumstances.
This configuration shouldn't be resolvable.

## After this PR
==COMMIT_MSG==
`baseline-exact-dependencies` ensures `compileCopy` configuration it creates is not resolvable, so it can't be resolved accidentally.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

