### PR TITLE
Don't modify exact dependencies index

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
@@ -81,9 +80,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         Set<ResolvedArtifact> necessaryArtifacts = Streams.stream(
                         sourceClasses.get().iterator())
                 .flatMap(BaselineExactDependencies::referencedClasses)
-                .map(BaselineExactDependencies.INDEXES::classToDependency)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(BaselineExactDependencies.INDEXES::classToArtifacts)
                 .collect(Collectors.toSet());
 
         Set<ResolvedArtifact> possiblyUnused = Sets.difference(declaredArtifacts, necessaryArtifacts);
@@ -119,9 +116,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
                                 BaselineExactDependencies.VALID_ARTIFACT_EXTENSIONS.contains(artifact.getExtension()))
                         .flatMap(BaselineExactDependencies.INDEXES::classesFromArtifact)
                         .filter(referencedClasses()::contains)
-                        .map(BaselineExactDependencies.INDEXES::classToDependency)
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
+                        .flatMap(BaselineExactDependencies.INDEXES::classToArtifacts)
                         .filter(artifact -> !declaredArtifacts.contains(artifact))
                         .collect(Collectors.toSet());
 


### PR DESCRIPTION
## Before this PR
The values in the `classToDependency` index can be modified if the same class is produced by multiple artifacts and subprojects are not all using the same artifact to provide this class.

This can happen quite easily when using our internal jakarta renames plugin.

## After this PR
The `classToDependency` index stores sets of artifacts that provide a given class. The `checkUnusedDependencies` and `checkImplicitDependencies` tasks have been updated to handle multiple artifacts as gracefully as possible.

This was pretty trivial for the `checkUnusedDependencies` task. It was a bit more involved for the `checkImplicitDependencies` task since we have to treat the potential artifacts as a conjunctive normal form.