### PR TITLE
Always set JVM 8 target in Scala compiler

### DIFF
--- a/changelog/@unreleased/pr-1524.yml
+++ b/changelog/@unreleased/pr-1524.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: No longer set target version for Scala compiler to match that of Java compiler.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1524

--- a/changelog/@unreleased/pr-1524.yml
+++ b/changelog/@unreleased/pr-1524.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: No longer set target version for Scala compiler to match that of Java compiler.
+  description: Always set target version for Scala compiler to JVM 8.
   links:
   - https://github.com/palantir/gradle-baseline/pull/1524

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.plugins;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import groovy.util.Node;
 import groovy.xml.QName;
@@ -29,14 +30,20 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.ScalaSourceSet;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 
 public final class BaselineScalastyle extends AbstractBaselinePlugin {
+    private static final String SCALA_TARGET_VERSION = "jvm-8";
+
     @Override
     public void apply(Project project) {
         this.project = project;
         project.getPluginManager().withPlugin("scala", plugin -> {
             JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+            project.getTasks().withType(ScalaCompile.class).configureEach(scalaCompile -> scalaCompile
+                    .getScalaCompileOptions()
+                    .setAdditionalParameters(ImmutableList.of("-target:" + SCALA_TARGET_VERSION)));
             project.getRootProject().getPluginManager().withPlugin("idea", ideaPlugin -> project.getRootProject()
                     .getExtensions()
                     .configure(
@@ -46,8 +53,7 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                                     javaConvention
                                             .getSourceSets()
                                             .named(SourceSet.MAIN_SOURCE_SET_NAME)
-                                            .get(),
-                                    javaConvention.getTargetCompatibility().toString())));
+                                            .get())));
             project.getPluginManager().apply(ScalaStylePlugin.class);
             TaskCollection<ScalaStyleTask> scalaStyleTasks = project.getTasks().withType(ScalaStyleTask.class);
             scalaStyleTasks.configureEach(scalaStyleTask -> {
@@ -66,7 +72,7 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
         });
     }
 
-    private void configureIdeaPlugin(IdeaModel ideaModel, SourceSet mainSourceSet, String javaVersion) {
+    private void configureIdeaPlugin(IdeaModel ideaModel, SourceSet mainSourceSet) {
         Convention scalaConvention = (Convention) InvokerHelper.getProperty(mainSourceSet, "convention");
         ScalaSourceSet scalaSourceSet = scalaConvention.getPlugin(ScalaSourceSet.class);
         // If scala source directory doesn't contain java files use "JavaThenScala" compilation mode
@@ -77,6 +83,8 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                 ? "JavaThenScala"
                 : "Mixed";
         ideaModel.getProject().getIpr().withXml(xmlProvider -> {
+            // configure target jvm mode
+            String targetJvmVersion = "-target:" + SCALA_TARGET_VERSION;
             Node rootNode = xmlProvider.asNode();
             Node scalaCompilerConf = (Node) rootNode.getAt(new QName("component")).stream()
                     .filter(o -> ((Node) o).attributes().get("name").equals("ScalaCompilerConfiguration"))
@@ -90,6 +98,14 @@ public final class BaselineScalastyle extends AbstractBaselinePlugin {
                     .orElseGet(() -> scalaCompilerConf.appendNode("option"));
             compilerOrder.attributes().put("name", "compileOrder");
             compilerOrder.attributes().put("value", compilerMode);
+            Node parametersNode = (Node) scalaCompilerConf.getAt(new QName("parameters")).stream()
+                    .findFirst()
+                    .orElseGet(() -> scalaCompilerConf.appendNode("parameters"));
+            Node parameter = (Node) parametersNode.getAt(new QName("parameter")).stream()
+                    .filter(o -> ((Node) o).attributes().get("value").equals(targetJvmVersion))
+                    .findFirst()
+                    .orElseGet(() -> parametersNode.appendNode("parameter"));
+            parameter.attributes().put("value", targetJvmVersion);
         });
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineScalastyleTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineScalastyleTest.groovy
@@ -21,6 +21,7 @@ import org.github.ngbinh.scalastyle.ScalaStylePlugin
 import org.github.ngbinh.scalastyle.ScalaStyleTask
 import org.gradle.api.Project
 import org.gradle.api.XmlProvider
+import org.gradle.api.tasks.scala.ScalaCompile
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
@@ -65,6 +66,14 @@ final class BaselineScalastyleTest extends Specification {
         def tasks = project.tasks.withType(ScalaStyleTask.class)
         for (ScalaStyleTask task : tasks) {
             assert task.getSource().getFiles().contains(file)
+        }
+    }
+
+    def configuresTargetJvmVersion() {
+        expect:
+        def tasks = project.tasks.withType(ScalaCompile.class)
+        for (ScalaCompile task : tasks) {
+            assert task.getScalaCompileOptions().getAdditionalParameters().contains("-target:jvm-8")
         }
     }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineScalastyleTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineScalastyleTest.groovy
@@ -21,8 +21,6 @@ import org.github.ngbinh.scalastyle.ScalaStylePlugin
 import org.github.ngbinh.scalastyle.ScalaStyleTask
 import org.gradle.api.Project
 import org.gradle.api.XmlProvider
-import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.tasks.scala.ScalaCompile
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
@@ -67,19 +65,6 @@ final class BaselineScalastyleTest extends Specification {
         def tasks = project.tasks.withType(ScalaStyleTask.class)
         for (ScalaStyleTask task : tasks) {
             assert task.getSource().getFiles().contains(file)
-        }
-    }
-
-    def configuresTargetJvmVersion() {
-        String targetVersion = project.getConvention()
-                .getPlugin(JavaPluginConvention.class)
-                .getTargetCompatibility()
-                .toString()
-
-        expect:
-        def tasks = project.tasks.withType(ScalaCompile.class)
-        for (ScalaCompile task : tasks) {
-            assert task.getScalaCompileOptions().getAdditionalParameters().contains("-target:jvm-" + targetVersion)
         }
     }
 


### PR DESCRIPTION
## Before this PR
Projects with gradle-baseline cannot compile Scala code if they set Java targetCompatibility to 11. The error is:
```
> Task :optimizer-rules:compileScala
'jvm-11' is not a valid choice for '-target'
bad option: '-target:jvm-11'
```

BaselineScalaStyle sets scalac `-target` to match that of javac. However scalac 2.12 only accepts target values up-to `jvm-8` [(see here)](https://github.com/scala/scala/blob/v2.12.12/project/ScalaOptionParser.scala#L109). Scala version 2.13 supports higher targets, but 2.12 was released July this year and we still need to support it.

## After this PR
**Edit:** ~No longer set target version for Scala compiler to match that of Java compiler.~

==COMMIT_MSG==
Always set target version for Scala compiler to JVM 8.
==COMMIT_MSG==

## Possible downsides?
If using scalac 2.13 (which permits `jvm-9+`), this change can result in a lower target version. I don't think that's dangerous but might be overlooking something.

`jvm-7` and lower are [disallowed by 2.12](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#version-compatibility-table) - they wouldn't have been valid targets before. The last 2.11 version was released in 2016.
