### PR TITLE
Fix baseline-exact-dependencies with new GCV

### DIFF
--- a/changelog/@unreleased/pr-1487.v2.yml
+++ b/changelog/@unreleased/pr-1487.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix `com.palantir.baseline-exact-dependencies` to work with GCV 1.26.0+.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1487

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -157,7 +157,9 @@ public final class BaselineExactDependencies implements Plugin<Project> {
             // but we can rely on this since we control GCV.
             // Alternatively, we could tell GCV to lock this configuration, at the cost of a slightly more
             // expensive 'unifiedClasspath' resolution during lock computation.
-            explicitCompile.extendsFrom(project.getConfigurations().getByName("lockConstraints"));
+            if (project.getRootProject().getPluginManager().hasPlugin("com.palantir.versions-lock")) {
+                explicitCompile.extendsFrom(project.getConfigurations().getByName("lockConstraints"));
+            }
             // Inherit the excludes from compileClasspath too (that get aggregated from all its super-configurations).
             compileClasspath.getExcludeRules().forEach(rule -> explicitCompile.exclude(excludeRuleAsMap(rule)));
         });

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -153,9 +153,11 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         });
 
         explicitCompile.withDependencies(deps -> {
-            // Mirror the transitive constraints form compileClasspath in order to pick up GCV locks.
-            // We should really do this with an addAllLater but that would require Gradle 6, or a hacky workaround.
-            explicitCompile.getDependencyConstraints().addAll(compileClasspath.getAllDependencyConstraints());
+            // Pick up GCV locks. We're making an internal assumption that this configuration exists,
+            // but we can rely on this since we control GCV.
+            // Alternatively, we could tell GCV to lock this configuration, at the cost of a slightly more
+            // expensive 'unifiedClasspath' resolution during lock computation.
+            explicitCompile.extendsFrom(project.getConfigurations().getByName("lockConstraints"));
             // Inherit the excludes from compileClasspath too (that get aggregated from all its super-configurations).
             compileClasspath.getExcludeRules().forEach(rule -> explicitCompile.exclude(excludeRuleAsMap(rule)));
         });


### PR DESCRIPTION
## Before this PR

`com.palantir.baseline-exact-dependencies` tries to copy over constraints from `<source-set>CompileClasspath`, in order to pick up versions.lock constraints generated by GCV.

However, after https://github.com/palantir/gradle-consistent-versions/pull/557, these are no longer implemented as explicit constraints inherited by that configuration (which would have shown up in `compileClasspath.getAllDependencyConstraints()`), but instead GCV uses a _dependency_ to a configuration on the root project, which _itself_ holds these constraints in a single centralized place.

This means that the configuration resolved by tasks like `checkUnusedDependenciesMain` etc now lacks `versions.lock` constraints, leading to weird outcomes including flakes.

## After this PR
==COMMIT_MSG==
Fix `com.palantir.baseline-exact-dependencies` to work with GCV 1.26.0+.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

