### PR TITLE
Replace deprecated Report.enabled property

### DIFF
--- a/changelog/@unreleased/pr-1839.v2.yml
+++ b/changelog/@unreleased/pr-1839.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Replace deprecated Report.enabled property
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1839

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
@@ -64,7 +64,7 @@ public final class BaselineCircleCi implements Plugin<Project> {
         }
 
         project.getRootProject().allprojects(proj -> proj.getTasks().withType(Test.class, test -> {
-            test.getReports().getHtml().setEnabled(true);
+            test.getReports().getHtml().getRequired().set(true);
             test.getReports().getHtml().setDestination(junitPath(circleArtifactsDir, test.getPath()));
         }));
     }

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/CheckstyleReportHandler.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/CheckstyleReportHandler.java
@@ -29,7 +29,7 @@ public final class CheckstyleReportHandler extends ReportHandler<Checkstyle> {
     @Override
     public void configureTask(Checkstyle task) {
         // Ensure XML output is enabled
-        task.getReports().findByName("xml").setEnabled(true);
+        task.getReports().findByName("xml").getRequired().set(true);
     }
 
     @Override


### PR DESCRIPTION
## Before this PR

The `Report.enabled` property is deprecated and will get removed with Gradle 7 ([docs](https://docs.gradle.org/7.1.1/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled)).

## After this PR
Replace deprecated Report.enabled with Report.required.

==COMMIT_MSG==
Replace deprecated Report.enabled property
==COMMIT_MSG==