### PR TITLE
Add error-prone check for system time zone usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `ImmutablesBuilderMissingInitialization`: Prevent building Immutables.org builders when not all fields have been populated.
 - `UnnecessarilyQualified`: Types should not be qualified if they are also imported. 
 - `DeprecatedGuavaObjects`: `com.google.common.base.Objects` has been obviated by `java.util.Objects`.
+- `JavaTimeSystemDefaultTimeZone`: Avoid using the system default time zone.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/JavaTimeSystemDefaultTimeZone.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/JavaTimeSystemDefaultTimeZone.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "JavaTimeSystemDefaultTimeZone",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.WARNING,
+        summary = "The system default time zone should not be used, since the behavior is system dependent. "
+                + "Instead, UTC should always be used.")
+public final class JavaTimeSystemDefaultTimeZone extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final Matcher<ExpressionTree> CLOCK_SYSTEM_DEFAULT_ZONE_MATCHER = Matchers.staticMethod()
+            .onClass("java.time.Clock")
+            .named("systemDefaultZone")
+            .withParameters();
+    private static final Matcher<ExpressionTree> ZONE_ID_SYSTEM_DEFAULT_MATCHER = Matchers.staticMethod()
+            .onClass("java.time.ZoneId")
+            .named("systemDefault")
+            .withParameters();
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (CLOCK_SYSTEM_DEFAULT_ZONE_MATCHER.matches(tree, state)) {
+            return buildDescription(tree)
+                    .addFix(SuggestedFix.builder()
+                            .replace(tree, "Clock.systemUTC()")
+                            .addImport("java.time.Clock")
+                            .build())
+                    .build();
+        }
+
+        if (ZONE_ID_SYSTEM_DEFAULT_MATCHER.matches(tree, state)) {
+            return buildDescription(tree)
+                    .addFix(SuggestedFix.builder()
+                            .replace(tree, "ZoneOffset.UTC")
+                            .addImport("java.time.ZoneOffset")
+                            .build())
+                    .build();
+        }
+
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/JavaTimeSystemDefaultTimeZone.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/JavaTimeSystemDefaultTimeZone.java
@@ -32,7 +32,7 @@ import com.sun.source.tree.MethodInvocationTree;
         name = "JavaTimeSystemDefaultTimeZone",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = BugPattern.SeverityLevel.WARNING,
+        severity = BugPattern.SeverityLevel.ERROR,
         summary = "The system default time zone should not be used, since the behavior is system dependent. "
                 + "Instead, UTC should always be used.")
 public final class JavaTimeSystemDefaultTimeZone extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JavaTimeSystemDefaultTimeZoneTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JavaTimeSystemDefaultTimeZoneTest.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+final class JavaTimeSystemDefaultTimeZoneTest {
+
+    @Test
+    void clockSystemDefaultZone() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import java.time.Clock;",
+                        "class Test {",
+                        "  static void f() {",
+                        "    Clock clock = Clock.systemDefaultZone();",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.time.Clock;",
+                        "class Test {",
+                        "  static void f() {",
+                        "    Clock clock = Clock.systemUTC();",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void zoneIdSystemDefault() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import java.time.ZoneId;",
+                        "class Test {",
+                        "  static void f() {",
+                        "    ZoneId zoneId = ZoneId.systemDefault();",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.time.ZoneId;",
+                        "import java.time.ZoneOffset;",
+                        "class Test {",
+                        "  static void f() {",
+                        "    ZoneId zoneId = ZoneOffset.UTC;",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(new JavaTimeSystemDefaultTimeZone(), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-1531.v2.yml
+++ b/changelog/@unreleased/pr-1531.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Adds a `JavaTimeSystemDefaultTimeZone` error-prone check to prevent
+    uses of the system default time zone.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1531


### PR DESCRIPTION
Error Prone has a built-in [JavaTimeDefaultTimeZone](https://errorprone.info/bugpattern/JavaTimeDefaultTimeZone) check. However this check only matches _implicit_ uses of the system default time zone.

There's no good reason to use the system default time zone so we should also prevent _explicit_ uses. This PR add a `JavaTimeSystemDefaultTimeZone` error-prone check that matches these explicit uses and suggests a replacement.