### PR TITLE
Fix IncubatingMethod check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IncubatingMethod.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IncubatingMethod.java
@@ -40,7 +40,7 @@ public final class IncubatingMethod extends BugChecker
 
     /** Matcher for the Incubating annotation, using the full qualified path. */
     private static final Matcher<Tree> INCUBATING_MATCHER =
-            Matchers.hasAnnotation("com.palantir.conjure.java.lib.internal.Incubating");
+            Matchers.symbolHasAnnotation("com.palantir.conjure.java.lib.internal.Incubating");
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IncubatingMethodTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IncubatingMethodTest.java
@@ -17,7 +17,7 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IncubatingMethodTest {
 

--- a/changelog/@unreleased/pr-1698.v2.yml
+++ b/changelog/@unreleased/pr-1698.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Fix IncubatingMethod check
+
+    The check was non-functional; the test did not catch this since it was using the wrong `@Test` annotation. Fixed both issues.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1698


### PR DESCRIPTION
The check was non-functional; the test did not catch this since it was using the wrong `@Test` annotation. Fixed both issues.

