### PR TITLE
Add baseline-encoding plugin to force UTF-8 during compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ _Baseline is a family of Gradle plugins for configuring Java projects with sensi
 | `com.palantir.baseline-config`                | Config files for the above plugins
 | `com.palantir.baseline-reproducibility`       | Sensible defaults to ensure Jar, Tar and Zip tasks can be reproduced
 | `com.palantir.baseline-exact-dependencies`    | Ensures projects explicitly declare all the dependencies they rely on, no more and no less
+| `com.palantir.baseline-encoding`              | Ensures projects use the UTF-8 encoding in compile tasks.
 | `com.palantir.baseline-release-compatibility` | Ensures projects targetting older JREs only compile against classes and methods available in those JREs.
 | `com.palantir.baseline-testing`               | Configures test tasks to dump heap dumps (hprof files) for convenient debugging
 
@@ -364,6 +365,10 @@ checkImplicitDependencies {
     ignore 'org.slf4j', 'slf4j-api'
 }
 ```
+
+## com.palantir.baseline-encoding
+
+This plugin sets the encoding for JavaCompile tasks to `UTF-8`.
 
 ## com.palantir.baseline-release-compatibility
 

--- a/changelog/@unreleased/pr-1600.v2.yml
+++ b/changelog/@unreleased/pr-1600.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Baseline now provides a `com.palantir.baseline-encoding` plugin to
+    force UTF-8 in compilation tasks.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1600

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -41,6 +41,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineIdea.class);
             proj.getPluginManager().apply(BaselineErrorProne.class);
             proj.getPluginManager().apply(BaselineFormat.class);
+            proj.getPluginManager().apply(BaselineEncoding.class);
             proj.getPluginManager().apply(BaselineReproducibility.class);
             proj.getPluginManager().apply(BaselineClassUniquenessPlugin.class);
             proj.getPluginManager().apply(BaselineExactDependencies.class);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEncoding.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEncoding.java
@@ -24,8 +24,8 @@ public final class BaselineEncoding implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getTasks().withType(JavaCompile.class).configureEach(t -> {
-            t.getOptions().setEncoding("UTF-8");
+        project.getTasks().withType(JavaCompile.class).configureEach(javaCompileTask -> {
+            javaCompileTask.getOptions().setEncoding("UTF-8");
         });
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEncoding.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEncoding.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+public final class BaselineEncoding implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getTasks().withType(JavaCompile.class).configureEach(t -> {
+            t.getOptions().setEncoding("UTF-8");
+        });
+    }
+}

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-encoding.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-encoding.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineEncoding

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEncodingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEncodingIntegrationTest.groovy
@@ -68,6 +68,7 @@ class BaselineEncodingIntegrationTest extends AbstractPluginTest {
         then:
         BuildResult result = with('compileJava').build()
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        !result.output.contains("unmappable character")
     }
 
     def 'compileJava fails with other encoding'() {
@@ -76,7 +77,8 @@ class BaselineEncodingIntegrationTest extends AbstractPluginTest {
         file('src/main/java/test/Test.java').text = javaFile
 
         then:
-        BuildResult result = with('compileJava').buildAndFail()
-        result.task(":compileJava").outcome == TaskOutcome.FAILED
+        BuildResult result = with('compileJava').build()
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        result.output.contains("unmappable character")
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEncodingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEncodingIntegrationTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline
+
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+
+class BaselineEncodingIntegrationTest extends AbstractPluginTest {
+
+    def standardBuildFile = '''
+        plugins {
+            id 'java'
+            id 'com.palantir.baseline-encoding'
+        }
+
+        sourceCompatibility = 1.8
+
+        repositories {
+            mavenLocal()
+            jcenter()
+        }
+    '''.stripIndent()
+
+    def otherEncodingBuildFile = '''
+        plugins {
+            id 'java'
+        }
+
+        sourceCompatibility = 1.8
+
+        repositories {
+            mavenLocal()
+            jcenter()
+        }
+        
+        tasks.withType(JavaCompile) {
+            options.encoding = 'US-ASCII'
+        }
+    '''.stripIndent()
+
+    def javaFile = '''
+        package test;
+        public class Test {
+            private static final String VALUE = "•";
+        }
+    '''.stripIndent()
+
+    def 'compileJava succeeds with baseline-encoding'() {
+        when:
+        buildFile << standardBuildFile
+        file('src/main/java/test/Test.java').text = javaFile
+
+        then:
+        BuildResult result = with('compileJava').build()
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+    }
+
+    def 'compileJava fails with other encoding'() {
+        when:
+        buildFile << otherEncodingBuildFile
+        file('src/main/java/test/Test.java').text = javaFile
+
+        then:
+        BuildResult result = with('compileJava').buildAndFail()
+        result.task(":compileJava").outcome == TaskOutcome.FAILED
+    }
+}


### PR DESCRIPTION
## Before this PR
`JavaCompile` tasks use the platform charset by default. This is often `UTF-8`, but we have seen internal CI builds where the platform charset is `US_ASCII`. This can lead to compilation failures if source files contains non-ASCII characters.

## After this PR
Baseline now provides a `baseline-encoding` plugin that set the encoding to `UTF-8` for all `JavaCompile` tasks.

