### PR TITLE
Don't use lambda to provider compiler arguments

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.process.CommandLineArgumentProvider;
 
 public final class BaselineImmutables implements Plugin<Project> {
 
@@ -36,12 +37,16 @@ public final class BaselineImmutables implements Plugin<Project> {
                         .get()
                         .getOptions()
                         .getCompilerArgumentProviders()
-                        .add(() -> {
-                            if (hasImmutablesProcessor(project, sourceSet)) {
-                                return Collections.singletonList("-Aimmutables.gradle.incremental");
-                            }
+                        // Use an anonymous class because tasks with lambda inputs cannot be cached
+                        .add(new CommandLineArgumentProvider() {
+                            @Override
+                            public Iterable<String> asArguments() {
+                                if (hasImmutablesProcessor(project, sourceSet)) {
+                                    return Collections.singletonList("-Aimmutables.gradle.incremental");
+                                }
 
-                            return Collections.emptyList();
+                                return Collections.emptyList();
+                            }
                         });
             });
         });


### PR DESCRIPTION
https://github.com/palantir/gradle-baseline/pull/1752 broke the Immutables incremental compilation because the compile argument provider is a lambda. Because lambda class names are not stable, Gradle can't cache the results of the compile task.
```
Caching disabled for task ':compileJava' because:
  Non-cacheable inputs: property 'options.compilerArgumentProviders.$2' was implemented by the Java lambda 'com.palantir.baseline.plugins.BaselineImmutables$$Lambda$16803/0x0000000801da7c58'. Using Java lambdas is not supported, use an (anonymous) inner class instead.
Task ':compileJava' is not up-to-date because:
  Implementation of input property 'options.compilerArgumentProviders.$2' has changed for task ':compileJava'
The input changes require a full rebuild for incremental task ':compileJava'.
Full recompilation is required because no incremental change information is available. This is usually caused by clean builds or changing compiler arguments.
```

See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:how_does_it_work.