### PR TITLE
Escape gradle failure text properly with CDATA section in junit reports

### DIFF
--- a/changelog/@unreleased/pr-1587.v2.yml
+++ b/changelog/@unreleased/pr-1587.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: A CDATA section is used in junit reports to avoid string escaping problems.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1587

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportCreator.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportCreator.java
@@ -58,7 +58,7 @@ final class JunitReportCreator {
                     testCaseXml.appendChild(failureXml);
                     failureXml.setAttribute("message", failure.message());
                     failureXml.setAttribute("type", "ERROR");
-                    failureXml.setTextContent(failure.details());
+                    failureXml.appendChild(xml.createCDATASection(failure.details()));
                 }
             }
 


### PR DESCRIPTION
## Before this PR
I think with an internal PR I have printed out some characters that cause the junit report produced by the `JunitReportsPlugin` to produce invalid xml, at least according to circle :

<img width="607" alt="Screen Shot 2020-12-15 at 2 58 57 PM" src="https://user-images.githubusercontent.com/397795/102231696-28a16c80-3ee6-11eb-8c08-49d62e98e371.png">

One of these characters: https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_reference_overview

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
A CDATA section is used in junit reports to avoid string escaping problems.
==COMMIT_MSG==

## Possible downsides?

