### PR TITLE
Add LogsafeRid error-prone check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeRid.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeRid.java
@@ -30,13 +30,14 @@ import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Type;
 
 @AutoService(BugChecker.class)
 @BugPattern(
         name = "LogsafeRid",
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = SeverityLevel.SUGGESTION,
+        severity = SeverityLevel.WARNING,
         summary = "Prevent rids from being logged as safe.")
 public final class LogsafeRid extends BugChecker implements MethodInvocationTreeMatcher {
 
@@ -51,7 +52,9 @@ public final class LogsafeRid extends BugChecker implements MethodInvocationTree
             return Description.NO_MATCH;
         }
 
-        if (ASTHelpers.getReturnType(tree).toString().contains("com.palantir.ri.ResourceIdentifier")) {
+        ExpressionTree value = tree.getArguments().get(1);
+        Type valueType = ASTHelpers.getType(value);
+        if (valueType != null && valueType.toString().contains("com.palantir.ri.ResourceIdentifier")) {
             SuggestedFix.Builder builder = SuggestedFix.builder();
             String unsafeArg = SuggestedFixes.qualifyType(state, builder, "com.palantir.logsafe.UnsafeArg");
             return buildDescription(tree)

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeRid.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeRid.java
@@ -55,7 +55,7 @@ public final class LogsafeRid extends BugChecker implements MethodInvocationTree
             SuggestedFix.Builder builder = SuggestedFix.builder();
             String unsafeArg = SuggestedFixes.qualifyType(state, builder, "com.palantir.logsafe.UnsafeArg");
             return buildDescription(tree)
-                    .setMessage("Arguments with with rid values must be marked as unsafe.")
+                    .setMessage("Arguments with with rid values are not guaranteed to be safe.")
                     .addFix(builder.replace(tree.getMethodSelect(), unsafeArg + ".of")
                             .build())
                     .build();

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeRid.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeRid.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "LogsafeRid",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.SUGGESTION,
+        summary = "Prevent rids from being logged as safe.")
+public final class LogsafeRid extends BugChecker implements MethodInvocationTreeMatcher {
+
+    private static final Matcher<ExpressionTree> SAFE_ARG_OF =
+            Matchers.staticMethod().onClass("com.palantir.logsafe.SafeArg").named("of");
+
+    public LogsafeRid() {}
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!SAFE_ARG_OF.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        if (ASTHelpers.getReturnType(tree).toString().contains("com.palantir.ri.ResourceIdentifier")) {
+            SuggestedFix.Builder builder = SuggestedFix.builder();
+            String unsafeArg = SuggestedFixes.qualifyType(state, builder, "com.palantir.logsafe.UnsafeArg");
+            return buildDescription(tree)
+                    .setMessage("Arguments with with rid values must be marked as unsafe.")
+                    .addFix(builder.replace(tree.getMethodSelect(), unsafeArg + ".of")
+                            .build())
+                    .build();
+        }
+
+        return Description.NO_MATCH;
+    }
+    //
+    // private static boolean containsRid(Object value) {
+    //     if (value instanceof ResourceIdentifier) {
+    //         return true;
+    //     }
+    //     if (value instanceof String) {
+    //         return ResourceIdentifier.isValid((String) value);
+    //     }
+    //     if (value instanceof Optional<?>) {
+    //         return ((Optional<?>) value).map(LogsafeRid::containsRid).orElse(false);
+    //     }
+    //     if (value instanceof Collection<?>) {
+    //         return ((Collection<?>) value).stream().anyMatch(LogsafeRid::containsRid);
+    //     }
+    //     if (value instanceof Map<?, ?>) {
+    //         return ((Map<?, ?>) value)
+    //                 .entrySet().stream()
+    //                         .anyMatch(entry -> containsRid(entry.getKey()) || containsRid(entry.getValue()));
+    //     }
+    //     return false;
+    // }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeRid.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeRid.java
@@ -63,25 +63,4 @@ public final class LogsafeRid extends BugChecker implements MethodInvocationTree
 
         return Description.NO_MATCH;
     }
-    //
-    // private static boolean containsRid(Object value) {
-    //     if (value instanceof ResourceIdentifier) {
-    //         return true;
-    //     }
-    //     if (value instanceof String) {
-    //         return ResourceIdentifier.isValid((String) value);
-    //     }
-    //     if (value instanceof Optional<?>) {
-    //         return ((Optional<?>) value).map(LogsafeRid::containsRid).orElse(false);
-    //     }
-    //     if (value instanceof Collection<?>) {
-    //         return ((Collection<?>) value).stream().anyMatch(LogsafeRid::containsRid);
-    //     }
-    //     if (value instanceof Map<?, ?>) {
-    //         return ((Map<?, ?>) value)
-    //                 .entrySet().stream()
-    //                         .anyMatch(entry -> containsRid(entry.getKey()) || containsRid(entry.getValue()));
-    //     }
-    //     return false;
-    // }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeRidTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeRidTests.java
@@ -59,7 +59,8 @@ public final class LogsafeRidTests {
                         "  void f() {",
                         "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
                                 + "UUID.randomUUID().toString());\n",
-                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be safe.",
+                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be"
+                                + " safe.",
                         "    SafeArg.of(\"rid\", rid);",
                         "  }",
                         "",
@@ -128,7 +129,8 @@ public final class LogsafeRidTests {
                         "  void f() {",
                         "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
                                 + "UUID.randomUUID().toString());\n",
-                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be safe.",
+                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be"
+                                + " safe.",
                         "    SafeArg.of(\"rid\", Optional.of(rid));",
                         "  }",
                         "",
@@ -200,7 +202,8 @@ public final class LogsafeRidTests {
                         "  void f() {",
                         "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
                                 + "UUID.randomUUID().toString());\n",
-                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be safe.",
+                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be"
+                                + " safe.",
                         "    SafeArg.of(\"rid\", Map.of(rid, 1));",
                         "  }",
                         "",
@@ -272,7 +275,8 @@ public final class LogsafeRidTests {
                         "  void f() {",
                         "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
                                 + "UUID.randomUUID().toString());\n",
-                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be safe.",
+                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be"
+                                + " safe.",
                         "    SafeArg.of(\"rid\", Set.of(rid));",
                         "  }",
                         "",
@@ -345,7 +349,8 @@ public final class LogsafeRidTests {
                         "  void f() {",
                         "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
                                 + "UUID.randomUUID().toString());\n",
-                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be safe.",
+                        "    // BUG: Diagnostic contains: Arguments with with rid values are not guaranteed to be"
+                                + " safe.",
                         "    SafeArg.of(\"rid\", Set.of(List.of(rid)));",
                         "  }",
                         "",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeRidTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeRidTests.java
@@ -1,0 +1,341 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+public final class LogsafeRidTests {
+
+    @Test
+    public void ignores_ridarg_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.Arg;",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.UUID;",
+                        "class RidArg {",
+                        "  @SuppressWarnings(\"LogsafeRid\")",
+                        "  public static Arg<ResourceIdentifier> of(ResourceIdentifier rid) {",
+                        "    return SafeArg.of(\"rid\", rid);",
+                        "  }",
+                        "}",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    RidArg.of(rid);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void catches_safe_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    // BUG: Diagnostic contains: must be marked as unsafe",
+                        "    SafeArg.of(\"rid\", rid);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void fixes_safe_rid_arg() {
+        getRefactoringHelper()
+                .addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    SafeArg.of(\"rid\", rid);",
+                        "  }",
+                        "",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.logsafe.UnsafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    UnsafeArg.of(\"rid\", rid);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void ignores_non_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "class Test {",
+                        "  void f() {",
+                        "    SafeArg.of(\"v\", \"value\");",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void catches_safe_optional_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Optional;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    // BUG: Diagnostic contains: must be marked as unsafe",
+                        "    SafeArg.of(\"rid\", Optional.of(rid));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void fixes_safe_optional_rid_arg() {
+        getRefactoringHelper()
+                .addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Optional;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    SafeArg.of(\"rid\", Optional.of(rid));",
+                        "  }",
+                        "",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.logsafe.UnsafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Optional;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    UnsafeArg.of(\"rid\", Optional.of(rid));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void ignores_non_optional_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import java.util.Optional;",
+                        "class Test {",
+                        "  void f() {",
+                        "    SafeArg.of(\"v\", Optional.of(1));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void catches_safe_map_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Map;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    // BUG: Diagnostic contains: must be marked as unsafe",
+                        "    SafeArg.of(\"rid\", Map.of(rid, 1));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void fixes_safe_map_rid_arg() {
+        getRefactoringHelper()
+                .addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Map;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    SafeArg.of(\"rid\", Map.of(1, rid));",
+                        "  }",
+                        "",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.logsafe.UnsafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Map;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    UnsafeArg.of(\"rid\", Map.of(1, rid));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void ignores_non_map_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import java.util.Map;",
+                        "class Test {",
+                        "  void f() {",
+                        "    SafeArg.of(\"v\", Map.of(1, \"1\"));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void catches_safe_collection_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Set;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    // BUG: Diagnostic contains: must be marked as unsafe",
+                        "    SafeArg.of(\"rid\", Set.of(rid));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void fixes_safe_collection_rid_arg() {
+        getRefactoringHelper()
+                .addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Set;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    SafeArg.of(\"rid\", Set.of(rid));",
+                        "  }",
+                        "",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import com.palantir.logsafe.UnsafeArg;",
+                        "import com.palantir.ri.ResourceIdentifier;",
+                        "import java.util.Set;",
+                        "import java.util.UUID;",
+                        "class Test {",
+                        "  void f() {",
+                        "    ResourceIdentifier rid = ResourceIdentifier.of(\"service\", \"instance\", \"locator\", "
+                                + "UUID.randomUUID().toString());\n",
+                        "    UnsafeArg.of(\"rid\", Set.of(rid));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void ignores_non_set_rid_arg() {
+        getCompilationHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.SafeArg;",
+                        "import java.util.Set;",
+                        "class Test {",
+                        "  void f() {",
+                        "    SafeArg.of(\"v\", Set.of(1));",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    private static RefactoringValidator getRefactoringHelper() {
+        return RefactoringValidator.of(LogsafeRid.class, LogsafeRid.class);
+    }
+
+    private static CompilationTestHelper getCompilationHelper() {
+        return CompilationTestHelper.newInstance(LogsafeRid.class, LogsafeRid.class);
+    }
+}

--- a/changelog/@unreleased/pr-1817.v2.yml
+++ b/changelog/@unreleased/pr-1817.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: '`LogsafeRid` errorprone check flags instances of `com.palantir.ri.ResourceIdentifier`s
+    being logged as safe.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1817

--- a/versions.props
+++ b/versions.props
@@ -5,7 +5,6 @@ com.google.errorprone:error_prone_core = 2.7.1
 com.google.errorprone:error_prone_refaster = 2.7.1
 com.google.errorprone:error_prone_test_helpers = 2.7.1
 com.google.guava:guava = 30.1.1-jre
-com.palantir.ri:resource-identifier = 1.3.0
 com.palantir.safe-logging:* = 1.16.0
 org.apache.maven.shared:maven-dependency-analyzer = 1.11.3
 org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11 = 1.0.1

--- a/versions.props
+++ b/versions.props
@@ -5,6 +5,7 @@ com.google.errorprone:error_prone_core = 2.7.1
 com.google.errorprone:error_prone_refaster = 2.7.1
 com.google.errorprone:error_prone_test_helpers = 2.7.1
 com.google.guava:guava = 30.1.1-jre
+com.palantir.ri:resource-identifier = 1.3.0
 com.palantir.safe-logging:* = 1.16.0
 org.apache.maven.shared:maven-dependency-analyzer = 1.11.3
 org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.11 = 1.0.1


### PR DESCRIPTION
## Before this PR
`ResourceIdentifier` are not safe to log if their locators contain unsafe data. However, there are many instances where `ResourceIdentifier`s are logged as safe, as `ResourceIdentifier`s are _usually_ safe. We should warn developers before they safe-log their rids.

## After this PR
==COMMIT_MSG==
`LogsafeRid` errorprone check flags instances of `com.palantir.ri.ResourceIdentifier`s being logged as safe.
==COMMIT_MSG==

This is just a `SeverityLevel.WARNING` right now; we'll change the level to `SeverityLevel.ERROR` on the repos we wish to enforce this.

## Possible downsides?
Ideally, the fix would be to replace `SafeArg` with `RidArg` (instead of `UnsafeArg`, as we do in this PR). We can't do this yet, but will see if we can start publishing `RidArg` in a more easily available library so we can recommend usage of it here.
