### PR TITLE
Enable ConsistentOverrides by default

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConsistentOverrides.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConsistentOverrides.java
@@ -122,10 +122,14 @@ public final class ConsistentOverrides extends BugChecker implements MethodTreeM
     }
 
     private static boolean equivalentNames(String actual, String expected) {
-        return actual.equals(expected)
+        return actual.equalsIgnoreCase(expected)
                 // Handle StrictUnusedVariable underscore prefixes in both directions
-                || (actual.charAt(0) == '_' && actual.length() == expected.length() + 1 && actual.endsWith(expected))
-                || (expected.charAt(0) == '_' && expected.length() == actual.length() + 1 && expected.endsWith(actual));
+                || (actual.charAt(0) == '_'
+                        && actual.length() == expected.length() + 1
+                        && actual.substring(1).equalsIgnoreCase(expected))
+                || (expected.charAt(0) == '_'
+                        && expected.length() == actual.length() + 1
+                        && expected.substring(1).equalsIgnoreCase(actual));
     }
 
     // If any parameters have names that don't match 'arg\d+', names are retained.

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ConsistentOverridesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ConsistentOverridesTest.java
@@ -82,7 +82,6 @@ class ConsistentOverridesTest {
     void ignores_unhelpfulNames() {
         fix().addInputLines(
                         "Test.java",
-                        "import " + List.class.getCanonicalName() + ";",
                         "class Test {",
                         "  interface Foo {",
                         "    void doStuff(String a, String b);",
@@ -97,10 +96,43 @@ class ConsistentOverridesTest {
     }
 
     @Test
+    void ignores_caseInsensitiveRename() {
+        fix().addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  interface Foo {",
+                        "    void doStuff(String Foo, String Bar);",
+                        "  }",
+                        "  class DefaultFoo implements Foo {",
+                        "    @Override",
+                        "    public void doStuff(String foo, String bar) {}",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    void ignores_caseInsensitiveRenameWithUnused() {
+        fix().addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  interface Foo {",
+                        "    void doStuff(String Foo, String Bar);",
+                        "  }",
+                        "  class DefaultFoo implements Foo {",
+                        "    @Override",
+                        "    public void doStuff(String _foo, String _bar) {}",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
     void allows_unused_variables() {
         fix().addInputLines(
                         "Test.java",
-                        "import " + List.class.getCanonicalName() + ";",
                         "class Test {",
                         "  interface Foo {",
                         "    void doStuff(String foo, String bar);",
@@ -118,7 +150,6 @@ class ConsistentOverridesTest {
     void allows_unused_variable_names() {
         fix().addInputLines(
                         "Test.java",
-                        "import " + List.class.getCanonicalName() + ";",
                         "class Test {",
                         "  interface Foo {",
                         "    void doStuff(String foo, String bar);",
@@ -130,7 +161,6 @@ class ConsistentOverridesTest {
                         "}")
                 .addOutputLines(
                         "Test.java",
-                        "import " + List.class.getCanonicalName() + ";",
                         "class Test {",
                         "  interface Foo {",
                         "    void doStuff(String foo, String bar);",
@@ -147,7 +177,6 @@ class ConsistentOverridesTest {
     void allows_unused_variables_to_be_used() {
         fix().addInputLines(
                         "Test.java",
-                        "import " + List.class.getCanonicalName() + ";",
                         "class Test {",
                         "  interface Foo {",
                         "    void doStuff(String foo, String _bar);",

--- a/changelog/@unreleased/pr-1820.v2.yml
+++ b/changelog/@unreleased/pr-1820.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enable ConsistentOverrides by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1820

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -35,6 +35,7 @@ public class BaselineErrorProneExtension {
             "CollectionStreamForEach",
             "CompileTimeConstantViolatesLiskovSubstitution",
             "ConsistentLoggerName",
+            "ConsistentOverrides",
             "DeprecatedGuavaObjects",
             "ExecutorSubmitRunnableFutureIgnored",
             "ExtendsErrorOrThrowable",

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -224,10 +224,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "CatchSpecificity",
                 "InlineMeSuggester",
                 "PreferImmutableStreamExCollections",
-                "UnusedVariable",
-                // ConsistentOverrides will be enabled in a follow-up with
-                // a clean migration path.
-                "ConsistentOverrides");
+                "UnusedVariable");
         errorProneOptions.error(
                 "EqualsHashCode",
                 "EqualsIncompatibleType",


### PR DESCRIPTION
Note that this will automatically apply fixes for findings, which
_must_ be manually reviewed relatively carefully to avoid making
certain bugs less detectable. This will allow more upgrades to
merge successfully and prevent _future_ bugs from merging because
these are only automatically applied by baseline upgrades and
when they're run manually.

This change also updates the check to allow case-insensitive matching
which will allow checks to pass in places that previously caused
friction or required suppressions. Sometimes third party APIs
use upper-camel names, and it can be difficult to fix them in a
reasonable amount of time. I've never encountered such a case where
two parameters had the same name with different casing. If we find
such APIs, it may be best to migrate to other libraries...

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable ConsistentOverrides by default
==COMMIT_MSG==