### PR TITLE
Saner test event logging default for CI

### DIFF
--- a/changelog/@unreleased/pr-1576.v2.yml
+++ b/changelog/@unreleased/pr-1576.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Print more test logging output to avoid builds with long running tests
+    getting terminated by circle ("context deadline exceeded").
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1576

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -145,10 +145,11 @@ public final class BaselineTesting implements Plugin<Project> {
         // provide some stdout feedback when tests fail when running on CI and locally
         task.getTestLogging().getEvents().add(TestLogEvent.FAILED);
 
-        // Only on CI, print out more detailed test information to avoid hitting the circleci 10 min deadline if
-        // there are lots of tests. Don't do this locally to avoid spamming massive amount of info for people running
-        // unit tests through the command line
-        if ("true".equals(System.getenv("CI"))) {
+        // Only on CI and for non-unit test tasks, print out more detailed test information to avoid hitting the
+        // circleci 10 min deadline if there are lots of tests. Don't do this locally to avoid spamming massive
+        // amount of info for people running tests through the command line. Only for non unit test tasks as unit
+        // test tasks tend to be fast and avoid this issue.
+        if (!task.getName().equals("test") && "true".equals(System.getenv("CI"))) {
             task.getTestLogging()
                     .getEvents()
                     .addAll(ImmutableSet.of(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED));


### PR DESCRIPTION
## Before this PR
We've seen numerous times that when projects have long running integration test tasks that take longer than 10 mins they get killed by circle ("context deadline exceeded"). If there are no failing tests we won't print anything in the gradle output, so it's possible to hit this deadline.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Print more test logging output to avoid builds with long running tests getting terminated by circle ("context deadline exceeded").
==COMMIT_MSG==

## Possible downsides?
Perhaps more noisy, but the failed tests already have junit xml produced in circle, so this should be strictly better.

