### PR TITLE
baseline-reproducibility validates that sourceCompatibility is set explicitly

### DIFF
--- a/changelog/@unreleased/pr-1574.v2.yml
+++ b/changelog/@unreleased/pr-1574.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: baseline-reproducibility validates that sourceCompatibility is set
+    explicitly
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1574

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
@@ -51,7 +51,7 @@ public final class BaselineReproducibility implements Plugin<Project> {
             JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
 
             // just being a bit defensive because we need to cast to an internal gradle class... don't wanna block
-            // upgrades
+            // gradle upgrades
             String clazz = javaConvention.getClass().getCanonicalName();
             String expected = "org.gradle.api.plugins.internal.DefaultJavaPluginConvention";
             if (!clazz.equals(expected)) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
@@ -16,10 +16,17 @@
 
 package com.palantir.baseline.plugins;
 
+import com.palantir.baseline.tasks.CheckExplicitSourceCompatibilityTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.file.DuplicatesStrategy;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.util.GradleVersion;
 
 /** Sensible defaults so that all Jar, Tar, Zip tasks can be deterministically reproduced. */
 public final class BaselineReproducibility implements Plugin<Project> {
@@ -38,6 +45,33 @@ public final class BaselineReproducibility implements Plugin<Project> {
                             "Please remove the 'nebula.info' plugin from {} as it breaks "
                                     + "reproducibility of jars by adding a 'Build-Date' entry to the MANIFEST.MF",
                             project);
+        });
+
+        project.getPlugins().withType(JavaBasePlugin.class, _plugin -> {
+            JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+
+            // just being a bit defensive because we need to cast to an internal gradle class... don't wanna block
+            // upgrades
+            String clazz = javaConvention.getClass().getCanonicalName();
+            String expected = "org.gradle.api.plugins.internal.DefaultJavaPluginConvention";
+            if (!clazz.equals(expected)) {
+                project.getLogger()
+                        .error(
+                                "BaselineReproducibility unable to check sourceCompatibility - please report this to "
+                                        + "https://github.com/palantir/gradle-baseline/issues and mention the current"
+                                        + " Gradle version ({}). Expected '{}' found '{}'",
+                                GradleVersion.current(),
+                                expected,
+                                clazz);
+                return;
+            }
+
+            TaskProvider<? extends Task> checkExplicitSourceCompatibility = project.getTasks()
+                    .register("checkExplicitSourceCompatibility", CheckExplicitSourceCompatibilityTask.class);
+
+            project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(check -> {
+                check.dependsOn(checkExplicitSourceCompatibility);
+            });
         });
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReproducibility.java
@@ -22,11 +22,9 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
-import org.gradle.util.GradleVersion;
 
 /** Sensible defaults so that all Jar, Tar, Zip tasks can be deterministically reproduced. */
 public final class BaselineReproducibility implements Plugin<Project> {
@@ -48,24 +46,6 @@ public final class BaselineReproducibility implements Plugin<Project> {
         });
 
         project.getPlugins().withType(JavaBasePlugin.class, _plugin -> {
-            JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-
-            // just being a bit defensive because we need to cast to an internal gradle class... don't wanna block
-            // gradle upgrades
-            String clazz = javaConvention.getClass().getCanonicalName();
-            String expected = "org.gradle.api.plugins.internal.DefaultJavaPluginConvention";
-            if (!clazz.equals(expected)) {
-                project.getLogger()
-                        .error(
-                                "BaselineReproducibility unable to check sourceCompatibility - please report this to "
-                                        + "https://github.com/palantir/gradle-baseline/issues and mention the current"
-                                        + " Gradle version ({}). Expected '{}' found '{}'",
-                                GradleVersion.current(),
-                                expected,
-                                clazz);
-                return;
-            }
-
             TaskProvider<? extends Task> checkExplicitSourceCompatibility = project.getTasks()
                     .register("checkExplicitSourceCompatibility", CheckExplicitSourceCompatibilityTask.class);
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -86,7 +86,7 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
         if (shouldFix.get()) {
             Files.write(
                     getProject().getBuildFile().toPath(),
-                    Collections.singletonList(String.format("%nsourceCompatibility = %s", JavaVersion.current())),
+                    Collections.singletonList(String.format("%nsourceCompatibility = %s%n", JavaVersion.current())),
                     StandardCharsets.UTF_8,
                     StandardOpenOption.APPEND,
                     StandardOpenOption.CREATE);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -66,12 +66,12 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
     }
 
     @Option(option = "fix", description = "Whether to apply the suggested fix to build.gradle")
-    public void setShouldFix(boolean value) {
+    public final void setShouldFix(boolean value) {
         shouldFix.set(value);
     }
 
     @TaskAction
-    public void taskAction() throws IOException {
+    public final void taskAction() throws IOException {
         // We're doing this naughty casting because we need access to the `getRawSourceCompatibility` method.
         org.gradle.api.plugins.internal.DefaultJavaPluginConvention convention =
                 (org.gradle.api.plugins.internal.DefaultJavaPluginConvention)
@@ -101,7 +101,7 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
                         + "     ./gradlew %s --fix%n"
                         + "%n"
                         + "This will automatically add a suggested line "
-                        + "(you may need to adjust the number, e.g. to '8' for maximum compatibility).",
+                        + "(you may need to adjust the number, e.g. to '1.8' for maximum compatibility).",
                 getProject(),
                 getProject().getRootProject().relativePath(getProject().getBuildFile()),
                 JavaVersion.current(),

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -72,12 +72,14 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
 
     @TaskAction
     public void taskAction() throws IOException {
+        // We're doing this naughty casting because we need access to the `getRawSourceCompatibility` method.
         org.gradle.api.plugins.internal.DefaultJavaPluginConvention convention =
                 (org.gradle.api.plugins.internal.DefaultJavaPluginConvention)
                         getProject().getConvention().getPlugin(JavaPluginConvention.class);
 
         if (convention.getRawSourceCompatibility() != null) {
-            // this means the user has explicitly set sourceCompatibility, which is great.
+            // In theory, users could configure the fancy new 'java toolchain' as an alternative to explicit
+            // sourceCompatibility, but there's no method to access this yet (as of Gradle 6.8).
             return;
         }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.tasks;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+/**
+ * By default, Gradle will infer sourceCompat based on whatever JVM is currently being used to evaluate the
+ * build.gradle files. This is bad for reproducibility because if we make an automated PR to upgrade the Java major
+ * version (e.g. 11 -> 15) then a library might unintentionally start publishing jars containing Java15 bytecode!
+ *
+ * Better to just require everyone to specify sourceCompatibility explicitly!
+ */
+public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
+
+    private final Property<Boolean> shouldFix;
+
+    @Inject
+    public CheckExplicitSourceCompatibilityTask(ObjectFactory objectFactory) {
+        setGroup("Verification");
+        setDescription("Ensures build.gradle specifies sourceCompatibility explicitly, otherwise it is inferred based"
+                + " on $JAVA_HOME which is fragile.");
+        this.shouldFix = objectFactory.property(Boolean.class);
+        this.shouldFix.set(false);
+    }
+
+    @Option(option = "fix", description = "Whether to apply the suggested fix to build.gradle")
+    public void setShouldFix(boolean value) {
+        shouldFix.set(value);
+    }
+
+    @TaskAction
+    public void taskAction() throws IOException {
+        org.gradle.api.plugins.internal.DefaultJavaPluginConvention convention =
+                (org.gradle.api.plugins.internal.DefaultJavaPluginConvention)
+                        getProject().getConvention().getPlugin(JavaPluginConvention.class);
+
+        if (convention.getRawSourceCompatibility() != null) {
+            // this means the user has explicitly set sourceCompatibility, which is great.
+            return;
+        }
+
+        if (shouldFix.get()) {
+            Files.write(
+                    getProject().getBuildFile().toPath(),
+                    Collections.singletonList(String.format("%nsourceCompatibility = %s%n", JavaVersion.current())),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.APPEND);
+            return;
+        }
+
+        throw new GradleException(String.format(
+                "Project must set java 'sourceCompatibility' explicitly in %s, "
+                        + "otherwise compilation will not be reproducible but instead depends on the Java version "
+                        + "that Gradle is currently running with (%s). Re-run ./gradlew %s --fix to automatically add "
+                        + "a suggested line (you may need to adjust the number, e.g. to '8' for maximum "
+                        + "compatibility).",
+                getProject().getBuildFile(), JavaVersion.current(), getPath()));
+    }
+}

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineReproducibilityIntegrationSpec.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineReproducibilityIntegrationSpec.groovy
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins
+
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+class BaselineReproducibilityIntegrationSpec extends IntegrationSpec {
+
+    def 'task surfaces the badness'() {
+        when:
+        buildFile << """
+        ${applyPlugin(BaselineReproducibility.class)}
+        apply plugin: 'java'
+        apply plugin: 'maven-publish'
+
+        version '1.2.3'
+
+        publishing {
+            publications {
+                maven(MavenPublication) {
+                    from components.java
+                }
+            }
+        }
+        """.stripIndent()
+
+        writeHelloWorld()
+
+        then:
+        ExecutionResult output = runTasksWithFailure("check")
+        output.getStandardError().contains("./gradlew :checkExplicitSourceCompatibility --fix")
+    }
+
+    def 'task passes when explicitly set'() {
+        when:
+        buildFile << """
+        ${applyPlugin(BaselineReproducibility.class)}
+        apply plugin: 'java'
+        apply plugin: 'maven-publish'
+
+        version '1.2.3'
+
+        sourceCompatibility = 1.8
+
+        publishing {
+            publications {
+                maven(MavenPublication) {
+                    from components.java
+                }
+            }
+        }
+        """.stripIndent()
+
+        writeHelloWorld()
+
+        then:
+        runTasksSuccessfully("checkExplicitSourceCompatibility")
+    }
+
+    def 'no-op if nothing is published'() {
+        when:
+        buildFile << """
+        ${applyPlugin(BaselineReproducibility.class)}
+        apply plugin: 'java'
+        version '1.2.3'
+        """.stripIndent()
+
+        writeHelloWorld()
+
+        then:
+        def output = runTasksSuccessfully("check")
+        output.getStandardOutput().contains("> Task :checkExplicitSourceCompatibility SKIPPED")
+    }
+}


### PR DESCRIPTION
## Before this PR

To get a new JVM rolled out fleet wide, we blast out excavators which just dial up the JVM used at CI time.  This has been pretty much fine so far as most projects set `sourceCompatibility` explicitly, but nothing actually _validates_ this right now.

Occasionally, this manifests as a question in `#dev-foundry-infra` about the product-dependencies.lock file differing locally on CI (because on CI it's inferring java 15) and locally it's inferring whatever JVM the dev is using, often 11.

## After this PR
==COMMIT_MSG==
baseline-reproducibility validates that sourceCompatibility is set explicitly using a new `checkExplicitSourceCompatibility` task.
==COMMIT_MSG==

## Possible downsides?
- it's one more task that will get registered on every project, also can't see any reasonable way of caching this badboy

