### PR TITLE
Exclude internal ImmutablesStyle annotations from auto-imports and completion

### DIFF
--- a/changelog/@unreleased/pr-1668.v2.yml
+++ b/changelog/@unreleased/pr-1668.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Internal `ImmutablesStyle` annotations are now excluded from Intellij auto-imports and completion.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1668

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -441,7 +441,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 <name>org.inferred.freebuilder.shaded</name>
                 <name>org.immutables.value.internal</name>
                 <name>com.palantir.conjure.java.client.config.ImmutablesStyle</name>
-                <name>com.palantir.sls.versionsImmutablesStyle</name>
+                <name>com.palantir.sls.versions.ImmutablesStyle</name>
                 <name>com.palantir.tokens.auth.ImmutablesStyle</name>
               </excluded-names>
             </component>

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -96,7 +96,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             addInspectionProjectProfile(node)
             addJavacSettings(node)
             addGitHubIssueNavigation(node)
-            ignoreCommonShadedPackages(node)
+            addExcludedAutoImports(node)
         }
         configureProjectForIntellijImport(rootProject)
 
@@ -430,7 +430,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
         }
     }
 
-    private static void ignoreCommonShadedPackages(Node node) {
+    private static void addExcludedAutoImports(Node node) {
         // language=xml
         node.append(new XmlParser().parseText('''
             <component name="JavaProjectCodeInsightSettings">
@@ -440,6 +440,9 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 <name>autovalue.shaded</name>
                 <name>org.inferred.freebuilder.shaded</name>
                 <name>org.immutables.value.internal</name>
+                <name>com.palantir.conjure.java.client.config.ImmutablesStyle</name>
+                <name>com.palantir.sls.versionsImmutablesStyle</name>
+                <name>com.palantir.tokens.auth.ImmutablesStyle</name>
               </excluded-names>
             </component>
         '''.stripIndent()))


### PR DESCRIPTION
These `ImmutablesStyle` annotations should not be public, but doing so would be a breaking change.

To prevent continued accidental usage, prevent them from being automatically imported or appearing in completion results.