### PR TITLE
Automatically fix JavaTimeSystemDefaultTimeZone

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -38,6 +38,8 @@ public class BaselineErrorProneExtension {
             "ExtendsErrorOrThrowable",
             "FinalClass",
             "ImplicitPublicBuilderConstructor",
+            "JavaTimeDefaultTimeZone",
+            "JavaTimeSystemDefaultTimeZone",
             "LambdaMethodReference",
             "LoggerEnclosingClass",
             "LogsafeArgName",


### PR DESCRIPTION
Follow up to https://github.com/palantir/gradle-baseline/pull/1531

Automatically fixes `JavaTimeDefaultTimeZone` and `JavaTimeSystemDefaultTimeZone`.
