### PR TITLE
Allow `PreferSafeLogger` to migrate uses with level-checks

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLogger.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLogger.java
@@ -128,7 +128,8 @@ public final class PreferSafeLogger extends BugChecker implements BugChecker.Var
         }
         List<? extends Tree> arguments = tree.getArguments();
         if (arguments.isEmpty()) {
-            return false;
+            // is<level>Enabled
+            return true;
         }
         if (!state.getTypes()
                 .isSameType(ASTHelpers.getType(arguments.get(0)), state.getTypeFromString(String.class.getName()))) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggerTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggerTest.java
@@ -131,6 +131,35 @@ class PreferSafeLoggerTest {
     }
 
     @Test
+    void testFixWithLevelCheck() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void action(Throwable t) {",
+                        "    if (log.isInfoEnabled()) {",
+                        "        log.info(\"foo\", t);",
+                        "    }",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.logger.SafeLogger;",
+                        "import com.palantir.logsafe.logger.SafeLoggerFactory;",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                        "  private static final SafeLogger log = SafeLoggerFactory.get(Test.class);",
+                        "  void action(Throwable t) {",
+                        "    if (log.isInfoEnabled()) {",
+                        "        log.info(\"foo\", t);",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testIgnoresIncorrectlyOrderedThrowables() {
         fix().addInputLines(
                         "Test.java",

--- a/changelog/@unreleased/pr-1842.v2.yml
+++ b/changelog/@unreleased/pr-1842.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Allow `PreferSafeLogger` to migrate logger uses which include level-checks
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1842


### PR DESCRIPTION
Oversight in the initial implementation which prevented
level checks from being handled as expected.

## After this PR
==COMMIT_MSG==
Allow `PreferSafeLogger` to migrate logger uses which include level-checks
==COMMIT_MSG==
