### PR TITLE
Disable InlineMeSuggester by default

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -222,6 +222,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.disable(
                 "AutoCloseableMustBeClosed",
                 "CatchSpecificity",
+                "InlineMeSuggester",
                 "PreferImmutableStreamExCollections",
                 "UnusedVariable",
                 // ConsistentOverrides will be enabled in a follow-up with


### PR DESCRIPTION
The `InlineMeSuggester` check suggests adding the `@InlineMe` annotation to any single-statement method annotated with `@Deprecated`. There are a couple problems with this.
- Consumers generally don't have the error-prone annotations on their compile classpath, so they couldn't add `@InlineMe` even if they wanted to.
- Methods are deprecated for many different reasons. Often methods are deprecated simply because they should not be used and not because they delegate to a replacement. In these cases, we definitely don't want callers to inline the method. The fact that the method happens to be a single statement is irrelevant.