### PR TITLE
Fix error message to reflect correct static constant

### DIFF
--- a/changelog/@unreleased/pr-1630.v2.yml
+++ b/changelog/@unreleased/pr-1630.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix error message to reflect correct static constant
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1630

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -351,7 +351,7 @@
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="\bCharset.defaultCharset\("/>
-            <property name="message" value="Use explicit charset (e.g. StandardCharsets.UTF-8) instead of default."/>
+            <property name="message" value="Use explicit charset (e.g. StandardCharsets.UTF_8) instead of default."/>
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="\bIOUtils\.toString\("/>


### PR DESCRIPTION
## Before this PR
Error message recommends using `StandardCharsets.UTF-8` but it should be `UTF_8` https://docs.oracle.com/javase/7/docs/api/java/nio/charset/StandardCharsets.html#UTF_8

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix error message to reflect correct static constant
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

