### PR TITLE
Let StrictUnusedVariable ignore record fields

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -147,7 +147,9 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             "org.openqa.selenium.support.FindBys");
 
     /** The set of types exempting a type that is extending or implementing them. */
-    private static final ImmutableSet<String> EXEMPTING_SUPER_TYPES = ImmutableSet.of();
+    private static final ImmutableSet<String> EXEMPTING_SUPER_TYPES = ImmutableSet.of(
+            // Don't check record fields
+            "java.lang.Record");
 
     /** The set of types exempting a field of type extending them. */
     private static final ImmutableSet<String> EXEMPTING_FIELD_SUPER_TYPES =
@@ -768,14 +770,6 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
         @Override
         public Void visitMethod(MethodTree tree, Void unused) {
-            // From the perspective of an errorprone rule there are two standalone trees for a single `record`
-            // definition; A MethodTree which looks like a void function and a ClassTree which has the record fields.
-            //
-            // Its unclear why both trees are emitted, but we can identify and ignore a record's MethodTree by checking
-            // if it does not have any associated source.
-            if (state.getEndPosition(tree) < 0) {
-                return null;
-            }
             return isSuppressed(tree) ? null : super.visitMethod(tree, unused);
         }
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -305,12 +305,7 @@ public class StrictUnusedVariableTest {
                 .setArgs(ImmutableList.of("--enable-preview", "--release", "15"));
 
         compilationHelper
-                .addSourceLines(
-                        "Test.java",
-                        "class Test {",
-                        "@SuppressWarnings(\"StrictUnusedVariable\")",
-                        " record Foo(int foo) {}",
-                        "}")
+                .addSourceLines("Test.java", "class Test {", "  record Foo(int bar) {}", "}")
                 .doTest();
     }
 

--- a/changelog/@unreleased/pr-1602.v2.yml
+++ b/changelog/@unreleased/pr-1602.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Ignore unused record fields
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1602

--- a/changelog/@unreleased/pr-1602.v2.yml
+++ b/changelog/@unreleased/pr-1602.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Ignore unused record fields
+  description: Let StrictUnusedVariable ignore record fields
   links:
   - https://github.com/palantir/gradle-baseline/pull/1602

--- a/changelog/@unreleased/pr-1602.v2.yml
+++ b/changelog/@unreleased/pr-1602.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Let StrictUnusedVariable ignore record fields
   links:
   - https://github.com/palantir/gradle-baseline/pull/1602


### PR DESCRIPTION
## Before this PR
Record fields were flagged as unused and had to be manually suppressed.

```java
class Test {
  // without @SuppressWarnings("StrictUnusedVariable")	
  record Foo(int bar) {}

  static void method() {
    new Foo(1).bar()
  }
}
```

throws: `error: [StrictUnusedVariable] The field 'bar' is never read.`

## After this PR
Flup on https://github.com/palantir/gradle-baseline/pull/1412 and https://github.com/palantir/gradle-baseline/pull/1414 now that error prone has better support for records.

Ignore record fields when checking for unused variables as only the record's getter-methods might be used.

Note that checking for the actual unused record class is done with the `UnusedNestedClass` check.

==COMMIT_MSG==
Let StrictUnusedVariable ignore record fields
==COMMIT_MSG==