### PR TITLE
Fix unit tests on java 15

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FallThroughTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FallThroughTest.java
@@ -28,7 +28,7 @@ public class FallThroughTest {
     @DisabledForJreRange(max = JRE.JAVA_13)
     public void testSwitchExpression() {
         CompilationTestHelper compilationHelper = CompilationTestHelper.newInstance(FallThrough.class, getClass())
-                .setArgs(ImmutableList.of("--enable-preview", "--release", "14"));
+                .setArgs(ImmutableList.of("--enable-preview", "--release", "15"));
 
         compilationHelper
                 .addSourceLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -302,7 +302,7 @@ public class StrictUnusedVariableTest {
     @DisabledForJreRange(max = JRE.JAVA_13)
     public void testRecord() {
         compilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass())
-                .setArgs(ImmutableList.of("--enable-preview", "--release", "14"));
+                .setArgs(ImmutableList.of("--enable-preview", "--release", "15"));
 
         compilationHelper
                 .addSourceLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessaryParenthesesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/UnnecessaryParenthesesTest.java
@@ -29,7 +29,7 @@ public class UnnecessaryParenthesesTest {
     public void testSwitchExpression() {
         CompilationTestHelper compilationHelper = CompilationTestHelper.newInstance(
                         UnnecessaryParentheses.class, getClass())
-                .setArgs(ImmutableList.of("--enable-preview", "--release", "14"));
+                .setArgs(ImmutableList.of("--enable-preview", "--release", "15"));
 
         compilationHelper
                 .addSourceLines(


### PR DESCRIPTION
## Before this PR
We switched testing on java 14 to testing on java 15 in https://github.com/palantir/gradle-baseline/commit/02c9f15d91056bb8bdbcc7eae910fe06424fe562 which broke some tests on java 15 and automerged before we could fix the tests.

Failures: https://app.circleci.com/pipelines/github/palantir/gradle-baseline/1492/workflows/f8aaf40f-f7fb-4a28-8860-80f00df4532d/jobs/21807

## After this PR

Fix unit tests when running with java 15.

==COMMIT_MSG==
Fix unit tests on java 15
==COMMIT_MSG==