### PR TITLE
Fix false positive ClassInitializationDeadlock on `.class` access

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ClassInitializationDeadlock.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ClassInitializationDeadlock.java
@@ -190,7 +190,10 @@ public final class ClassInitializationDeadlock extends BugChecker implements Bug
             if (symbol != null && symbol.isStatic() && symbol instanceof VarSymbol) {
                 VarSymbol varSymbol = (VarSymbol) symbol;
                 // Constant values may be accessed without forcing initialization
-                if (varSymbol.getConstValue() == null && isSubtype(varSymbol.owner.type, baseType, state)) {
+                if (varSymbol.getConstValue() == null
+                        && isSubtype(varSymbol.owner.type, baseType, state)
+                        // .class access does not force class initialization
+                        && !varSymbol.name.contentEquals("class")) {
                     state.reportMatch(describeMatch(node));
                     return null;
                 }

--- a/changelog/@unreleased/pr-1654.v2.yml
+++ b/changelog/@unreleased/pr-1654.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix false positive ClassInitializationDeadlock on `.class` access
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1654


### PR DESCRIPTION
## Before this PR
False positive preventing baseline upgrades in sls-packaging: https://github.com/palantir/sls-packaging/pull/1062

## After this PR
Accessing the class field does not initialize a class.
==COMMIT_MSG==
Fix false positive ClassInitializationDeadlock on `.class` access
==COMMIT_MSG==

## Possible downsides?
There are operations one can invoke upon the `Class` object which will initialize
the referenced class, but those are relatively rare and out of scope for this check.
