### PR TITLE
Promote BoxedPrimitiveEquality and ReferenceEquality

### DIFF
--- a/changelog/@unreleased/pr-1514.v2.yml
+++ b/changelog/@unreleased/pr-1514.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Error-prone's `BoxedPrimitiveEquality` and `ReferenceEquality` checks
+    will now fail the build, as we consider them errors not just warnings.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1514

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -233,7 +233,9 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "StreamResourceLeak",
                 "InputStreamSlowMultibyteRead",
                 "JavaDurationGetSecondsGetNano",
-                "URLEqualsHashCode");
+                "URLEqualsHashCode",
+                "BoxedPrimitiveEquality",
+                "ReferenceEquality");
         // Relax some checks for test code
         if (errorProneOptions.getCompilingTestOnlyCode().get()) {
             errorProneOptions.disable("UnnecessaryLambda");


### PR DESCRIPTION
## Before this PR

@Jolyon-S reported in #dev-foundry-infra that a `Long == Long` snippet of code wasn't flagged by any of our static analysis.

There are existing error-prone checks that can catch this though, but they were just at Warning (which atlasdb didn't opt-in to with `-Werror`.

- https://errorprone.info/bugpattern/ReferenceEquality
- https://errorprone.info/bugpattern/BoxedPrimitiveEquality

## After this PR
==COMMIT_MSG==
Error-prone's `BoxedPrimitiveEquality` and `ReferenceEquality` checks will now fail the build, as we consider them errors not just warnings.
==COMMIT_MSG==

## Possible downsides?

- Every time we promote checks like this there's the danger of introducing unnecessary friction to developers if there are false positives (or harmless cases).  For these two checks though, I don't anticipate there to be lots of false positives, and getting it wrong seems pretty serious.

