### PR TITLE
Fix VarUsage false positives in lambdas

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/VarUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/VarUsage.java
@@ -27,8 +27,10 @@ import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
 import com.google.errorprone.util.ErrorProneToken;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
 
 @AutoService(BugChecker.class)
@@ -47,6 +49,15 @@ public final class VarUsage extends BugChecker implements BugChecker.VariableTre
         // prior to tokenizing the variable tree.
         String sourceType = state.getSourceForNode(typeTree);
         if (sourceType != null) {
+            return Description.NO_MATCH;
+        }
+        TreePath parentPath = state.getPath().getParentPath();
+        if (parentPath == null) {
+            return Description.NO_MATCH;
+        }
+        Tree parentTree = parentPath.getLeaf();
+        if (parentTree instanceof LambdaExpressionTree) {
+            // Lambdas may take the form: var -> var.foo()
             return Description.NO_MATCH;
         }
         for (ErrorProneToken token : state.getOffsetTokensForNode(tree)) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/VarUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/VarUsageTest.java
@@ -66,6 +66,20 @@ class VarUsageTest {
                 .doTest();
     }
 
+    @Test
+    void testNegative() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import java.util.stream.Stream;",
+                        "class Test {",
+                        "  void function(Stream<String> stream) {",
+                        "    stream.forEach(var -> System.out.println(var));",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
     private RefactoringValidator fix() {
         return RefactoringValidator.of(VarUsage.class, getClass());
     }

--- a/changelog/@unreleased/pr-1789.v2.yml
+++ b/changelog/@unreleased/pr-1789.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix VarUsage false positives in lambdas
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1789


### PR DESCRIPTION
==COMMIT_MSG==
Fix VarUsage false positives in lambdas
==COMMIT_MSG==

Failure: https://github.com/palantir/conjure/pull/880