### PR TITLE
Disable WhitespaceAround when using palantir-java-format

### DIFF
--- a/changelog/@unreleased/pr-1603.v2.yml
+++ b/changelog/@unreleased/pr-1603.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Disable `WhitespaceAround` Checkstyle rule when palantir-java-format
+    is applied.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1603

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -81,14 +81,7 @@
         </module>
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
-            <property name="excludes" value="
-                com.google.common.base.Preconditions.*,
-                com.palantir.logsafe.Preconditions.*,
-                java.util.Collections.*,
-                java.util.stream.Collectors.*,
-                org.apache.commons.lang3.Validate.*,
-                org.assertj.core.api.Assertions.*,
-                org.mockito.Mockito.*"/>
+            <property name="excludes" value="com.google.common.base.Preconditions.*, com.palantir.logsafe.Preconditions.*, java.util.Collections.*, java.util.stream.Collectors.*, org.apache.commons.lang3.Validate.*, org.assertj.core.api.Assertions.*, org.mockito.Mockito.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
@@ -138,12 +131,12 @@
         <module name="IllegalImport"> <!-- Java Coding Guidelines: Import the canonical package -->
             <property name="id" value="BanShadedClasses"/>
             <property name="illegalPkgs" value=".*\.(repackaged|shaded|thirdparty)"/>
-            <property name="regexp" value="true" />
+            <property name="regexp" value="true"/>
             <message key="import.illegal" value="Must not import repackaged classes."/>
         </module>
         <module name="IllegalImport">
             <property name="illegalPkgs" value="^org\.gradle\.(internal|.*\.internal)"/>
-            <property name="regexp" value="true" />
+            <property name="regexp" value="true"/>
             <message key="import.illegal" value="Do not rely on gradle internal classes as these may change in minor releases - use org.gradle.api versions instead."/>
         </module>
         <module name="IllegalImport">
@@ -397,7 +390,7 @@
         <module name="SuppressWarnings">
             <property name="format" value="serial"/>
         </module>
-        <module name="SuppressWarningsHolder" />  <!-- Required for SuppressWarningsFilter -->
+        <module name="SuppressWarningsHolder"/>  <!-- Required for SuppressWarningsFilter -->
         <module name="TypeName"> <!-- Java Style Guide: Class names -->
             <message key="name.invalidPattern" value="Type name ''{0}'' must match pattern ''{1}''."/>
         </module>

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineConfigIntegrationTest.groovy
@@ -152,5 +152,11 @@ class BaselineConfigIntegrationTest extends AbstractPluginTest {
         !new File(projectDir, '.baseline/checkstyle/checkstyle.xml').readLines().any {
             it.contains '<module name="ParenPad">'
         }
+        !new File(projectDir, '.baseline/checkstyle/checkstyle.xml').readLines().any {
+            it.contains '<module name="LeftCurly">'
+        }
+        !new File(projectDir, '.baseline/checkstyle/checkstyle.xml').readLines().any {
+            it.contains '<module name="WhitespaceAround">'
+        }
     }
 }


### PR DESCRIPTION
## Before this PR

The `WhitespaceAround` checkstyle check conflicts with how palantir-java-format (correctly) formats empty blocks in switch expressions.

The following code:
```
enum Case { ONE, TWO }
switch (foo) {
    case ONE -> {},
    case TWO -> {
        ...
    }
}
```
Results in the following errors:
```
WhitespaceAround: '}' is not preceded with whitespace.
WhitespaceAround: '{' is not followed by whitespace. Empty blocks may only be represented as {} when not part of a multi-block statement (4.1.3)
```

See internal build https://c.p.b/gh/foundry/mp/236221

## After this PR

The `WhitespaceAround` checkstyle check is removed when using palantir-java-format.

This is similar to what we've done previously for other checks in https://github.com/palantir/gradle-baseline/pull/987, https://github.com/palantir/gradle-baseline/pull/1205, and https://github.com/palantir/gradle-baseline/pull/1278.

I've also taken the liberty to refactor this to use Java's XML tooling to make it a bit more robust and easier to read/modify. This did result in some slight formatting changes to the output. See https://g.p.b/foundry/mp/commit/acc37f76 for an example of the changes.