### PR TITLE
error-prone UnnecessarilyQualified

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `LogsafeArgName`: Prevent certain named arguments as being logged as safe. Specify unsafe argument names using `LogsafeArgName:UnsafeArgNames` errorProne flag.
 - `ImplicitPublicBuilderConstructor`: Prevent builders from unintentionally leaking public constructors.
 - `ImmutablesBuilderMissingInitialization`: Prevent building Immutables.org builders when not all fields have been populated.
+- `UnnecessarilyQualified`: Types should not be qualified if they are also imported. 
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnnecessarilyQualified.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/UnnecessarilyQualified.java
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.LinkType;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.MemberSelectTree;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "UnnecessarilyQualified",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = LinkType.CUSTOM,
+        providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
+        severity = SeverityLevel.WARNING,
+        summary = "Types should not be qualified if they are also imported")
+public final class UnnecessarilyQualified extends BugChecker implements BugChecker.MemberSelectTreeMatcher {
+
+    @Override
+    public Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
+        String nameString = state.getSourceForNode(tree);
+        if (nameString == null) {
+            return Description.NO_MATCH;
+        }
+        CompilationUnitTree compilationUnitTree =
+                ASTHelpers.findEnclosingNode(state.getPath(), CompilationUnitTree.class);
+        if (compilationUnitTree == null || ASTHelpers.findEnclosingNode(state.getPath(), ImportTree.class) != null) {
+            return Description.NO_MATCH;
+        }
+
+        for (ImportTree importTree : compilationUnitTree.getImports()) {
+            if (!importTree.isStatic()
+                    && nameString.equals(state.getSourceForNode(importTree.getQualifiedIdentifier()))) {
+                SuggestedFix.Builder fix = SuggestedFix.builder();
+                String treeSource = state.getSourceForNode(tree);
+                String updated = treeSource.replace(nameString, SuggestedFixes.qualifyType(state, fix, nameString));
+                return buildDescription(tree)
+                        .addFix(fix.replace(tree, updated).build())
+                        .build();
+            }
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessarilyQualifiedTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessarilyQualifiedTest.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+class UnnecessarilyQualifiedTest {
+
+    @Test
+    void testUnnecessarilyQualified() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import java.util.List;",
+                        "import java.util.Set;",
+                        "class Test {",
+                        "  java.util.List<java.util.Set<Object>> get() {",
+                        "    return null;",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.util.List;",
+                        "import java.util.Set;",
+                        "class Test {",
+                        "  List<Set<Object>> get() {",
+                        "    return null;",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testUnnecessarilyQualifiedType() {
+        fix().addInputLines("Test.java", "import java.util.List;", "class Test {", "  java.util.List value;", "}")
+                .addOutputLines("Test.java", "import java.util.List;", "class Test {", "  List value;", "}")
+                .doTest();
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(new UnnecessarilyQualified(), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-1510.v2.yml
+++ b/changelog/@unreleased/pr-1510.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: error-prone UnnecessarilyQualified
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1510

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -60,6 +60,7 @@ public class BaselineErrorProneExtension {
             "StrictUnusedVariable",
             "StringBuilderConstantParameters",
             "ThrowError",
+            "UnnecessarilyQualified",
             "UnnecessaryLambdaArgumentParentheses",
             // TODO(ckozak): re-enable pending scala check
             // "ThrowSpecificity",


### PR DESCRIPTION
## Before this PR
Mixed qualified and unqualified uses of the same type in the same java file.

## After this PR
Note that we don't disallow fully qualified classes, they can be useful when two types with the same simple name are used to avoid ambiguity.

==COMMIT_MSG==
error-prone UnnecessarilyQualified
==COMMIT_MSG==

## Possible downsides?
Might cause code churn, however it makes the code substantially easier to follow, and fixes itself.