### PR TITLE
Disable AutoCloseableMustBeClosed by default

### DIFF
--- a/changelog/@unreleased/pr-1677.v2.yml
+++ b/changelog/@unreleased/pr-1677.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Disable AutoCloseableMustBeClosed by default
+
+    Projects can choose to manually opt-in by enabling the `AutoCloseableMustBeClosed` check as part of their baseline configuration and running `./gradlew compileJava compileTestJava -PerrorProneApply=AutoCloseableMustBeClosed && ./gradlew format` to apply the automated fixes.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1677

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -219,7 +219,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                     : CheckSeverity.OFF;
         }));
 
-        errorProneOptions.disable("CatchSpecificity", "UnusedVariable");
+        errorProneOptions.disable("AutoCloseableMustBeClosed", "CatchSpecificity", "UnusedVariable");
         errorProneOptions.error(
                 "EqualsHashCode",
                 "EqualsIncompatibleType",


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/gradle-baseline/pull/1673 added `AutoCloseableMustBeClosed` which is quite noisy on some large projects

## After this PR
==COMMIT_MSG==
Disable AutoCloseableMustBeClosed by default

Projects can choose to manually opt-in by enabling the `AutoCloseableMustBeClosed` check as part of their baseline configuration and running `./gradlew compileJava compileTestJava -PerrorProneApply=AutoCloseableMustBeClosed && ./gradlew format` to apply the automated fixes.
==COMMIT_MSG==

## Possible downsides?

