### PR TITLE
Add ImmutablesInterfaceDefaultValue

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesInterfaceDefaultValue.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesInterfaceDefaultValue.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.LinkType;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.MethodTree;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+
+/**
+ * Checks that interface default methods in an immutables.org @Value.Immutable are marked with @Value.Default.
+ */
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "ImmutablesInterfaceDefaultValue",
+        linkType = LinkType.CUSTOM,
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        severity = BugPattern.SeverityLevel.ERROR,
+        summary = "@Value.Immutable interface default methods should be annotated @Value.Default")
+public final class ImmutablesInterfaceDefaultValue extends BugChecker implements MethodTreeMatcher {
+
+    @Override
+    public Description matchMethod(MethodTree tree, VisitorState state) {
+        ClassSymbol enclosingClass = ASTHelpers.enclosingClass(ASTHelpers.getSymbol(tree));
+        if (enclosingClass != null
+                && ASTHelpers.hasAnnotation(enclosingClass, "org.immutables.value.Value.Immutable", state)) {
+            MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
+            if (methodSymbol != null
+                    && methodSymbol.isDefault()
+                    && !ASTHelpers.hasAnnotation(methodSymbol, "org.immutables.value.Value.Default", state)
+                    && !ASTHelpers.hasAnnotation(methodSymbol, "org.immutables.value.Value.Derived", state)
+                    && !ASTHelpers.hasAnnotation(methodSymbol, "org.immutables.value.Value.Lazy", state)) {
+                SuggestedFix.Builder builder = SuggestedFix.builder();
+                String annotation = SuggestedFixes.qualifyType(state, builder, "org.immutables.value.Value.Default");
+                return buildDescription(tree)
+                        .addFix(builder.prefixWith(tree, "@" + annotation + " ").build())
+                        .build();
+            }
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesInterfaceDefaultValueTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesInterfaceDefaultValueTest.java
@@ -1,0 +1,133 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+public class ImmutablesInterfaceDefaultValueTest {
+
+    @Test
+    public void testPassesWhenDefaultMethodAnnotatedValueDefault() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.immutables.value.*;",
+                        "public class Test {",
+                        "    @Value.Immutable",
+                        "    public interface InterfaceWithValueDefault {",
+                        "        String value();",
+                        "        @Value.Default",
+                        "        default String defaultValue() {",
+                        "            return \"default\";",
+                        "        }",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testPassesWhenDefaultMethodAnnotatedValueDerived() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.immutables.value.*;",
+                        "public class Test {",
+                        "    @Value.Immutable",
+                        "    public interface InterfaceWithValueDefault {",
+                        "        String value();",
+                        "        @Value.Derived",
+                        "        default String derivedValue() {",
+                        "            return value();",
+                        "        }",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testPassesWhenDefaultMethodAnnotatedValueLazy() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.immutables.value.*;",
+                        "public class Test {",
+                        "    @Value.Immutable",
+                        "    public interface InterfaceWithValueDefault {",
+                        "        String value();",
+                        "        @Value.Lazy",
+                        "        default String lazyValue() {",
+                        "            return value();",
+                        "        }",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void refactorsMissingDefaultValueAnnotation() {
+        refactoring()
+                .addInputLines(
+                        "Test.java",
+                        "import org.immutables.value.*;",
+                        "public class Test {",
+                        "    @Value.Immutable",
+                        "    public interface InterfaceWithValueDefault {",
+                        "        String value();",
+                        "    // BUG: Diagnostic contains: "
+                                + "@Value.Immutable interface default methods should be annotated @Value.Default",
+                        "        default String defaultValue() {",
+                        "            return \"default\";",
+                        "        }",
+                        "        @Value.Derived",
+                        "        default String derivedValue() {",
+                        "            return value();",
+                        "        }",
+                        "        @Value.Lazy",
+                        "        default String lazyValue() {",
+                        "            return value();",
+                        "        }",
+                        "    }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import org.immutables.value.*;",
+                        "public class Test {",
+                        "    @Value.Immutable",
+                        "    public interface InterfaceWithValueDefault {",
+                        "        String value();",
+                        "        @Value.Default",
+                        "        default String defaultValue() {",
+                        "            return \"default\";",
+                        "        }",
+                        "        @Value.Derived",
+                        "        default String derivedValue() {",
+                        "            return value();",
+                        "        }",
+                        "        @Value.Lazy",
+                        "        default String lazyValue() {",
+                        "            return value();",
+                        "        }",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    private CompilationTestHelper helper() {
+        return CompilationTestHelper.newInstance(ImmutablesInterfaceDefaultValue.class, getClass());
+    }
+
+    private RefactoringValidator refactoring() {
+        return RefactoringValidator.of(ImmutablesInterfaceDefaultValue.class, getClass());
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesInterfaceDefaultValueTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesInterfaceDefaultValueTest.java
@@ -21,6 +21,27 @@ import org.junit.jupiter.api.Test;
 public class ImmutablesInterfaceDefaultValueTest {
 
     @Test
+    public void testFailsWhenDefaultMethodNotAnnotated() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.immutables.value.*;",
+                        "public class Test {",
+                        "    @Value.Immutable",
+                        "    public interface InterfaceWithValueDefault {",
+                        "        String value();",
+                        "",
+                        "        // BUG: Diagnostic contains: @Value.Immutable interface"
+                                + " default methods should be annotated with"
+                                + " @Value.Default, @Value.Derived, or @Value.Lazy",
+                        "        default String defaultValue() {",
+                        "            return \"default\";",
+                        "        }",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testPassesWhenDefaultMethodAnnotatedValueDefault() {
         helper().addSourceLines(
                         "Test.java",
@@ -29,6 +50,7 @@ public class ImmutablesInterfaceDefaultValueTest {
                         "    @Value.Immutable",
                         "    public interface InterfaceWithValueDefault {",
                         "        String value();",
+                        "",
                         "        @Value.Default",
                         "        default String defaultValue() {",
                         "            return \"default\";",
@@ -47,6 +69,7 @@ public class ImmutablesInterfaceDefaultValueTest {
                         "    @Value.Immutable",
                         "    public interface InterfaceWithValueDefault {",
                         "        String value();",
+                        "",
                         "        @Value.Derived",
                         "        default String derivedValue() {",
                         "            return value();",
@@ -65,6 +88,7 @@ public class ImmutablesInterfaceDefaultValueTest {
                         "    @Value.Immutable",
                         "    public interface InterfaceWithValueDefault {",
                         "        String value();",
+                        "",
                         "        @Value.Lazy",
                         "        default String lazyValue() {",
                         "            return value();",
@@ -84,15 +108,18 @@ public class ImmutablesInterfaceDefaultValueTest {
                         "    @Value.Immutable",
                         "    public interface InterfaceWithValueDefault {",
                         "        String value();",
+                        "",
                         "    // BUG: Diagnostic contains: "
                                 + "@Value.Immutable interface default methods should be annotated @Value.Default",
                         "        default String defaultValue() {",
                         "            return \"default\";",
                         "        }",
+                        "",
                         "        @Value.Derived",
                         "        default String derivedValue() {",
                         "            return value();",
                         "        }",
+                        "",
                         "        @Value.Lazy",
                         "        default String lazyValue() {",
                         "            return value();",
@@ -106,14 +133,17 @@ public class ImmutablesInterfaceDefaultValueTest {
                         "    @Value.Immutable",
                         "    public interface InterfaceWithValueDefault {",
                         "        String value();",
+                        "",
                         "        @Value.Default",
                         "        default String defaultValue() {",
                         "            return \"default\";",
                         "        }",
+                        "",
                         "        @Value.Derived",
                         "        default String derivedValue() {",
                         "            return value();",
                         "        }",
+                        "",
                         "        @Value.Lazy",
                         "        default String lazyValue() {",
                         "            return value();",

--- a/changelog/@unreleased/pr-1761.v2.yml
+++ b/changelog/@unreleased/pr-1761.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Add ImmutablesInterfaceDefaultValue
+
+    @Value.Immutable interface default methods should be annotated @Value.Default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1761


### PR DESCRIPTION
## Before this PR
In code reviews, noticed some uses of `@Value.Immutable` on `default` methods in interfaces without corresponding `@Value.Default`, `@Value.Lazy` or `@Value.Derived`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add ImmutablesInterfaceDefaultValue

@Value.Immutable interface default methods should be annotated @Value.Default
==COMMIT_MSG==

## Possible downsides?
Refactoring suggestion assumes `@Value.Default` was intended if not already annotated `@Value.Lazy` or `@Value.Derived`


