### PR TITLE
Preserve DOCTYPE in checkstyle.xml

### DIFF
--- a/changelog/@unreleased/pr-1606.v2.yml
+++ b/changelog/@unreleased/pr-1606.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Baseline correctly preserves the DOCTYPE when generating checkstyle.xml.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1606

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -3,13 +3,6 @@
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
         "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
-<!--
-    Palantir Baseline Checkstyle configuration.
-    Authors: Robert Fink, Brian Worth, Merrick Zoubeiri, and many other contributors. Based in part on http://checkstyle.sourceforge.net/google_style.html
-    Please keep checks alphabetized with one exception: "relaxed" checks are grouped together at the bottom for easier disabling.
-    Check-specific comments reference documents internal to Palantir and can be safely ignored or removed.
- -->
-
 <module name="Checker">
     <property name="charset" value="UTF-8"/>
     <property name="severity" value="error"/>

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -3,6 +3,13 @@
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
         "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
+<!--
+    Palantir Baseline Checkstyle configuration.
+    Authors: Robert Fink, Brian Worth, Merrick Zoubeiri, and many other contributors. Based in part on http://checkstyle.sourceforge.net/google_style.html
+    Please keep checks alphabetized with one exception: "relaxed" checks are grouped together at the bottom for easier disabling.
+    Check-specific comments reference documents internal to Palantir and can be safely ignored or removed.
+ -->
+
 <module name="Checker">
     <property name="charset" value="UTF-8"/>
     <property name="severity" value="error"/>

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineConfig.java
@@ -126,6 +126,10 @@ class BaselineConfig extends AbstractBaselinePlugin {
                     TransformerFactory transformerFactory = TransformerFactory.newInstance();
                     Transformer transformer = transformerFactory.newTransformer();
                     transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+                    transformer.setOutputProperty(
+                            OutputKeys.DOCTYPE_PUBLIC, document.getDoctype().getPublicId());
+                    transformer.setOutputProperty(
+                            OutputKeys.DOCTYPE_SYSTEM, document.getDoctype().getSystemId());
 
                     DOMSource source = new DOMSource(document);
                     StreamResult result = new StreamResult(new FileWriter(checkstyleXml.toFile()));


### PR DESCRIPTION
## Before this PR
The XML parsing/writing logic added in https://github.com/palantir/gradle-baseline/pull/1603 doesn't preserve the DOCTYPE. This causes the `checkstyleMainCircleFinalizer` task to fail.

https://app.circleci.com/pipelines/github/palantir/gradle-baseline/1699/workflows/2623eafb-018b-41d4-bd1f-9fb2e6511f37/jobs/23047

## After this PR
Preserve the DOCTYPE when writing the checkstyle XML.