### PR TITLE
Add baseline-immutables plugin to enable incremental compilation for Immutables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ _Baseline is a family of Gradle plugins for configuring Java projects with sensi
 | `com.palantir.baseline-encoding`              | Ensures projects use the UTF-8 encoding in compile tasks.
 | `com.palantir.baseline-release-compatibility` | Ensures projects targetting older JREs only compile against classes and methods available in those JREs.
 | `com.palantir.baseline-testing`               | Configures test tasks to dump heap dumps (hprof files) for convenient debugging
+| `com.palantir.baseline-immutables`            | Enables incremental compilation for the [Immutables](http://immutables.github.io/) annotation processor.
 
 See also the [Baseline Java Style Guide and Best Practices](./docs).
 
@@ -402,6 +403,14 @@ The plugin also adds a `checkJUnitDependencies` to make the migration to JUnit5 
 
 3. For repos that use 'snapshot' style testing, it's convenient to have a single command to accept the updated snapshots after a code change.
 This plugin ensures that if you run tests with `./gradlew test -Drecreate=true`, the system property will be passed down to the running Java process (which can be detected with `Boolean.getBoolean("recreate")`).
+
+## com.palantir.baseline-immutables
+
+This plugin enables incremental compilation for the [Immutables](http://immutables.github.io/) annotation processor.
+
+This plugin adds the `-Aimmutables.gradle.incremental` compiler arg to the compile Java task for any source set whose annotation processor configuration contains the Immutables annotation processor.
+
+For more details, see the Immutables incremental compilation [tracking issue](https://github.com/immutables/immutables/issues/804).
 
 ## com.palantir.baseline-fix-gradle-java (off by default)
 

--- a/changelog/@unreleased/pr-1750.v2.yml
+++ b/changelog/@unreleased/pr-1750.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Adds the `baseline-immutables` plugin to enable incremental compilation for Immutables.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1750

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -48,6 +48,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineReleaseCompatibility.class);
             proj.getPluginManager().apply(BaselineTesting.class);
             proj.getPluginManager().apply(BaselineJavaParameters.class);
+            proj.getPluginManager().apply(BaselineImmutables.class);
 
             // TODO(dsanduleac): enable this when people's idea{} blocks no longer reference things like
             //    configurations.integrationTestCompile

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import java.util.Objects;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+public final class BaselineImmutables implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().withPlugin("java", unused -> {
+            project.afterEvaluate(proj -> {
+                proj.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().stream()
+                        .filter(sourceSet -> hasImmutablesProcessor(project, sourceSet))
+                        .forEach(sourceSet -> addImmutablesIncrementalCompilerArg(project, sourceSet));
+            });
+        });
+    }
+
+    private static boolean hasImmutablesProcessor(Project project, SourceSet sourceSet) {
+        return project
+                .getConfigurations()
+                .getByName(sourceSet.getAnnotationProcessorConfigurationName())
+                .getDependencies()
+                .stream()
+                .anyMatch(BaselineImmutables::isImmutablesValue);
+    }
+
+    private static boolean isImmutablesValue(Dependency dep) {
+        return Objects.equals(dep.getGroup(), "org.immutables") && Objects.equals(dep.getName(), "value");
+    }
+
+    private static void addImmutablesIncrementalCompilerArg(Project project, SourceSet sourceSet) {
+        project.getTasks()
+                .named(sourceSet.getCompileJavaTaskName(), JavaCompile.class)
+                .get()
+                .getOptions()
+                .getCompilerArgs()
+                .add("-Aimmutables.gradle.incremental");
+    }
+}

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-immutables.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-immutables.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineImmutables


### PR DESCRIPTION
## Before this PR
Most of our internal projects use the [Immutables](http://immutables.github.io/) annotation processor to generate immutable value objects.

Unfortunately, the Immutables processor does not support incremental compilation by default. This means that even trivial changes to subprojects that use the Immutables processor trigger a full rebuild.

For more details, see https://g.p.b/foundry/multipass/pull/11849.

## After this PR
Fortunately, Immutables has opt-in support for enabling incremental compilation. See https://github.com/immutables/immutables/issues/804.

This PR adds the `baseline-immutables` plugin to enable incremental compilation for source sets using the Immutables processor.

In my testing, I haven't encountered any issues and it dramatically improves compilation times during incremental work, which is fairly typical in dev workflows.