### PR TITLE
Fix baseline-idea inspection configuration

### DIFF
--- a/changelog/@unreleased/pr-1530.v2.yml
+++ b/changelog/@unreleased/pr-1530.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix baseline-idea inspection configuration
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1530

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -356,6 +356,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
         node.append(new XmlParser().parseText("""
             <component name="InspectionProjectProfileManager">
                 <profile version="1.0">
+                    <option name="myName" value="Project Default" />
                     <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WARNING" enabled_by_default="true">
                         <option name="ignoreObjectMethods" value="false" />
                         <option name="ignoreAnonymousClassMethods" value="false" />
@@ -363,7 +364,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
                         
                     <inspection_tool class="PlaceholderCountMatchesArgumentCount" enabled="false" level="WARNING" enabled_by_default="false" />
                 </profile>
-                <option name="PROJECT_PROFILE" value="Default" />
+                <option name="PROJECT_PROFILE" value="Project Default" />
                 <option name="USE_PROJECT_PROFILE" value="true" />
             </component>
             """.stripIndent()))


### PR DESCRIPTION
Discovered while working on
https://github.com/palantir/gradle-baseline/pull/1529

## Before this PR
The inspection profile we created was not used by my IDE (ultimate-EAP)
until I added a name and pointed the profile at it.

## After this PR
profile is used.
==COMMIT_MSG==
Fix baseline-idea inspection configuration
==COMMIT_MSG==

## Possible downsides?
Maybe this breaks some idea versions in some way?
