### PR TITLE
ProxyNonConstantType documents describe suppression cases and steps

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ProxyNonConstantType.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ProxyNonConstantType.java
@@ -41,7 +41,8 @@ import java.lang.reflect.Proxy;
         severity = SeverityLevel.WARNING,
         summary = "Proxy instances should be created using constant types known at compile time to allow native-image "
                 + "behavior to match hotspot. Methods which build proxies should take a "
-                + "`Function<InvocationHandler, ? extends T>` instead of arbitrary class references. "
+                + "`Function<InvocationHandler, ? extends T>` instead of arbitrary class references. This check can "
+                + "be safely suppressed in legacy code using @SuppressWarnings(\"ProxyNonConstantType\"). "
                 + "The proxy annotation processor can make this process much easier: "
                 + "https://github.com/palantir/proxy-processor\n"
                 + "See https://www.graalvm.org/reference-manual/native-image/DynamicProxy/#automatic-detection")
@@ -65,7 +66,7 @@ public final class ProxyNonConstantType extends BugChecker implements BugChecker
             if (interfaces instanceof NewArrayTree) {
                 NewArrayTree newArrayTree = (NewArrayTree) interfaces;
                 for (ExpressionTree element : newArrayTree.getInitializers()) {
-                    if (!isDirectClassAccess(element)) {
+                    if (!isDirectClassAccess(element) && !TestCheckUtils.isTestCode(state)) {
                         return describeMatch(interfaces);
                     }
                 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ProxyNonConstantTypeTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ProxyNonConstantTypeTest.java
@@ -62,6 +62,22 @@ class ProxyNonConstantTypeTest {
                 .doTest();
     }
 
+    @Test
+    void testIgnoresTestCode() {
+        helper().addSourceLines(
+                        "Foo.java",
+                        "import java.lang.reflect.Proxy;",
+                        "import org.junit.Test;",
+                        "class Foo {",
+                        "  @Test",
+                        "  public void test() {}",
+                        "  void f(Class<?> iface) {",
+                        "    Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{iface}, null);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(ProxyNonConstantType.class, getClass());
     }

--- a/changelog/@unreleased/pr-1827.v2.yml
+++ b/changelog/@unreleased/pr-1827.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ProxyNonConstantType documents describe suppression cases and steps
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1827


### PR DESCRIPTION
The check no longer fails on test code.

==COMMIT_MSG==
ProxyNonConstantType documents describe suppression cases and steps
==COMMIT_MSG==

