### PR TITLE
Broaden the check to catch all final types which don't override equals/hashCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `ClassInitializationDeadlock`: Detect type structures which can cause deadlocks initializing classes.
 - `ConsistentLoggerName`: Ensure Loggers are named consistently.
 - `PreferImmutableStreamExCollections`: It's common to use toMap/toSet/toList() as the terminal operation on a stream, but would be extremely surprising to rely on the mutability of these collections. Prefer `toImmutableMap`, `toImmutableSet` and `toImmutableList`. (If the performance overhead of a stream is already acceptable, then the `UnmodifiableFoo` wrapper is likely tolerable).
+- `DangerousIdentityKey`: Key type does not override equals() and hashCode, so comparisons will be done on reference equality only.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousIdentityKey.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousIdentityKey.java
@@ -16,27 +16,42 @@
 
 package com.palantir.baseline.errorprone;
 
+import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.AbstractAsKeyOfSetOrMap;
-import com.google.errorprone.util.ASTHelpers;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.util.Name;
 
 /**
  * Warns that users should not have a {@link java.util.regex.Pattern} as a key to a Set or Map.
  */
 @BugPattern(
-        name = "PatternAsKeyOfSetOrMap",
-        summary = "Pattern does not override equals() or hashCode, so comparisons will be done on"
+        name = "DangerousIdentityKey",
+        summary = "Key type does not override equals() and hashCode, so comparisons will be done on"
                 + " reference equality only. If neither deduplication nor lookup are needed,"
                 + " consider using a List instead. Otherwise, use IdentityHashMap/Set,"
                 + " or an Iterable/List of pairs.",
         severity = SeverityLevel.WARNING)
-public final class PatternAsKeyOfSetOrMap extends AbstractAsKeyOfSetOrMap {
+public final class DangerousIdentityKey extends AbstractAsKeyOfSetOrMap {
 
     @Override
     protected boolean isBadType(Type type, VisitorState state) {
-        return ASTHelpers.isSubtype(type, state.getTypeFromString("java.util.regex.Pattern"), state);
+        // Only flag final types, otherwise we'll encounter false positives when presented with overrides.
+        if (type == null || !type.isFinal()) {
+            return false;
+        }
+        return !implementsMethod(state.getTypes(), type, state.getNames().equals, state)
+                || !implementsMethod(state.getTypes(), type, state.getNames().hashCode, state);
+    }
+
+    private static boolean implementsMethod(Types types, Type type, Name methodName, VisitorState state) {
+        MethodSymbol equals =
+                (MethodSymbol) state.getSymtab().objectType.tsym.members().findFirst(methodName);
+        return !Iterables.isEmpty(types.membersClosure(type, false)
+                .getSymbolsByName(methodName, m -> m != equals && m.overrides(equals, type.tsym, types, false)));
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousIdentityKeyTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousIdentityKeyTest.java
@@ -20,13 +20,13 @@ import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public final class PatternAsKeyOfSetOrMapTest {
+public final class DangerousIdentityKeyTest {
 
     private CompilationTestHelper compilationHelper;
 
     @BeforeEach
     public void before() {
-        compilationHelper = CompilationTestHelper.newInstance(PatternAsKeyOfSetOrMap.class, getClass());
+        compilationHelper = CompilationTestHelper.newInstance(DangerousIdentityKey.class, getClass());
     }
 
     @Test
@@ -38,7 +38,7 @@ public final class PatternAsKeyOfSetOrMapTest {
                         "import java.util.regex.Pattern;",
                         "class Test {",
                         "    private Object test() {",
-                        "        // BUG: Diagnostic contains: Pattern does not override equals",
+                        "        // BUG: Diagnostic contains: does not override equals",
                         "        return new HashMap<Pattern, String>();",
                         "    }",
                         "}")
@@ -54,7 +54,7 @@ public final class PatternAsKeyOfSetOrMapTest {
                         "import java.util.regex.Pattern;",
                         "class Test {",
                         "    private Object test() {",
-                        "        // BUG: Diagnostic contains: Pattern does not override equals",
+                        "        // BUG: Diagnostic contains: does not override equals",
                         "        return new HashSet<Pattern>();",
                         "    }",
                         "}")

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousIdentityKeyTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousIdentityKeyTest.java
@@ -17,7 +17,6 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
-import java.util.HashSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousIdentityKeyTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousIdentityKeyTest.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
+import java.util.HashSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +72,134 @@ public final class DangerousIdentityKeyTest {
                         "class Test {",
                         "    private Object test() {",
                         "        return new IdentityHashMap<Pattern, String>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testValidSetKey() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    private Object test() {",
+                        "        return new HashSet<String>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testValidNonFinal() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    static class Impl {}",
+                        "    private Object test() {",
+                        "        return new HashSet<Impl>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testValidEnum() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    enum Impl {",
+                        "        INSTANCE",
+                        "    }",
+                        "    private Object test() {",
+                        "        return new HashSet<Impl>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testInvalidNoEquals() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    static final class Impl {",
+                        "        @Override public boolean equals(Object o) {",
+                        "            return true;",
+                        "        }",
+                        "    }",
+                        "    private Object test() {",
+                        "        // BUG: Diagnostic contains: does not override",
+                        "        return new HashSet<Impl>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testInvalidNoHash() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    static final class Impl {",
+                        "        @Override public int hashCode() {",
+                        "            return 1;",
+                        "        }",
+                        "    }",
+                        "    private Object test() {",
+                        "        // BUG: Diagnostic contains: does not override",
+                        "        return new HashSet<Impl>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testObjectAllowed() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    private Object test() {",
+                        "        return new HashSet<Object>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testRawTypeAllowed() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    private Object test() {",
+                        "        return new HashSet();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testWildcardAllowed() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    private HashSet<?> test() {",
+                        "        return new HashSet<>();",
                         "    }",
                         "}")
                 .doTest();


### PR DESCRIPTION

==COMMIT_MSG==
Broaden the check to catch all final types which don't override equals/hashCode
==COMMIT_MSG==

