### PR TITLE
Fix NPE when checking immutables builders from abstract methods

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitialization.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitialization.java
@@ -238,7 +238,7 @@ public final class ImmutablesBuilderMissingInitialization extends BugChecker imp
     private boolean methodJustConstructsBuilder(
             MethodSymbol methodSymbol, VisitorState state, ClassSymbol immutableClass, ClassSymbol interfaceClass) {
         MethodTree methodTree = ASTHelpers.findMethod(methodSymbol, state);
-        if (methodTree != null) {
+        if (methodTree != null && methodTree.getBody() != null) {
             // Check that the method just contains one statement, which is of the form `return new Something();` or
             // `return ImmutableType.builder();`
             if (methodTree.getBody().getStatements().size() != 1) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitializationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitializationTest.java
@@ -203,6 +203,24 @@ public class ImmutablesBuilderMissingInitializationTest {
     }
 
     @Test
+    public void testPassesWhenBuilderFromInterfaceMethod() {
+        helper().addSourceLines(
+                        "Context.java",
+                        importInterface("Person"),
+                        "public interface Context {",
+                        "    Person.Builder personBuilder();",
+                        "}")
+                .addSourceLines(
+                        "MyTest.java",
+                        "public class MyTest {",
+                        "    public void makePerson(Context context) {",
+                        "        context.personBuilder().build();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testFailsWhenOneMandatoryFieldOmitted() {
         helper().addSourceLines(
                         "MyTest.java",

--- a/changelog/@unreleased/pr-1519.v2.yml
+++ b/changelog/@unreleased/pr-1519.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix null pointer exception when checking immutables builders that are
+    returned from abstract methods
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1519


### PR DESCRIPTION
## Before this PR
The ImmutablesBuilderMissingInitialization check throws a null pointer exception if the builder comes from an abstract method.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix null pointer exception when checking immutables builders that are returned from abstract methods
==COMMIT_MSG==

Fixes https://github.com/palantir/gradle-baseline/issues/1518