### PR TITLE
Exclude generated sources from error-prone

### DIFF
--- a/changelog/@unreleased/pr-1571.v2.yml
+++ b/changelog/@unreleased/pr-1571.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Exclude generated sources from error-prone
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1571

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -201,9 +201,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         }
 
         errorProneOptions.getDisableWarningsInGeneratedCode().set(true);
-        errorProneOptions
-                .getExcludedPaths()
-                .set(excludedPathsRegex());
+        errorProneOptions.getExcludedPaths().set(excludedPathsRegex());
 
         // FallThrough does not currently work with switch expressions
         // See https://github.com/google/error-prone/issues/1649

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -201,13 +201,9 @@ public final class BaselineErrorProne implements Plugin<Project> {
         }
 
         errorProneOptions.getDisableWarningsInGeneratedCode().set(true);
-        // don't want backslashes on windows to break our regex
-        String separator = File.separatorChar == '\\' ? Pattern.quote("\\") : File.separator;
         errorProneOptions
                 .getExcludedPaths()
-                .set(String.format(
-                        ".*(build%sgenerated%ssources|src%sgenerated.*)%s.*",
-                        separator, separator, separator, separator));
+                .set(excludedPathsRegex());
 
         // FallThrough does not currently work with switch expressions
         // See https://github.com/google/error-prone/issues/1649
@@ -290,6 +286,12 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 });
             }
         }
+    }
+
+    static String excludedPathsRegex() {
+        // don't want backslashes on windows to break our regex
+        String separator = File.separator.contains("\\") ? Pattern.quote("\\") : File.separator;
+        return String.format(".*%s(build|generated_.*[sS]rc|src%sgenerated.*)%s.*", separator, separator, separator);
     }
 
     private static Optional<Stream<String>> getSpecificErrorProneChecks(Project project) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineErrorProneTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineErrorProneTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins
+
+import java.util.regex.Pattern
+import spock.lang.Specification
+
+class BaselineErrorProneTest extends Specification {
+    void testExcludedPaths() {
+        when:
+        String excludedPaths = BaselineErrorProne.excludedPathsRegex()
+        def predicate = Pattern.compile(excludedPaths).asPredicate()
+
+        then:
+        predicate.test 'tritium-core/build/metricSchema/generated_src'
+        predicate.test 'tritium-registry/generated_src/com/palantir/tritium/metrics/registry/ImmutableMetricName.java'
+        predicate.test 'tritium-metrics/build/metricSchema/generated_src/com/palantir/tritium/metrics/TlsMetrics.java'
+        predicate.test 'tritium-jmh/generated_testSrc/com/palantir/tritium/microbenchmarks/generated/ProxyBenchmark_jmhType.java'
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
As seen in excavator bump PR https://github.com/palantir/tritium/pull/925 , the changes in https://github.com/palantir/gradle-baseline/pull/1568 do not seem to handle cases that previously were excluded such as `build/metricSchema/generated_src` used by `metric-schema` which is causing the baseline bump excavator on tritium to fail compilation: https://app.circleci.com/pipelines/github/palantir/tritium/906/workflows/7c65b97b-b475-46fc-a1e1-b5a4bf7198a0/jobs/11565

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Exclude generated sources from error-prone
==COMMIT_MSG==

Closes https://github.com/palantir/gradle-baseline/issues/1570

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Probably want some additional test cases.
