### PR TITLE
Automatically fix the new `ZoneIdOfZ` check

### DIFF
--- a/changelog/@unreleased/pr-1621.v2.yml
+++ b/changelog/@unreleased/pr-1621.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Automatically fix the new `ZoneIdOfZ` check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1621

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -78,7 +78,8 @@ public class BaselineErrorProneExtension {
             "ObjectsHashCodePrimitive",
             "PreferJavaTimeOverload",
             "ProtectedMembersInFinalClass",
-            "UnnecessaryParentheses");
+            "UnnecessaryParentheses",
+            "ZoneIdOfZ");
 
     private final ListProperty<String> patchChecks;
 


### PR DESCRIPTION
See https://errorprone.info/bugpattern/ZoneIdOfZ

## Before this PR
ZoneIdOfZ prevented baseline/error-prone upgrades. The check has a trivial automatic fix, tested internally.

## After this PR
==COMMIT_MSG==
Automatically fix the new `ZoneIdOfZ` check
==COMMIT_MSG==

