### PR TITLE
Fix ImmutablesStyle check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesStyle.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesStyle.java
@@ -42,17 +42,18 @@ import org.immutables.value.Value;
                 + "See https://github.com/immutables/immutables/issues/291.")
 public final class ImmutablesStyle extends BugChecker implements BugChecker.ClassTreeMatcher {
 
-    private static final Matcher<ClassTree> INLINE_STYLE_ANNOTATION = Matchers.hasAnnotation(Value.Style.class);
+    private static final Matcher<ClassTree> STYLE_ANNOTATION = Matchers.hasAnnotation(Value.Style.class);
 
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
+        if (!STYLE_ANNOTATION.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
         switch (tree.getKind()) {
             case CLASS:
             case INTERFACE:
-                if (INLINE_STYLE_ANNOTATION.matches(tree, state)) {
-                    return describeMatch(tree);
-                }
-                break;
+                return describeMatch(tree);
             case ANNOTATION_TYPE:
                 ClassSymbol classSymbol = ASTHelpers.getSymbol(tree);
                 if (!ElementPredicates.hasSourceRetention(classSymbol)) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesStyleTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesStyleTest.java
@@ -16,7 +16,7 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ImmutablesStyleTest {
 
@@ -96,6 +96,13 @@ public class ImmutablesStyleTest {
                         "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)\n",
                         "public @interface MyMetaAnnotation {}")
                 .addSourceLines("Person.java", "@MyMetaAnnotation", "public interface Person {}")
+                .doTest();
+    }
+
+    @Test
+    public void testOtherAnnotation() {
+        helper().addSourceLines("MyOtherAnnotation.java", "public @interface MyOtherAnnotation {}")
+                .addSourceLines("Person.java", "@MyOtherAnnotation", "public interface Person {}")
                 .doTest();
     }
 


### PR DESCRIPTION
I forgot to check the annotation class in the `ANNOTATION_TYPE` case in https://github.com/palantir/gradle-baseline/pull/1727. As a result, the `ImmutableStyle` check reports false positives for all other annotations.