### PR TITLE
Fix: Correctly expose junit-reports plugin

### DIFF
--- a/changelog/@unreleased/pr-1778.v2.yml
+++ b/changelog/@unreleased/pr-1778.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correctly expose junit-reports plugin
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1778

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/JunitReportsPluginSpec.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/JunitReportsPluginSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline
 
+import com.palantir.baseline.plugins.BaselineCircleCi
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.lang.IgnoreIf
@@ -31,15 +32,15 @@ class JunitReportsPluginSpec extends IntegrationSpec {
         gradleVersion = gradleVersionNumber
 
         when:
-        buildFile << '''
+        buildFile << """
             apply plugin: 'java'
             apply plugin: 'checkstyle'
-            apply plugin: 'com.palantir.junit-reports'
+            ${applyPlugin(BaselineCircleCi)}
             
             repositories {
                 jcenter()
             }
-        '''.stripIndent()
+        """.stripIndent()
 
         file('src/main/java/foo/Foo.java') << '''
             package foo;

--- a/gradle-junit-reports/src/main/resources/META-INF/gradle-plugins/com.palantir.junit-reports.properties
+++ b/gradle-junit-reports/src/main/resources/META-INF/gradle-plugins/com.palantir.junit-reports.properties
@@ -1,1 +1,1 @@
-implementation-class=com.palantir.baseline.plugins.BaselineCircleCi
+implementation-class=com.palantir.gradle.junit.JunitReportsPlugin


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
Correctly expose junit-reports plugin
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

