### PR TITLE
Suppress immutables check on tests

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitializationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitializationTest.java
@@ -24,6 +24,7 @@ import org.immutables.value.Value;
 import org.immutables.value.Value.Style.ImplementationVisibility;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("ImmutablesStyle") // explicitly testing immutables
 public class ImmutablesBuilderMissingInitializationTest {
     @Test
     public void testPassesWhenAllFieldsPopulated() {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Excavator https://github.com/palantir/gradle-baseline/pull/1762 is failing due to `ImmutablesStyle` check on tests using immutables `@Value.Style` to control 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
ImmutablesBuilderMissingInitializationTest compiles with latest gradle-baseline
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

