### PR TITLE
Migrate preconditions to the new package

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -75,7 +75,7 @@
         </module>
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
-            <property name="excludes" value="com.google.common.base.Preconditions.*, com.palantir.logsafe.Preconditions.*, java.util.Collections.*, java.util.stream.Collectors.*, org.apache.commons.lang3.Validate.*, org.assertj.core.api.Assertions.*, org.mockito.Mockito.*"/>
+            <property name="excludes" value="com.google.common.base.Preconditions.*, com.palantir.logsafe.Preconditions.*, com.palantir.logsafe.preconditions.Preconditions.*, java.util.Collections.*, java.util.stream.Collectors.*, org.apache.commons.lang3.Validate.*, org.assertj.core.api.Assertions.*, org.mockito.Mockito.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferSafeLoggingPreconditions`: Users should use the safe-logging versions of Precondition checks for standardization when there is equivalent functionality
     ```diff
     -com.google.common.base.Preconditions.checkNotNull(variable, "message");
-    +com.palantir.logsafe.Preconditions.checkNotNull(variable, "message"); // equivalent functionality is available in the safe-logging variant
+    +com.palantir.logsafe.preconditions.Preconditions.checkNotNull(variable, "message"); // equivalent functionality is available in the safe-logging variant
     ```
 - `ShutdownHook`: Applications should not use `Runtime#addShutdownHook`.
 - `GradleCacheableTaskAction`: Gradle plugins should not call `Task.doFirst` or `Task.doLast` with a lambda, as that is not cacheable. See [gradle/gradle#5510](https://github.com/gradle/gradle/issues/5510) for more details.
@@ -202,6 +202,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `IncubatingMethod`: Prevents calling Conjure incubating APIs unless you explicitly opt-out of the check on a per-use or per-project basis.
 - `CompileTimeConstantViolatesLiskovSubstitution`: Requires consistent application of the `@CompileTimeConstant` annotation to resolve inconsistent validation based on the reference type on which the met is invoked.
 - `ClassInitializationDeadlock`: Detect type structures which can cause deadlocks initializing classes.
+- `SafeLoggingPreconditionsMigration`: Migrate safe-logging preconditions references to the new non-deprecated package.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsMessageFormat.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogSafePreconditionsMessageFormat.java
@@ -41,7 +41,7 @@ public final class LogSafePreconditionsMessageFormat extends PreconditionsMessag
     private static final long serialVersionUID = 1L;
 
     private static final Matcher<ExpressionTree> LOGSAFE_PRECONDITIONS_METHOD = MethodMatchers.staticMethod()
-            .onClassAny("com.palantir.logsafe.Preconditions")
+            .onClassAny("com.palantir.logsafe.preconditions.Preconditions")
             .withNameMatching(Pattern.compile("checkArgument|checkState|checkNotNull"));
 
     public LogSafePreconditionsMessageFormat() {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditions.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
         providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
         severity = BugPattern.SeverityLevel.WARNING,
         summary = "Precondition and similar checks with a constant message and no parameters should use equivalent"
-                + " checks from com.palantir.logsafe.Preconditions for standardization as functionality is the"
+                + " checks from com.palantir.logsafe.preconditions.Preconditions for standardization as functionality is the"
                 + " same.")
 public final class PreferSafeLoggingPreconditions extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
@@ -92,13 +92,15 @@ public final class PreferSafeLoggingPreconditions extends BugChecker implements 
         }
 
         SuggestedFix.Builder fix = SuggestedFix.builder();
-        String logSafeQualifiedClassName = SuggestedFixes.qualifyType(state, fix, "com.palantir.logsafe.Preconditions");
+        String logSafeQualifiedClassName =
+                SuggestedFixes.qualifyType(state, fix, "com.palantir.logsafe.preconditions.Preconditions");
         String logSafeMethodName = getLogSafeMethodName(ASTHelpers.getSymbol(tree));
         String replacement = String.format("%s.%s", logSafeQualifiedClassName, logSafeMethodName);
 
         return buildDescription(tree)
-                .setMessage("The call can be replaced with an equivalent one from com.palantir.logsafe.Preconditions "
-                        + "for standardization as the functionality is the same.")
+                .setMessage(
+                        "The call can be replaced with an equivalent one from com.palantir.logsafe.preconditions.Preconditions "
+                                + "for standardization as the functionality is the same.")
                 .addFix(fix.replace(tree.getMethodSelect(), replacement).build())
                 .build();
     }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPreconditionsMigration.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPreconditionsMigration.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.Tree;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "SafeLoggingPreconditionsMigration",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.SUGGESTION,
+        summary = "Prefer the non-deprecated safe-logging preconditions path. "
+                + "See https://github.com/palantir/safe-logging/pull/515 for context. Using gradle baseline, "
+                + "failures can be fixed automatically using "
+                + "`./gradlew classes testClasses -PerrorProneApply=SafeLoggingPreconditionsMigration`")
+public final class SafeLoggingPreconditionsMigration extends BugChecker implements BugChecker.MemberSelectTreeMatcher {
+
+    private static final Matcher<Tree> LEGACY_PRECONDITIONS_MATCHER =
+            Matchers.isSameType("com.palantir.logsafe.Preconditions");
+
+    @Override
+    public Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
+        if (LEGACY_PRECONDITIONS_MATCHER.matches(tree, state)
+                // Only attempt to warn or refactor when the preconditions dependency version is sufficiently new,
+                // older versions which haven't deprecated "com.palantir.logsafe.Preconditions" won't have the
+                // replacement.
+                && ASTHelpers.hasAnnotation(ASTHelpers.getSymbol(tree), Deprecated.class, state)) {
+            return buildDescription(tree)
+                    .addFix(SuggestedFix.replace(tree, "com.palantir.logsafe.preconditions.Preconditions"))
+                    .build();
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreconditionsTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreconditionsTests.java
@@ -41,7 +41,7 @@ public abstract class PreconditionsTests {
         compilationHelper()
                 .addSourceLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "import com.palantir.logsafe.UnsafeArg;",
                         "class Test {",
                         "  void f(String param) {",
@@ -149,7 +149,7 @@ public abstract class PreconditionsTests {
         compilationHelper()
                 .addSourceLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "import com.palantir.logsafe.UnsafeArg;",
                         "import java.util.Iterator;",
                         "class Test {",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditionsTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggingPreconditionsTests.java
@@ -191,9 +191,9 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "import com.google.common.base.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -213,7 +213,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkArgument(param != \"string\", \"constant\");",
@@ -229,7 +229,7 @@ public final class PreferSafeLoggingPreconditionsTests {
         RefactoringValidator.of(new PreferSafeLoggingPreconditions(), getClass())
                 .addInputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    com.google.common.base.Preconditions.checkArgument(param != \"string\", \"constant\");",
@@ -242,7 +242,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkArgument(param != \"string\", \"constant\");",
@@ -267,9 +267,9 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "    Preconditions.checkArgument(param != \"string\", \"constant\");",
                         "    Preconditions.checkState(param != \"string\", \"constant\");",
                         "    Preconditions.checkNotNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .addOutputLines(
@@ -277,12 +277,12 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "import com.google.common.base.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -301,7 +301,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "import java.util.Objects;",
                         "class Test {",
                         "  void f(String param) {",
@@ -323,7 +323,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkNotNull(param, \"constant\");",
@@ -337,7 +337,7 @@ public final class PreferSafeLoggingPreconditionsTests {
         RefactoringValidator.of(new PreferSafeLoggingPreconditions(), getClass())
                 .addInputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    java.util.Objects.requireNonNull(param, \"constant\");",
@@ -346,7 +346,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkNotNull(param, \"constant\");",
@@ -365,17 +365,17 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "class Test {",
                         "  void f(String param) {",
                         "    Objects.requireNonNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "import java.util.Objects;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkNotNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -396,7 +396,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "import org.apache.commons.lang3.Validate;",
                         "class Test {",
                         "  void f(String param) {",
@@ -422,7 +422,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkArgument(param != \"string\", \"constant\");",
@@ -438,7 +438,7 @@ public final class PreferSafeLoggingPreconditionsTests {
         RefactoringValidator.of(new PreferSafeLoggingPreconditions(), getClass())
                 .addInputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    org.apache.commons.lang3.Validate.isTrue(param != \"string\", \"constant\");",
@@ -451,7 +451,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkArgument(param != \"string\", \"constant\");",
@@ -476,23 +476,23 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "    Validate.isTrue(param != \"string\", \"constant\");",
                         "    Validate.validState(param != \"string\", \"constant\");",
                         "    Validate.notNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "import org.apache.commons.lang3.Validate;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkArgument(param != \"string\", \"constant\");",
                         "    Preconditions.checkState(param != \"string\", \"constant\");",
                         "    Preconditions.checkNotNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -519,10 +519,10 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "import java.util.Objects;",
                         "class Test {",
                         "  void f(String param) {",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -543,7 +543,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkNotNull(param, \"constant\");",
@@ -573,7 +573,7 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import com.palantir.logsafe.Preconditions;",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
                         "class Test {",
                         "  void f(String param) {",
                         "    Preconditions.checkNotNull(param, \"constant\");",
@@ -614,13 +614,13 @@ public final class PreferSafeLoggingPreconditionsTests {
                         "import java.util.Objects;",
                         "class Test {",
                         "  void f(String param) {",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkArgument(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkState(param != \"string\", \"constant\");",
-                        "    com.palantir.logsafe.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkArgument(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkState(param != \"string\", \"constant\");",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(param, \"constant\");",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPreconditionsMigrationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPreconditionsMigrationTest.java
@@ -1,0 +1,108 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+class SafeLoggingPreconditionsMigrationTest {
+
+    @Test
+    void testFullyQualified() {
+        helper().addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  void f(Object o) {",
+                        "    com.palantir.logsafe.Preconditions.checkNotNull(o);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  void f(Object o) {",
+                        "    com.palantir.logsafe.preconditions.Preconditions.checkNotNull(o);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testClassImport() {
+        helper().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.Preconditions;",
+                        "class Test {",
+                        "  void f(Object o) {",
+                        "    Preconditions.checkNotNull(o);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.preconditions.Preconditions;",
+                        "class Test {",
+                        "  void f(Object o) {",
+                        "    Preconditions.checkNotNull(o);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testStaticImport() {
+        helper().addInputLines(
+                        "Test.java",
+                        "import static com.palantir.logsafe.Preconditions.checkNotNull;",
+                        "class Test {",
+                        "  void f(Object o) {",
+                        "    checkNotNull(o);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static com.palantir.logsafe.preconditions.Preconditions.checkNotNull;",
+                        "class Test {",
+                        "  void f(Object o) {",
+                        "    checkNotNull(o);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testStaticStarImport() {
+        helper().addInputLines(
+                        "Test.java",
+                        "import static com.palantir.logsafe.Preconditions.*;",
+                        "class Test {",
+                        "  void f(Object o) {",
+                        "    checkNotNull(o);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static com.palantir.logsafe.preconditions.Preconditions.*;",
+                        "class Test {",
+                        "  void f(Object o) {",
+                        "    checkNotNull(o);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    private RefactoringValidator helper() {
+        return RefactoringValidator.of(new SafeLoggingPreconditionsMigration(), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-1632.v2.yml
+++ b/changelog/@unreleased/pr-1632.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Migrate preconditions to the new package
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1632

--- a/docs/java-style-guide/readme.md
+++ b/docs/java-style-guide/readme.md
@@ -332,7 +332,7 @@ the exception of the members of the following classes:
 
 - `java.util.Collections`
 - `java.util.stream.Collectors`
-- `com.palantir.logsafe.Preconditions`
+- `com.palantir.logsafe.preconditions.Preconditions`
 - `com.google.common.base.Preconditions`
 - `org.apache.commons.lang3.Validate`
 

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -81,7 +81,7 @@
         </module>
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
-            <property name="excludes" value="com.google.common.base.Preconditions.*, com.palantir.logsafe.Preconditions.*, java.util.Collections.*, java.util.stream.Collectors.*, org.apache.commons.lang3.Validate.*, org.assertj.core.api.Assertions.*, org.mockito.Mockito.*"/>
+            <property name="excludes" value="com.google.common.base.Preconditions.*, com.palantir.logsafe.preconditions.Preconditions.*, java.util.Collections.*, java.util.stream.Collectors.*, org.apache.commons.lang3.Validate.*, org.assertj.core.api.Assertions.*, org.mockito.Mockito.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -58,6 +58,7 @@ public class BaselineErrorProneExtension {
             "ReadReturnValueIgnored",
             "RedundantMethodReference",
             "RedundantModifier",
+            "SafeLoggingPreconditionsMigration",
             "Slf4jLevelCheck",
             "Slf4jLogsafeArgs",
             "Slf4jThrowable",


### PR DESCRIPTION
## Before this PR
See https://github.com/palantir/safe-logging/pull/515



## After this PR
This change does two things:
* The existing errorprone checks which reference preconditions
  have been updated to suggest the new package name
* A new `SafeLoggingPreconditionsMigration` check has been added
  to automatically migrate code to the new package when a
  sufficiently new `safe-logging` version is available.
==COMMIT_MSG==
Migrate preconditions to the new package
==COMMIT_MSG==
