### PR TITLE
Disable MissingCasesInEnumSwitch on Java 14

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/MissingCasesInEnumSwitchTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/MissingCasesInEnumSwitchTest.java
@@ -16,31 +16,34 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
-import com.google.errorprone.bugpatterns.FallThrough;
+import com.google.errorprone.bugpatterns.MissingCasesInEnumSwitch;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
-public class FallThroughTest {
+public class MissingCasesInEnumSwitchTest {
 
     @Test
     @DisabledForJreRange(max = JRE.JAVA_13)
     public void testSwitchExpression() {
-        CompilationTestHelper compilationHelper = CompilationTestHelper.newInstance(FallThrough.class, getClass());
+        CompilationTestHelper compilationHelper =
+                CompilationTestHelper.newInstance(MissingCasesInEnumSwitch.class, getClass());
 
         compilationHelper
                 .addSourceLines(
                         "Test.java",
                         "class Test {",
-                        "  static void foo(int value) {",
+                        "  enum Enum {",
+                        "    A,",
+                        "    B,",
+                        "  }",
+                        "  static void foo(Enum value) {",
+                        "    // BUG: Diagnostic contains: Non-exhaustive switch",
                         "    switch (value) {",
-                        "      case 42 -> {}",
-                        "      // BUG: Diagnostic matches: X",
-                        "      default -> {}",
+                        "      case A, B -> {}",
                         "    };",
                         "  }",
                         "}")
-                .expectErrorMessage("X", input -> input.contains("Execution may fall through from the previous case"))
                 .doTest();
     }
 }

--- a/changelog/@unreleased/pr-1588.v2.yml
+++ b/changelog/@unreleased/pr-1588.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Disable `MissingCasesInEnumSwitch` on Java 14 source to avoid false
+    positives
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1588

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -211,6 +211,14 @@ public final class BaselineErrorProne implements Plugin<Project> {
                     ? CheckSeverity.DEFAULT
                     : CheckSeverity.OFF;
         }));
+        // MissingCasesInEnumSwitch does not currently work with multi-label switch expressions
+        // See https://github.com/google/error-prone/pull/2026
+        errorProneOptions.check("MissingCasesInEnumSwitch", project.provider(() -> {
+            JavaPluginExtension ext = project.getExtensions().getByType(JavaPluginExtension.class);
+            return ext.getSourceCompatibility().compareTo(JavaVersion.toVersion(14)) < 0
+                    ? CheckSeverity.DEFAULT
+                    : CheckSeverity.OFF;
+        }));
         // UnnecessaryParentheses does not currently work with switch expressions
         errorProneOptions.check("UnnecessaryParentheses", project.provider(() -> {
             JavaPluginExtension ext = project.getExtensions().getByType(JavaPluginExtension.class);


### PR DESCRIPTION
Similar to https://github.com/palantir/gradle-baseline/pull/1442

## Before this PR
`MissingCasesInEnumSwitch` results in false positives when using switch expressions.

## After this PR
`MissingCasesInEnumSwitch` is disabled when using Java 14 or newer.

Upstream fix is in https://github.com/google/error-prone/pull/2026.