### PR TITLE
Additional negative test for OptionalOrElseGetValue

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseGetValueTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseGetValueTest.java
@@ -147,4 +147,19 @@ public final class OptionalOrElseGetValueTest {
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
+
+    @Test
+    public void testNegativeCollection() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.Optional;",
+                        "class Test {",
+                        "    private final ImmutableList<String> l = Optional.of(ImmutableList.<String>of())",
+                        "        .orElseGet(() -> ImmutableList.of(\"str\"));",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
 }


### PR DESCRIPTION
This is a failed attempt to reproduce a bug posted internally.

## After this PR
==COMMIT_MSG==
Additional negative test for OptionalOrElseGetValue
==COMMIT_MSG==
