### PR TITLE
Smarter CheckExplicitSourceCompatibilityTask

### DIFF
--- a/changelog/@unreleased/pr-1577.v2.yml
+++ b/changelog/@unreleased/pr-1577.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`baseline-reproducibility` no longer requires people to set `sourceCompatibility`
+    if the publishing plugin is applied but nothing is published.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1577

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -58,9 +58,13 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
             public boolean isSatisfiedBy(Task element) {
                 // sometimes people apply the 'java' plugin to projects that doesn't actually have any java code in it
                 // (e.g. the root project), so if they're not publishing anything, then we don't bother enforcing the
-                // sourceCompat thing
+                // sourceCompat thing. Also they might apply the publishing plugin just to get the 'publish' task.
                 PublishingExtension publishing = getProject().getExtensions().findByType(PublishingExtension.class);
-                return publishing != null;
+                if (publishing == null) {
+                    return false;
+                }
+
+                return !publishing.getPublications().isEmpty();
             }
         });
     }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineReproducibilityIntegrationSpec.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineReproducibilityIntegrationSpec.groovy
@@ -78,6 +78,7 @@ class BaselineReproducibilityIntegrationSpec extends IntegrationSpec {
         ${applyPlugin(BaselineReproducibility.class)}
         apply plugin: 'java'
         version '1.2.3'
+        apply plugin: 'maven-publish'
         """.stripIndent()
 
         writeHelloWorld()


### PR DESCRIPTION
## Before this PR

@pkoenig10 received a baseline upgrade on MP which failed CI asking for a `sourceCompatibility` line onthe root project, because our docs plugin was applying the PublishingPlugin just to get the `publish` lifecycle task created.

## After this PR
==COMMIT_MSG==
Smarter CheckExplicitSourceCompatibilityTask
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

