### PR TITLE
fix NPE on unused lambda param in static initializer

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -224,7 +224,13 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             ImmutableList<SuggestedFix> fixes;
             if (symbol.getKind() == ElementKind.PARAMETER && !isEverUsed.contains(unusedSymbol)) {
                 Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) symbol.owner;
-                int index = methodSymbol.params.indexOf(symbol);
+                int index;
+                if (methodSymbol.params == null) {
+                    // if the parameter is for a lambda is defined in a static initializer, params is null
+                    index = -1;
+                } else {
+                    index = methodSymbol.params.indexOf(symbol);
+                }
                 // If we can not find the parameter in the owning method, then it must be a parameter to a lambda
                 // defined within the method
                 if (index == -1) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -116,6 +116,24 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
+    void handles_lambdas_in_static_init() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.function.BiFunction;",
+                        "import java.util.Optional;",
+                        "class Test {",
+                        "  static {",
+                        "  // BUG: Diagnostic contains: Unused",
+                        "    BiFunction<String, String, Integer> first = (String value1, String value2) -> 1;",
+                        "  // BUG: Diagnostic contains: Unused",
+                        "    first.andThen(value3 -> 2);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void renames_previous_suppression() {
         refactoringTestHelper
                 .addInputLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -121,7 +121,6 @@ public class StrictUnusedVariableTest {
                 .addSourceLines(
                         "Test.java",
                         "import java.util.function.BiFunction;",
-                        "import java.util.Optional;",
                         "class Test {",
                         "  static {",
                         "  // BUG: Diagnostic contains: Unused",

--- a/changelog/@unreleased/pr-1843.v2.yml
+++ b/changelog/@unreleased/pr-1843.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix NPE from StrictUnusedVarible check for unused lambda parameters
+    in static initializers.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1843


### PR DESCRIPTION
## Before this PR
If a lambda with an unused parameter is declared in a static initializer, the `StrictUnusedVariable` check throws an NPE and halts gradle. `Symbol.MethodSymbol#params` is null on static initializers instead of an empty list.

## After this PR
==COMMIT_MSG==
fix NPE on unused lambda param in static initializer
==COMMIT_MSG==

## Possible downsides?
None.

