### PR TITLE
Ensure that Gradle CommandLineArgumentProvider are not written as lambdas

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableArgumentProvider.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleCacheableArgumentProvider.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.LambdaExpressionTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.Tree;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "GradleCacheableArgumentProvider",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.ERROR,
+        summary = "Forbid gradle argument providers to be implemented by lambdas.")
+public final class GradleCacheableArgumentProvider extends BugChecker implements LambdaExpressionTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Matcher<Tree> IS_COMMAND_LINE_ARGUMENT_PROVIDER =
+            Matchers.isSubtypeOf("org.gradle.process.CommandLineArgumentProvider");
+
+    @Override
+    public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
+        if (!IS_COMMAND_LINE_ARGUMENT_PROVIDER.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+        return buildDescription(tree)
+                .setMessage("Gradle command line providers are not cacheable when implemented by lambdas")
+                .build();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleCacheableArgumentProviderTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleCacheableArgumentProviderTest.java
@@ -1,0 +1,90 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GradleCacheableArgumentProviderTest {
+
+    private static final String errorMsg = "BUG: Diagnostic contains: "
+            + "Gradle command line providers are not cacheable when implemented by lambdas";
+
+    private CompilationTestHelper compilationHelper;
+
+    @BeforeEach
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(GradleCacheableArgumentProvider.class, getClass());
+    }
+
+    @Test
+    public void fails_for_compile_options_lambda_command_line_argument_provider() {
+        compilationHelper
+                .addSourceLines(
+                        "Foo.java",
+                        "import java.util.Collections;",
+                        "import org.gradle.api.tasks.compile.CompileOptions;",
+                        "class Foo {",
+                        "  public final void apply(CompileOptions compileOptions) {",
+                        "    // " + errorMsg,
+                        "    compileOptions.getCompilerArgumentProviders().add(() -> {",
+                        "      return Collections.singleton(\"I'm in a lambda\");",
+                        "    });",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void fails_for_exec_task_lambda_command_line_argument_provider() {
+        compilationHelper
+                .addSourceLines(
+                        "Foo.java",
+                        "import java.util.Collections;",
+                        "import org.gradle.api.tasks.Exec;",
+                        "class Foo {",
+                        "  public final void apply(Exec exec) {",
+                        "    // " + errorMsg,
+                        "    exec.getArgumentProviders().add(() -> {",
+                        "      return Collections.singleton(\"I'm in a lambda\");",
+                        "    });",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void succeeds_for_exec_task_anon_class_command_line_argument_provider() {
+        compilationHelper
+                .addSourceLines(
+                        "Foo.java",
+                        "import java.util.Collections;",
+                        "import org.gradle.api.tasks.Exec;",
+                        "import org.gradle.process.CommandLineArgumentProvider;",
+                        "class Foo {",
+                        "  public final void apply(Exec exec) {",
+                        "    exec.getArgumentProviders().add(new CommandLineArgumentProvider() {",
+                        "      public Iterable<String> asArguments() {",
+                        "        return Collections.singleton(\"I'm in a lambda\");",
+                        "      }",
+                        "    });",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+}

--- a/changelog/@unreleased/pr-1757.v2.yml
+++ b/changelog/@unreleased/pr-1757.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Error prone check to ensure that Gradle `CommandLineArgumentProvider`s are not written as lambdas, which causes them not to be cached.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1757


### PR DESCRIPTION
## Before this PR
As seen in #1755, using a lambda with a `CommandLineArgumentProvider` results in the task not being cached. This is a very subtle bug similar to using lambdas for task actions.

When I was writing the code, I actually thought "can this be cached" then thought it was ok as error prone did not complain.

## After this PR
==COMMIT_MSG==
Error prone check to ensure that Gradle `CommandLineArgumentProvider`s are not written as lambdas, which causes them not to be cached.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

