### PR TITLE
Apply baseline-class-unqiueness by default

### DIFF
--- a/changelog/@unreleased/pr-1553.v2.yml
+++ b/changelog/@unreleased/pr-1553.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The `baseline-class-unqiueness` plugin is now applied by default.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1553

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -42,6 +42,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineErrorProne.class);
             proj.getPluginManager().apply(BaselineFormat.class);
             proj.getPluginManager().apply(BaselineReproducibility.class);
+            proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);
             proj.getPluginManager().apply(BaselineExactDependencies.class);
             proj.getPluginManager().apply(BaselineReleaseCompatibility.class);
             proj.getPluginManager().apply(BaselineTesting.class);
@@ -50,8 +51,6 @@ public final class Baseline implements Plugin<Project> {
             //    configurations.integrationTestCompile
             // proj.getPluginManager().apply(BaselineFixGradleJava.class);
 
-            // TODO(dfox): enable this when it has been validated on a few real projects
-            // proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);
         });
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTest.groovy
@@ -48,6 +48,7 @@ class BaselineTest extends Specification {
         assert p.pluginManager.hasPlugin('com.palantir.baseline-error-prone')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-idea')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-release-compatibility')
+        assert p.pluginManager.hasPlugin('com.palantir.baseline-class-uniqueness')
     }
 
 }


### PR DESCRIPTION
Follow up to https://github.com/palantir/gradle-baseline/pull/267.

## Before this PR
The `baseline-class-unqiueness` plugin is not applied by default.

## After this PR
The `baseline-class-unqiueness` plugin is applied by default.