### PR TITLE
Fix ImmutablesBuilderMissingInitialization on Java 15 when immutables isn't on the classpath

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitialization.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitialization.java
@@ -311,7 +311,7 @@ public final class ImmutablesBuilderMissingInitialization extends BugChecker imp
                                     .tsym
                                     .getQualifiedName()
                                     .contentEquals("org.immutables.value.Generated"))
-                            .flatMap(annotation -> Stream.of(annotation.member(state.getName("generator"))))
+                            .map(annotation -> annotation.member(state.getName("generator")))
                             .filter(Objects::nonNull)
                             .anyMatch(attribute -> Objects.equals(attribute.getValue(), "Immutables"))
                     || extendsImmutablesGeneratedClass(((ClassSymbol) type.tsym).getSuperclass(), state);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitialization.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitialization.java
@@ -46,7 +46,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.immutables.value.Generated;
 
 /**
  * Checks that all required fields in an immutables.org generated builder have been populated.
@@ -307,9 +306,15 @@ public final class ImmutablesBuilderMissingInitialization extends BugChecker imp
      */
     private static boolean extendsImmutablesGeneratedClass(Type type, VisitorState state) {
         if (type.tsym instanceof ClassSymbol) {
-            return Optional.ofNullable(type.tsym.getAnnotation(Generated.class))
-                    .map(generated -> generated.generator().equals("Immutables"))
-                    .orElseGet(() -> extendsImmutablesGeneratedClass(((ClassSymbol) type.tsym).getSuperclass(), state));
+            return type.tsym.getRawAttributes().stream()
+                            .filter(compound -> compound.type
+                                    .tsym
+                                    .getQualifiedName()
+                                    .contentEquals("org.immutables.value.Generated"))
+                            .flatMap(annotation -> Stream.of(annotation.member(state.getName("generator"))))
+                            .filter(Objects::nonNull)
+                            .anyMatch(attribute -> Objects.equals(attribute.getValue(), "Immutables"))
+                    || extendsImmutablesGeneratedClass(((ClassSymbol) type.tsym).getSuperclass(), state);
         }
         return false;
     }

--- a/changelog/@unreleased/pr-1507.v2.yml
+++ b/changelog/@unreleased/pr-1507.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix ImmutablesBuilderMissingInitialization in java15
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1507


### PR DESCRIPTION
## Before this PR
The ImmutablesBuilderMissingInitialization check consistently fails with java 15 (but not <=14) if the immutables annotation jar isn't available on the classpath, such as in tests.

## After this PR
==COMMIT_MSG==
Fix ImmutablesBuilderMissingInitialization in java15
==COMMIT_MSG==

This fixes the issue because it now accesses the attributes directly from the AST rather than trying to reflectively instantiate the annotation to access the attributes. I'm not sure why this is java 15 specific...