### PR TITLE
Add configuration to checkImplicitDependencies suggestion

### DIFF
--- a/changelog/@unreleased/pr-1591.v2.yml
+++ b/changelog/@unreleased/pr-1591.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `checkImplicitDependencies` suggestion message now includes the
+    `implementation` configuration name.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1591

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -195,6 +195,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
                             task.dependenciesConfiguration(compileClasspath);
+                            task.suggestionConfigurationName(sourceSet.getImplementationConfigurationName());
 
                             task.ignore("org.slf4j", "slf4j-api");
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -102,7 +102,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
                         "'%s:%s'",
                         artifact.getModuleVersion().getId().getGroup(),
                         artifact.getModuleVersion().getId().getName());
-        return String.format("        %s", artifactNameString);
+        return String.format("        implementation %s", artifactNameString);
     }
 
     /**

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -47,6 +47,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
     private final ListProperty<Configuration> dependenciesConfigurations;
     private final Property<FileCollection> sourceClasses;
     private final SetProperty<String> ignore;
+    private final Property<String> suggestionConfigurationName;
 
     public CheckImplicitDependenciesTask() {
         setGroup("Verification");
@@ -56,6 +57,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
         sourceClasses = getProject().getObjects().property(FileCollection.class);
         ignore = getProject().getObjects().setProperty(String.class);
         ignore.set(Collections.emptySet());
+        suggestionConfigurationName = getProject().getObjects().property(String.class);
     }
 
     @TaskAction
@@ -102,7 +104,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
                         "'%s:%s'",
                         artifact.getModuleVersion().getId().getGroup(),
                         artifact.getModuleVersion().getId().getName());
-        return String.format("        implementation %s", artifactNameString);
+        return String.format("        %s %s", suggestionConfigurationName.get(), artifactNameString);
     }
 
     /**
@@ -171,5 +173,14 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
     @Input
     public final Provider<Set<String>> getIgnored() {
         return ignore;
+    }
+
+    @Input
+    public final Provider<String> getSuggestionConfigurationName() {
+        return suggestionConfigurationName;
+    }
+
+    public final void suggestionConfigurationName(String newSuggestionConfigurationName) {
+        this.suggestionConfigurationName.set(Objects.requireNonNull(newSuggestionConfigurationName));
     }
 }


### PR DESCRIPTION
## Before this PR
The `checkImplicitDependencies` suggestion message does not include the configuration name. This make it cumbersome for users to translate the suggestion to their Gradle configuration.
```
Found 1 implicit dependencies - consider adding the following explicit dependencies or avoid using classes from these jars:
    dependencies {
        'com.palantir.foo:foo'
    }
```

## After this PR
The `checkImplicitDependencies` suggestion message includes the `implementation` configuration name. This allows users to just copy and paste the suggestion into their Gradle configuration.
```
Found 1 implicit dependencies - consider adding the following explicit dependencies or avoid using classes from these jars:
    dependencies {
        implementation 'com.palantir.foo:foo'
    }
```

