### PR TITLE
Fix path sensitivity of compile tasks

### DIFF
--- a/changelog/@unreleased/pr-1568.v2.yml
+++ b/changelog/@unreleased/pr-1568.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: JavaCompile tasks should now get more build cache hits irrespective
+    of the location of your repo on disk, as `baseline-errorprone` no longer injects
+    an absolute path into `errorproneOptions.excludedPaths`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1568

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -25,7 +25,6 @@ import com.google.common.collect.MoreCollectors;
 import com.palantir.baseline.extensions.BaselineErrorProneExtension;
 import com.palantir.baseline.tasks.CompileRefasterTask;
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.AbstractList;
 import java.util.Collections;
 import java.util.List;
@@ -202,13 +201,13 @@ public final class BaselineErrorProne implements Plugin<Project> {
         }
 
         errorProneOptions.getDisableWarningsInGeneratedCode().set(true);
-        String projectPath = project.getProjectDir().getPath();
-        String separator = Pattern.quote(Paths.get(projectPath).getFileSystem().getSeparator());
+        // don't want backslashes on windows to break our regex
+        String separator = File.separatorChar == '\\' ? Pattern.quote("\\") : File.separator;
         errorProneOptions
                 .getExcludedPaths()
                 .set(String.format(
-                        "%s%s(build|src%sgenerated.*)%s.*",
-                        Pattern.quote(projectPath), separator, separator, separator));
+                        ".*(build%sgenerated%ssources|src%sgenerated.*)%s.*",
+                        separator, separator, separator, separator));
 
         // FallThrough does not currently work with switch expressions
         // See https://github.com/google/error-prone/issues/1649


### PR DESCRIPTION
## Before this PR

Our build caching is currently kinda broken, because you can't get cache hits between local & CI. [build scan link](https://gradle.p.b/c/m2khsesqbx2jw/kbk7v6omaei5k/task-inputs?expanded=WyJuejY2Z3RvdTZyNmtjLXNvdXJjZSIsImNwNGxucXJqYXU3d2Etc291cmNlIl0#ovd53fafhaeic-options.compilerargumentproviders.errorprone$1.errorproneoptions.excludedpaths)

![image](https://user-images.githubusercontent.com/3473798/100293005-251b6500-2f7a-11eb-8304-7b94ea26431d.png)

Specifically, on a local run the java compiler would be invoked with the following argument, which contains an absolute path 🌶🌶🌶:

```
-XepDisableWarningsInGeneratedCode -XepExcludedPaths:\Q/Volumes/git/container-vuln-scanner/container-vuln-scanner-api\E\Q/\E(build|src\Q/\Egenerated.*)\Q/\E.* -Xep:FallThrough -Xep:UnnecessaryParentheses -Xep:CatchSpecificity:OFF -Xep:UnusedVariable:OFF -Xep:EqualsHashCode:ERROR -Xep:EqualsIncompatibleType:ERROR -Xep:StreamResourceLeak:ERROR -Xep:InputStreamSlowMultibyteRead:ERROR -Xep:JavaDurationGetSecondsGetNano:ERROR -Xep:URLEqualsHashCode:ERROR -Xep:BoxedPrimitiveEquality:ERROR -Xep:ReferenceEquality:ERROR -XepOpt:LogsafeArgName:UnsafeArgNames=branch,branchid,branchname,branchrid,email,emailaddress,organization,organizationname,path,ref,secret,transactionref,token,username
```

When the repo is the checked out to a different location (e.g. `/home/circleci/container-vuln-scanner`), it computes a different set of args and causes a cache miss.

_cc @jmcampanini this is example number (3) of gradle enterprise saving the day_

## After this PR
==COMMIT_MSG==
JavaCompile tasks should now get more build cache hits irrespective of the location of your repo on disk, as `baseline-errorprone` no longer injects an absolute path into `errorproneOptions.excludedPaths`.
==COMMIT_MSG==

Interestingly I _think_ that windows compilation was also broken, and that this _might_ fix it.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

