### PR TITLE
Improve the StrictUnusedVariable failure message

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -238,9 +238,11 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             }
             state.reportMatch(buildDescription(unused)
                     .setMessage(String.format(
-                            "%s %s '%s' is never read.",
+                            "%s %s '%s' is never read. Intentional occurrences are acknowledged by renaming "
+                                    + "the unused variable with a leading underscore. '_%s', for example.",
                             unused instanceof VariableTree ? "The" : "The assignment to this",
                             describeVariable(symbol),
+                            symbol.name,
                             symbol.name))
                     .addAllFixes(fixes.stream()
                             .map(f -> SuggestedFix.builder()

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -72,11 +72,11 @@ public class StrictUnusedVariableTest {
                         "Test.java",
                         "import java.util.Optional;",
                         "class Test {",
-                        "  // BUG: Diagnostic contains: Unused",
+                        "  // BUG: Diagnostic contains: '_foo', for example",
                         "   Test(String foo) { }",
-                        "  // BUG: Diagnostic contains: Unused",
+                        "  // BUG: Diagnostic contains: '_buggy', for example",
                         "  private static void privateMethod(String buggy) { }",
-                        "  // BUG: Diagnostic contains: Unused",
+                        "  // BUG: Diagnostic contains: '_buggy', for example",
                         "  public static void publicMethod(String buggy) { }",
                         "}")
                 .doTest();

--- a/changelog/@unreleased/pr-1656.v2.yml
+++ b/changelog/@unreleased/pr-1656.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve the StrictUnusedVariable failure message
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1656


### PR DESCRIPTION
The StrictUnusedVariable failure message describes that leading
prefixes are used to acknowledge unused variables, previosuly
the check failed with `did you mean void foo(_varName)?` which
fails to convey expectations.

==COMMIT_MSG==
Improve the StrictUnusedVariable failure message
==COMMIT_MSG==
