### PR TITLE
AutoCloseableMustBeClosed doesn't match method overrides

### DIFF
--- a/changelog/@unreleased/pr-1685.v2.yml
+++ b/changelog/@unreleased/pr-1685.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: AutoCloseableMustBeClosed doesn't match method overrides
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1685


### PR DESCRIPTION
In most cases interactions occur with the base interface, not
the implementation, so we shouldn't flag implementations of
types we cannot control.

## Before this PR
Lots of findings when the check is enabled.

## After this PR
==COMMIT_MSG==
AutoCloseableMustBeClosed doesn't match method overrides
==COMMIT_MSG==

## Possible downsides?
Might miss some resource leaks, however I expect it to substantially improve the snr for rollout.

