### PR TITLE
disable PlaceholderCountMatchesArgumentCount

### DIFF
--- a/changelog/@unreleased/pr-1513.v2.yml
+++ b/changelog/@unreleased/pr-1513.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable intellij's missing slf4j placeholders inspection by default.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1513

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -360,6 +360,8 @@ class BaselineIdea extends AbstractBaselinePlugin {
                         <option name="ignoreObjectMethods" value="false" />
                         <option name="ignoreAnonymousClassMethods" value="false" />
                     </inspection_tool>
+                        
+                    <inspection_tool class="PlaceholderCountMatchesArgumentCount" enabled="false" level="WARNING" enabled_by_default="false" />
                 </profile>
                 <option name="PROJECT_PROFILE" value="Default" />
                 <option name="USE_PROJECT_PROFILE" value="true" />


### PR DESCRIPTION
## Before this PR

Intellij keeps warning about missing placeholders `{}` in our slf4j logs.
However, in the overwhelming majority of places in our code, we use sls logs which don't require placeholders.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Disable intellij's missing slf4j placeholders inspection by default.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

cc @fsamuel-bs 
