### PR TITLE
Improve the DangerousJsonTypeInfoUsage check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousJsonTypeInfoUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousJsonTypeInfoUsage.java
@@ -23,11 +23,14 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.AnnotationHasArgumentWithValue;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.IsSameType;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Symbol;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -35,36 +38,56 @@ import com.sun.source.tree.ExpressionTree;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,
-        summary = "Disallow usage of Jackson's JsonTypeInfo.Id.CLASS annotation for security reasons, "
+        summary = "Disallow usage of Jackson's Type Information features for security reasons, "
                 + "cf. https://github.com/FasterXML/jackson-databind/issues/1599")
-public final class DangerousJsonTypeInfoUsage extends BugChecker implements BugChecker.AnnotationTreeMatcher {
+public final class DangerousJsonTypeInfoUsage extends BugChecker
+        implements BugChecker.AnnotationTreeMatcher, BugChecker.MethodInvocationTreeMatcher {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Matcher<AnnotationTree> matcher = new AnnotationHasArgumentWithValue(
+    private static final Matcher<AnnotationTree> annotationMatcher = new AnnotationHasArgumentWithValue(
             "use",
             Matchers.allOf(
-                    new IsSameType<>("com.fasterxml.jackson.annotation.JsonTypeInfo$Id"),
-                    Matchers.anyOf(
-                            treeEqualsStringMatcher("JsonTypeInfo.Id.CLASS"),
-                            treeEqualsStringMatcher("JsonTypeInfo.Id.MINIMAL_CLASS"),
-                            treeEqualsStringMatcher("com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS"),
-                            treeEqualsStringMatcher(
-                                    "com.fasterxml.jackson.annotation.JsonTypeInfo.Id.MINIMAL_CLASS"))));
+                    Matchers.isSameType("com.fasterxml.jackson.annotation.JsonTypeInfo$Id"),
+                    Matchers.anyOf(symbolNamed("CLASS"), symbolNamed("MINIMAL_CLASS"))));
 
-    private static Matcher<ExpressionTree> treeEqualsStringMatcher(String value) {
-        return (expressionTree, state) -> state.getSourceForNode(expressionTree).equals(value);
+    private static final Matcher<ExpressionTree> objectMapperTypeInfoMatcher = MethodMatchers.instanceMethod()
+            .onDescendantOf("com.fasterxml.jackson.databind.ObjectMapper")
+            .namedAnyOf(
+                    "enableDefaultTyping",
+                    "enableDefaultTypingAsProperty",
+                    "activateDefaultTyping",
+                    "activateDefaultTypingAsProperty",
+                    "setDefaultTyping");
+
+    private static Matcher<ExpressionTree> symbolNamed(String value) {
+        return (expressionTree, state) -> {
+            Symbol symbol = ASTHelpers.getSymbol(expressionTree);
+            return symbol != null && symbol.name.contentEquals(value);
+        };
     }
 
     @Override
     public Description matchAnnotation(AnnotationTree tree, VisitorState state) {
-        if (!matcher.matches(tree, state)) {
+        if (!annotationMatcher.matches(tree, state)) {
             return Description.NO_MATCH;
         }
 
         return buildDescription(tree)
                 .setMessage("Must not use Jackson @JsonTypeInfo annotation with "
                         + "JsonTypeInfo.Id.CLASS or JsonTypeInfo.Id.MINIMAL_CLASS")
+                .build();
+    }
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!objectMapperTypeInfoMatcher.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+        return buildDescription(tree)
+                .setMessage("Must not use a Jackson ObjectMapper with default typings because it may allow remote "
+                        + "code execution upon deserialization. Additionally, using java types in API makes usage "
+                        + "more difficult for consumers using other languages.")
                 .build();
     }
 }

--- a/changelog/@unreleased/pr-1557.v2.yml
+++ b/changelog/@unreleased/pr-1557.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Improve the DangerousJsonTypeInfoUsage check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1557


### PR DESCRIPTION
## Before this PR
Check didn't validate default type info configuration on the mapper itself.
Check failed to validate symbols, only stringly matched annotation values.

==COMMIT_MSG==
Improve the DangerousJsonTypeInfoUsage check
==COMMIT_MSG==

