### PR TITLE
Baseline applies the `-parameters` javac option for method parameter metadata

### DIFF
--- a/changelog/@unreleased/pr-1690.v2.yml
+++ b/changelog/@unreleased/pr-1690.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Baseline applies the `-parameters` javac option for method parameter metadata
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1690

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -47,6 +47,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineExactDependencies.class);
             proj.getPluginManager().apply(BaselineReleaseCompatibility.class);
             proj.getPluginManager().apply(BaselineTesting.class);
+            proj.getPluginManager().apply(BaselineJavaParameters.class);
 
             // TODO(dsanduleac): enable this when people's idea{} blocks no longer reference things like
             //    configurations.integrationTestCompile

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaParameters.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaParameters.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+/**
+ * Applies the {@code -parameters} compiler option to include additional metadata for reflection on method parameters.
+ */
+public final class BaselineJavaParameters implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getTasks()
+                .withType(JavaCompile.class)
+                .configureEach(javaCompileTask ->
+                        javaCompileTask.getOptions().getCompilerArgs().add("-parameters"));
+    }
+}

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-java-properties.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-java-properties.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineJavaParameters


### PR DESCRIPTION
## Before this PR
No parameter metadata.

## After this PR
This produces bytecode with method parameter metadata to support
more powerful reflection features and stronger automated migrations.
==COMMIT_MSG==
Baseline applies the `-parameters` javac option for method parameter metadata
==COMMIT_MSG==

## Possible downsides?
Not sure how to test this. The change is pretty simple though, and we don't need to worry about applying the `-parameters` option twice because `javac` doesn't mind.
