### PR TITLE
improvement: checkExplicitSourceCompatabilityTask ignores projects without java source

### DIFF
--- a/changelog/@unreleased/pr-1584.v2.yml
+++ b/changelog/@unreleased/pr-1584.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: checkExplicitSourceCompatabilityTask ignores projects without java
+    source
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1584

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -78,8 +78,7 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
         onlyIf(new Spec<Task>() {
             @Override
             public boolean isSatisfiedBy(Task task) {
-                SourceSetContainer sourceSets = getProject().getExtensions().getByType(SourceSetContainer.class);
-                return sourceSets.stream()
+                return getProject().getExtensions().getByType(SourceSetContainer.class).stream()
                         .anyMatch(
                                 sourceSet -> !sourceSet.getAllJava().getFiles().isEmpty());
             }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -78,8 +78,10 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
         onlyIf(new Spec<Task>() {
             @Override
             public boolean isSatisfiedBy(Task task) {
-                return getProject().getExtensions().getByType(SourceSetContainer.class).stream()
-                        .anyMatch(sourceSet -> !sourceSet.getAllJava().isEmpty());
+                SourceSetContainer sourceSets = getProject().getExtensions().getByType(SourceSetContainer.class);
+                return sourceSets.stream()
+                        .anyMatch(
+                                sourceSet -> !sourceSet.getAllJava().getFiles().isEmpty());
             }
         });
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -31,6 +31,7 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Property;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.util.GradleVersion;
@@ -72,6 +73,13 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
                 }
 
                 return !publishing.getPublications().isEmpty();
+            }
+        });
+        onlyIf(new Spec<Task>() {
+            @Override
+            public boolean isSatisfiedBy(Task task) {
+                return getProject().getExtensions().getByType(SourceSetContainer.class).stream()
+                        .anyMatch(sourceSet -> !sourceSet.getAllJava().isEmpty());
             }
         });
     }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineReproducibilityIntegrationSpec.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineReproducibilityIntegrationSpec.groovy
@@ -69,7 +69,7 @@ class BaselineReproducibilityIntegrationSpec extends IntegrationSpec {
         writeHelloWorld()
 
         then:
-        runTasksSuccessfully("checkExplicitSourceCompatibility")
+        def result = runTasksSuccessfully("checkExplicitSourceCompatibility")
     }
 
     def 'no-op if nothing is published'() {
@@ -82,6 +82,28 @@ class BaselineReproducibilityIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         writeHelloWorld()
+
+        then:
+        def output = runTasksSuccessfully("check")
+        output.getStandardOutput().contains("> Task :checkExplicitSourceCompatibility SKIPPED")
+    }
+
+    def 'no-op if there is not source'() {
+        when:
+        buildFile << """
+        ${applyPlugin(BaselineReproducibility.class)}
+        apply plugin: 'java'
+        apply plugin: 'maven-publish'
+        version '1.2.3'
+
+        publishing {
+            publications {
+                maven(MavenPublication) {
+                    from components.java
+                }
+            }
+        }
+        """.stripIndent()
 
         then:
         def output = runTasksSuccessfully("check")


### PR DESCRIPTION
## Before this PR
We had blocked excavators on projects that didn't specify sourceCompat because they did not have any Java source

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
checkExplicitSourceCompatabilityTask ignores projects without java source
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

