### PR TITLE
Fix formatting of baseline-class-uniqueness.lock files

### DIFF
--- a/changelog/@unreleased/pr-1838.v2.yml
+++ b/changelog/@unreleased/pr-1838.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Fix the formatting of `baseline-class-uniqueness.lock` files when more
+    than one configuration is listed. A newline was missing. This may require running
+    `./gradlew checkClassUniqueness --write-locks` to update the files.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1838

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -125,9 +125,8 @@ public class CheckClassUniquenessLockTask extends DefaultTask {
             stringBuilder.append(HEADER);
             resultsByConfiguration.forEach((configuration, maybeContents) -> maybeContents.ifPresent(contents -> {
                 stringBuilder.append("## ").append(configuration).append("\n");
-                stringBuilder.append(contents);
+                stringBuilder.append(contents).append('\n');
             }));
-            stringBuilder.append('\n');
             ensureLockfileContains(stringBuilder.toString());
         }
     }


### PR DESCRIPTION
Fixes #1289 

## Before this PR
When the baseline class uniqueness check found issues in more than one configuration, a newline was missing between the previous configuration and the comment naming the next one. See: #1289

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix the formatting of `baseline-class-uniqueness.lock` files when more than one configuration is listed. A newline was missing. This may require running `./gradlew checkClassUniqueness --write-locks` to update the files.
==COMMIT_MSG==

## Possible downsides?
Requires running the command to write the locks in repos that are affected. (By default only one configuration is set up for the uniqueness check, so the number of affected repos may be small.) I'm not sure if this would be considered a break.
