### PR TITLE
Increase default test heap from 512m to 2g

### DIFF
--- a/changelog/@unreleased/pr-1813.v2.yml
+++ b/changelog/@unreleased/pr-1813.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Increase default test heap from 512m to 2g unless otherwise specified
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1813

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -47,6 +47,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineExactDependencies.class);
             proj.getPluginManager().apply(BaselineReleaseCompatibility.class);
             proj.getPluginManager().apply(BaselineTesting.class);
+            proj.getPluginManager().apply(BaselineTestHeap.class);
             proj.getPluginManager().apply(BaselineJavaParameters.class);
             proj.getPluginManager().apply(BaselineImmutables.class);
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTestHeap.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTestHeap.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.testing.Test;
+
+/**
+ * Increases the default {@code test} task heap from {@code 512m} to {@code 2g}.
+ */
+public final class BaselineTestHeap implements Plugin<Project> {
+
+    private static final String TEST_HEAP = "2g";
+
+    @Override
+    public void apply(Project project) {
+        project.getTasks().withType(Test.class).configureEach(testTask -> {
+            String currentValue = testTask.getMaxHeapSize();
+            if (currentValue == null) {
+                testTask.setMaxHeapSize(TEST_HEAP);
+            }
+        });
+    }
+}

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-test-heap.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-test-heap.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineTestHeap

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestHeapTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestHeapTest.groovy
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline
+
+
+import org.gradle.api.tasks.testing.Test
+import com.palantir.baseline.plugins.BaselineTestHeap;
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class BaselineTestHeapTest extends Specification {
+
+    def testDefaultHeapIsIncreased() {
+        when:
+        def project = ProjectBuilder.builder().build()
+        project.buildscript {
+            repositories {
+                mavenCentral()
+            }
+        }
+        project.plugins.apply 'java'
+        project.plugins.apply BaselineTestHeap
+        project.evaluate()
+
+        then:
+        Test testTask = project.tasks.getByName('test')
+        testTask.getMaxHeapSize() == '2g'
+    }
+
+    def testOverridesAreNotImpacted() {
+        when:
+        def project = ProjectBuilder.builder().build()
+        project.buildscript {
+            repositories {
+                mavenCentral()
+            }
+        }
+        project.plugins.apply 'java'
+        project.test {
+            maxHeapSize = '1024m'
+        }
+        project.plugins.apply BaselineTestHeap
+        project.evaluate()
+
+        then:
+        Test testTask = project.tasks.getByName('test')
+        testTask.getMaxHeapSize() == '1024m'
+    }
+}


### PR DESCRIPTION
This could have been added to the BaselineTesting plugin instead,
but I prefer small isolated components where possible. Not a terribly
strong opinion though.

==COMMIT_MSG==
Increase default test heap from 512m to 2g unless otherwise specified
==COMMIT_MSG==

