### PR TITLE
improvement: Disable inner import on classes that cause errorprone to fail

### DIFF
--- a/changelog/@unreleased/pr-1617.v2.yml
+++ b/changelog/@unreleased/pr-1617.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable inner import on classes that cause ErrorProne to fail
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1617

--- a/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
+++ b/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
@@ -44,6 +44,18 @@
               <package name="" withSubpackages="true" static="false" />
             </value>
           </option>
+          <DO_NOT_IMPORT_INNER>
+            <CLASS name="Builder" />
+            <CLASS name="Callback" />
+            <CLASS name="Class" />
+            <CLASS name="Entry" />
+            <CLASS name="Enum" />
+            <CLASS name="Factory" />
+            <CLASS name="Type" />
+            <CLASS name="Key" />
+            <CLASS name="Id" />
+            <CLASS name="Provider" />
+          </DO_NOT_IMPORT_INNER>
         </GroovyCodeStyleSettings>
         <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
         <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />


### PR DESCRIPTION
## Before this PR
Errorprone produces `BadImport` which fails if you import nested classes with commonly used names. We however configured intellij to blindly auto-import nested classes where possible.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Disable inner import on classes that cause ErrorProne to fail
==COMMIT_MSG==

List of classes to disable sourced from [here](https://github.com/google/error-prone/blob/master/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java#L67)

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

