### PR TITLE
PreferImmutableStreamExCollections is disabled by default

### DIFF
--- a/changelog/@unreleased/pr-1681.v2.yml
+++ b/changelog/@unreleased/pr-1681.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: PreferImmutableStreamExCollections is disabled by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1681

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -71,7 +71,6 @@ public class BaselineErrorProneExtension {
             // TODO(ckozak): re-enable pending scala check
             // "ThrowSpecificity",
             "UnsafeGaugeRegistration",
-            "PreferImmutableStreamExCollections",
 
             // Built-in checks
             "ArrayEquals",

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -219,7 +219,11 @@ public final class BaselineErrorProne implements Plugin<Project> {
                     : CheckSeverity.OFF;
         }));
 
-        errorProneOptions.disable("AutoCloseableMustBeClosed", "CatchSpecificity", "UnusedVariable");
+        errorProneOptions.disable(
+                "AutoCloseableMustBeClosed",
+                "CatchSpecificity",
+                "PreferImmutableStreamExCollections",
+                "UnusedVariable");
         errorProneOptions.error(
                 "EqualsHashCode",
                 "EqualsIncompatibleType",


### PR DESCRIPTION
## Before this PR
The suggested replacement is too risky, potentially causing failures
at runtime.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
PreferImmutableStreamExCollections is disabled by default
==COMMIT_MSG==
