### PR TITLE
baseline-format: can format build.gradle files

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ buildscript {
     }
 }
 
+apply plugin: 'com.palantir.java-format'
 apply plugin: 'com.diffplug.spotless'
 
 spotless {
@@ -313,6 +314,9 @@ spotless {
         trimTrailingWhitespace
         indentWithSpaces 4
     }
+    groovyGradle {
+        greclipse().configFile("$rootDir/build/baseline-format/greclipse.properties")
+    }
 }
 ```
 
@@ -320,7 +324,9 @@ spotless {
 
 To iterate on the eclipse.xml formatter config, you can import it into an instance of Eclipse, edit it through the preferences UI and then export it, or you can manually tune individual values by referring to the master list of [DefaultCodeFormatterConstants](https://github.com/eclipse/eclipse.jdt.core/blob/6a8cee1126829229d648db4ae0e5a6b70a5d4f13/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java) and [DefaultCodeFormatterOptions](https://github.com/eclipse/eclipse.jdt.core/blob/6a8cee1126829229d648db4ae0e5a6b70a5d4f13/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java#L41-L95). Running `./gradlew :gradle-baseline-java:test -Drecreate=true` should update all the checked-in snapshot test cases.
 
-**Add `com.palantir.baseline-format.palantir-java-format=true`** to your gradle.properties to run our experimental fork of google-java-format. The Palantir Java Formatter can be run from IntelliJ using the [palantir-java-format](https://plugins.jetbrains.com/plugin/13180-palantir-java-format) plugin.
+**Add `com.palantir.baseline-format.gradle-files=true`** to your gradle.properties to format your own build.gradle files
+(or alternatively run `./gradlew format -Pcom.palantir.baseline-format.gradle-files=true` to do a one-off run).
+
 
 ## com.palantir.baseline-reproducibility
 

--- a/changelog/@unreleased/pr-1561.v2.yml
+++ b/changelog/@unreleased/pr-1561.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: '`com.palantir.baseline-format` now understands how to format build.gradle
+    files. This is opt-in by default, so you need to run `./gradlew format -Pcom.palantir.baseline-format.gradle-files=true`
+    to try it, or add this property to your gradle.properties if you want to lock
+    it in.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1561

--- a/gradle-baseline-java/src/main/resources/greclipse.properties
+++ b/gradle-baseline-java/src/main/resources/greclipse.properties
@@ -1,0 +1,3 @@
+org.eclipse.jdt.core.formatter.tabulation.char=space
+org.eclipse.jdt.core.formatter.indent_empty_lines=false
+groovy.formatter.remove.unnecessary.semicolons=true


### PR DESCRIPTION
## Before this PR

Every now and again, we stumble across some elaborate build.gradle files full of custom stuff. These are sometimes hard to read due to each project's own idiosyncratic styling opinions.

Well it turns out spotless can just zap em all with a consistent format!

## After this PR
==COMMIT_MSG==
`com.palantir.baseline-format` now understands how to format build.gradle files. This is opt-in by default, so you need to run `./gradlew format -Pcom.palantir.baseline-format.gradle-files=true` to try it, or add this property to your gradle.properties if you want to lock it in.
==COMMIT_MSG==

I've intentionally made this opt-in because I'm intending to write an auto-merging excavator which will just come round and re-format your files, without incurring the annoyance of failing builds because someone has got their indentation wrong.

## Possible downsides?
- people can be pretty opinionated about styling, and I think there's a risk this might make certain build.gradles _longer_ (e.g. by expanding one-liners to multiple lines).  Overall though, I think most people have recognised the value of applying palantir-java-format everywhere, so maybe they'll be receptive???
- i've spent like 5 minutes on this PR, so there are no tests. #gottagofast