### PR TITLE
Don't impose a gradle 6.7 requirement

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -33,6 +33,7 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
+import org.gradle.util.GradleVersion;
 
 /**
  * By default, Gradle will infer sourceCompat based on whatever JVM is currently being used to evaluate the
@@ -56,6 +57,12 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
         onlyIf(new Spec<Task>() {
             @Override
             public boolean isSatisfiedBy(Task element) {
+                if (GradleVersion.current().compareTo(GradleVersion.version("6.7")) < 0) {
+                    // We're cheekily using this 'getRawSourceCompatibility' method which was only added in Gradle 6.7
+                    // https://github.com/gradle/gradle/commit/8e55abb151e7d933c8348b32b6163fb535254a08.
+                    return false;
+                }
+
                 // sometimes people apply the 'java' plugin to projects that doesn't actually have any java code in it
                 // (e.g. the root project), so if they're not publishing anything, then we don't bother enforcing the
                 // sourceCompat thing. Also they might apply the publishing plugin just to get the 'publish' task.


### PR DESCRIPTION
Had a couple of reports internally about folks unable to pick up gradle-baseline because they weren't on modern gradle.  I think there are sometimes valid reasons that people would want to hang back on gradle releases (e.g. the unsolved 'circleci build just hanging forever' thingy), and I think it might be preferable to keep them up to latest with baseline.

Here's another internal failure https://circle.p.b/gh/excavator-checks/excavator-gradle/25423

I don't have mega high conviction about this, just opened it to prompt the discussion really.