### PR TITLE
Use old version-string scheme for Scala compiler target

### DIFF
--- a/changelog/@unreleased/pr-1528.v2.yml
+++ b/changelog/@unreleased/pr-1528.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use old version-string scheme for Scala compiler target (`jvm-1.8` instead of `jvm-8`).
+  links:
+    - https://github.com/palantir/gradle-baseline/pull/1528

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineScalastyle.java
@@ -34,7 +34,7 @@ import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 
 public final class BaselineScalastyle extends AbstractBaselinePlugin {
-    private static final String SCALA_TARGET_VERSION = "jvm-8";
+    private static final String SCALA_TARGET_VERSION = "jvm-1.8";
 
     @Override
     public void apply(Project project) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineScalastyleTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineScalastyleTest.groovy
@@ -73,7 +73,7 @@ final class BaselineScalastyleTest extends Specification {
         expect:
         def tasks = project.tasks.withType(ScalaCompile.class)
         for (ScalaCompile task : tasks) {
-            assert task.getScalaCompileOptions().getAdditionalParameters().contains("-target:jvm-8")
+            assert task.getScalaCompileOptions().getAdditionalParameters().contains("-target:jvm-1.8")
         }
     }
 


### PR DESCRIPTION
## Before this PR
In #1524, we provide `-target:jvm-8` as parameter to scalac. It turns out the new version-string scheme (`8` instead of `1.8`) is [only supported from Scala 2.13](https://github.com/scala/scala/pull/8060). We need to support 2.12 and below. Apologies.

## After this PR
Set `-target:jvm-1.8` instead.

==COMMIT_MSG==
Use old version-string scheme for Scala compiler target (`jvm-1.8` instead of `jvm-8`).
==COMMIT_MSG==
