### PR TITLE
checkstyle 8.33 -> 8.36.1

### DIFF
--- a/changelog/@unreleased/pr-1496.v2.yml
+++ b/changelog/@unreleased/pr-1496.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: checkstyle 8.33 -> 8.36.1, which enables support for new language features
+    like `records`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1496

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java
@@ -29,7 +29,7 @@ import org.gradle.plugins.ide.eclipse.model.EclipseProject;
 /** Configures the Gradle "checkstyle" task with Baseline settings. */
 public final class BaselineCheckstyle extends AbstractBaselinePlugin {
 
-    private static final String DEFAULT_CHECKSTYLE_VERSION = "8.33";
+    private static final String DEFAULT_CHECKSTYLE_VERSION = "8.36.1";
 
     @Override
     public void apply(Project project) {


### PR DESCRIPTION
I tried to use a `record` but got a lame error:

```
[ant:checkstyle] Running Checkstyle 8.33 on 4 files
[ant:checkstyle] [ERROR] /Volumes/git/template-witchcraft/witchcraft-example/src/main/java/com/palantir/witchcraftexample/WitchcraftExampleResource.java:19:12: Method name 'Foo' must match pattern '^[a-z][a-zA-Z0-9_]+$'. [MethodName]
```

## After this PR
I think support was just added to checkstyle in https://github.com/checkstyle/checkstyle/issues/8023 (8.35), but figured we might as well dial up to latest :shrug:.

Release notes here: https://checkstyle.sourceforge.io/releasenotes.html

==COMMIT_MSG==
checkstyle 8.33 -> 8.36.1
==COMMIT_MSG==

I trialled this locally by setting:

```gradle
    checkstyle {
        toolVersion = '8.36.1'
    }
```

## Possible downsides?
- new rules might wreck us in new and exciting ways.

