### PR TITLE
BaselineClassUniqueness locks test classpaths by default

### DIFF
--- a/changelog/@unreleased/pr-1475.v2.yml
+++ b/changelog/@unreleased/pr-1475.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: BaselineClassUniqueness locks test classpaths by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1475

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock
@@ -28,4 +28,31 @@
   - javax.el.PropertyNotWritableException
   - javax.el.ResourceBundleELResolver
   - javax.el.ValueExpression
+  - javax.el.VariableMapper## testRuntimeClasspath
+[javax.el:javax.el-api, javax.servlet.jsp:jsp-api]
+  - javax.el.ArrayELResolver
+  - javax.el.BeanELResolver
+  - javax.el.BeanELResolver$BeanProperties
+  - javax.el.BeanELResolver$BeanProperty
+  - javax.el.CompositeELResolver
+  - javax.el.CompositeELResolver$CompositeIterator
+  - javax.el.ELContext
+  - javax.el.ELContextEvent
+  - javax.el.ELContextListener
+  - javax.el.ELException
+  - javax.el.ELResolver
+  - javax.el.ELUtil
+  - javax.el.ELUtil$1
+  - javax.el.Expression
+  - javax.el.ExpressionFactory
+  - javax.el.FunctionMapper
+  - javax.el.ListELResolver
+  - javax.el.MapELResolver
+  - javax.el.MethodExpression
+  - javax.el.MethodInfo
+  - javax.el.MethodNotFoundException
+  - javax.el.PropertyNotFoundException
+  - javax.el.PropertyNotWritableException
+  - javax.el.ResourceBundleELResolver
+  - javax.el.ValueExpression
   - javax.el.VariableMapper


### PR DESCRIPTION
## Before this PR
Some projects manually opt into locking test dependency uniqueness.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
BaselineClassUniqueness locks test classpaths by default
==COMMIT_MSG==

## Possible downsides?
Test runtime mostly duplicates runtime, but not always.
This may create noise for projects where duplicate jars aren't actively causing problems (yet).

