### PR TITLE
Fix regression in ./gradlew idea introduced in baseline 3.51.0

### DIFF
--- a/changelog/@unreleased/pr-1551.v2.yml
+++ b/changelog/@unreleased/pr-1551.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Fix regression in ./gradlew idea introduced in baseline 3.51.1
+  description: Fix regression in ./gradlew idea introduced in baseline 3.51.0
   links:
   - https://github.com/palantir/gradle-baseline/pull/1551

--- a/changelog/@unreleased/pr-1551.v2.yml
+++ b/changelog/@unreleased/pr-1551.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix regression in ./gradlew idea introduced in baseline 3.51.1
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1551

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -49,7 +49,23 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         buildFile << standardBuildFile
 
         then:
-        with('idea').build()
+        BuildResult result = with('idea').build()
+        assert result.task(':idea').outcome == TaskOutcome.SUCCESS ?: result.output
+    }
+
+    def 'Works with checkstyle and IntelliJ import'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << """ 
+        allprojects { 
+            apply plugin: 'com.palantir.baseline-checkstyle'
+        }
+        """
+
+        then:
+        BuildResult result = with('idea', '-Didea.active=true', '-is').build()
+        assert file(".idea/checkstyle-idea.xml").exists() ?: result.output
+        assert result.task(':idea').outcome == TaskOutcome.SUCCESS ?: result.output
     }
 
     def 'Throws error when configuration files are not present'() {


### PR DESCRIPTION
## Before this PR
@dtobin reported in #dev-foundry-infra that upgrading from baseline 3.50.0 -> 3.51.0 broke `./gradlew idea`.

```
groovy.lang.MissingPropertyException: No such property: DEFAULT_CHECKSTYLE_VERSION for class: com.palantir.baseline.plugins.BaselineCheckstyle
	at groovy.lang.MetaClassImpl.invokeStaticMissingProperty(MetaClassImpl.java:1021)
	at groovy.lang.MetaClassImpl.getProperty(MetaClassImpl.java:1866)
	at groovy.lang.MetaClassImpl.getProperty(MetaClassImpl.java:1842)
```

Clearly I goofed my original PR here: https://github.com/palantir/gradle-baseline/pull/1546

## After this PR
==COMMIT_MSG==
Fix regression in ./gradlew idea introduced in baseline 3.51.0
==COMMIT_MSG==

I also did a publishToMavenLocal and a manual verification of this, cos I don't really trust our tests for this plugin!

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

