### PR TITLE
Implement automatic fixes for `ImmutablesStyle`

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesStyle.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesStyle.java
@@ -16,18 +16,31 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.bugpatterns.inject.ElementPredicates;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.AnnotationMatcherUtils;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ClassTree;
-import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 @AutoService(BugChecker.class)
@@ -46,24 +59,87 @@ public final class ImmutablesStyle extends BugChecker implements BugChecker.Clas
 
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
-        if (!STYLE_ANNOTATION.matches(tree, state)) {
-            return Description.NO_MATCH;
+        if (STYLE_ANNOTATION.matches(tree, state)) {
+            switch (tree.getKind()) {
+                case CLASS:
+                case INTERFACE:
+                    return matchStyleAnnotatedType(tree, state);
+                case ANNOTATION_TYPE:
+                    return matchStyleMetaAnnotation(tree, state);
+                default:
+                    break;
+            }
         }
-
-        switch (tree.getKind()) {
-            case CLASS:
-            case INTERFACE:
-                return describeMatch(tree);
-            case ANNOTATION_TYPE:
-                ClassSymbol classSymbol = ASTHelpers.getSymbol(tree);
-                if (!ElementPredicates.hasSourceRetention(classSymbol)) {
-                    return describeMatch(tree);
-                }
-                break;
-            default:
-                break;
-        }
-
         return Description.NO_MATCH;
+    }
+
+    private Description matchStyleAnnotatedType(ClassTree tree, VisitorState state) {
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        String qualifiedTarget = SuggestedFixes.qualifyType(state, fix, Target.class.getName());
+        String qualifiedElementType = SuggestedFixes.qualifyType(state, fix, ElementType.class.getName());
+        String qualifiedRetention = SuggestedFixes.qualifyType(state, fix, Retention.class.getName());
+        String qualifiedRetentionPolicy = SuggestedFixes.qualifyType(state, fix, RetentionPolicy.class.getName());
+        AnnotationTree styleAnnotationTree = getAnnotation(tree, Value.Style.class, state);
+        String topLevelClassPrefix = ASTHelpers.enclosingClass(ASTHelpers.getSymbol(tree)) == null
+                ? "@SuppressWarnings({\"checkstyle:OuterTypeFilename\", \"checkstyle:OneTopLevelClass\"})\n"
+                : "";
+        return buildDescription(tree)
+                .addFix(fix.prefixWith(tree, String.format("@%sStyle\n", tree.getSimpleName()))
+                        .replace(styleAnnotationTree, "")
+                        .postfixWith(
+                                tree,
+                                String.format(
+                                        "\n@%s(%s.TYPE)\n@%s(%s.SOURCE)\n%s%s\n@interface %sStyle {}\n",
+                                        qualifiedTarget,
+                                        qualifiedElementType,
+                                        qualifiedRetention,
+                                        qualifiedRetentionPolicy,
+                                        topLevelClassPrefix,
+                                        state.getSourceForNode(styleAnnotationTree),
+                                        tree.getSimpleName()))
+                        .build())
+                .build();
+    }
+
+    private Description matchStyleMetaAnnotation(ClassTree tree, VisitorState state) {
+        AnnotationTree retention = getAnnotation(tree, Retention.class, state);
+        if (retention == null) {
+            SuggestedFix.Builder fix = SuggestedFix.builder();
+            fix.prefixWith(
+                    tree,
+                    String.format(
+                            "@%s(%s.SOURCE)",
+                            SuggestedFixes.qualifyType(state, fix, Retention.class.getName()),
+                            SuggestedFixes.qualifyType(state, fix, RetentionPolicy.class.getName())));
+            return buildDescription(tree).addFix(fix.build()).build();
+        }
+        ExpressionTree retentionValue = AnnotationMatcherUtils.getArgument(retention, "value");
+        Symbol retentionValueSymbol = ASTHelpers.getSymbol(retentionValue);
+        if (retentionValueSymbol == null
+                || !retentionValueSymbol.getSimpleName().contentEquals("SOURCE")) {
+            SuggestedFix.Builder fix = SuggestedFix.builder();
+            fix.merge(SuggestedFixes.updateAnnotationArgumentValues(
+                    retention,
+                    "value",
+                    ImmutableList.of(String.format(
+                            "%s.SOURCE", SuggestedFixes.qualifyType(state, fix, RetentionPolicy.class.getName())))));
+            return buildDescription(tree).addFix(fix.build()).build();
+        }
+        return Description.NO_MATCH;
+    }
+
+    @Nullable
+    private static AnnotationTree getAnnotation(
+            ClassTree tree, Class<? extends Annotation> annotationType, VisitorState state) {
+        List<? extends AnnotationTree> annotations = tree.getModifiers().getAnnotations();
+        Type retention = state.getTypeFromString(annotationType.getName());
+        if (retention != null) {
+            for (AnnotationTree annotation : annotations) {
+                if (ASTHelpers.isSameType(ASTHelpers.getType(annotation.getAnnotationType()), retention, state)) {
+                    return annotation;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesStyleTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesStyleTest.java
@@ -32,6 +32,30 @@ public class ImmutablesStyleTest {
     }
 
     @Test
+    public void fixInlineAnnotation() {
+        fix().addInputLines(
+                        "Person.java",
+                        "import org.immutables.value.Value;",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "public interface Person {}")
+                .addOutputLines(
+                        "Person.java",
+                        "import java.lang.annotation.ElementType;",
+                        "import java.lang.annotation.Retention;",
+                        "import java.lang.annotation.RetentionPolicy;",
+                        "import java.lang.annotation.Target;",
+                        "import org.immutables.value.Value;",
+                        "@PersonStyle",
+                        "public interface Person {}",
+                        "@Target(ElementType.TYPE)",
+                        "@Retention(RetentionPolicy.SOURCE)",
+                        "@SuppressWarnings({\"checkstyle:OuterTypeFilename\", \"checkstyle:OneTopLevelClass\"})",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "@interface PersonStyle {}")
+                .doTest();
+    }
+
+    @Test
     public void testMetaAnnotation_defaultRetention() {
         helper().addSourceLines(
                         "MyMetaAnnotation.java",
@@ -43,6 +67,30 @@ public class ImmutablesStyleTest {
                         "// BUG: Diagnostic contains: ImmutablesStyle",
                         "public @interface MyMetaAnnotation {}")
                 .addSourceLines("Person.java", "@MyMetaAnnotation", "public interface Person {}")
+                .doTest();
+    }
+
+    @Test
+    public void fixMetaAnnotation_defaultRetention() {
+        fix().addInputLines(
+                        "MyMetaAnnotation.java",
+                        "import java.lang.annotation.ElementType;",
+                        "import java.lang.annotation.Target;",
+                        "import org.immutables.value.Value;",
+                        "@Target({ElementType.PACKAGE, ElementType.TYPE})\n",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)\n",
+                        "public @interface MyMetaAnnotation {}")
+                .addOutputLines(
+                        "MyMetaAnnotation.java",
+                        "import java.lang.annotation.ElementType;",
+                        "import java.lang.annotation.Retention;",
+                        "import java.lang.annotation.RetentionPolicy;",
+                        "import java.lang.annotation.Target;",
+                        "import org.immutables.value.Value;",
+                        "@Retention(RetentionPolicy.SOURCE)",
+                        "@Target({ElementType.PACKAGE, ElementType.TYPE})\n",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)\n",
+                        "public @interface MyMetaAnnotation {}")
                 .doTest();
     }
 
@@ -65,6 +113,33 @@ public class ImmutablesStyleTest {
     }
 
     @Test
+    public void fixMetaAnnotation_classRetention() {
+        fix().addInputLines(
+                        "MyMetaAnnotation.java",
+                        "import java.lang.annotation.ElementType;",
+                        "import java.lang.annotation.Retention;",
+                        "import java.lang.annotation.RetentionPolicy;",
+                        "import java.lang.annotation.Target;",
+                        "import org.immutables.value.Value;",
+                        "@Target({ElementType.PACKAGE, ElementType.TYPE})",
+                        "@Retention(RetentionPolicy.CLASS)",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "public @interface MyMetaAnnotation {}")
+                .addOutputLines(
+                        "MyMetaAnnotation.java",
+                        "import java.lang.annotation.ElementType;",
+                        "import java.lang.annotation.Retention;",
+                        "import java.lang.annotation.RetentionPolicy;",
+                        "import java.lang.annotation.Target;",
+                        "import org.immutables.value.Value;",
+                        "@Target({ElementType.PACKAGE, ElementType.TYPE})",
+                        "@Retention(RetentionPolicy.SOURCE)",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "public @interface MyMetaAnnotation {}")
+                .doTest();
+    }
+
+    @Test
     public void testMetaAnnotation_runtimeRetention() {
         helper().addSourceLines(
                         "MyMetaAnnotation.java",
@@ -79,6 +154,33 @@ public class ImmutablesStyleTest {
                         "// BUG: Diagnostic contains: ImmutablesStyle",
                         "public @interface MyMetaAnnotation {}")
                 .addSourceLines("Person.java", "@MyMetaAnnotation", "public interface Person {}")
+                .doTest();
+    }
+
+    @Test
+    public void fixMetaAnnotation_runtimeRetention() {
+        fix().addInputLines(
+                        "MyMetaAnnotation.java",
+                        "import java.lang.annotation.ElementType;",
+                        "import java.lang.annotation.Retention;",
+                        "import java.lang.annotation.RetentionPolicy;",
+                        "import java.lang.annotation.Target;",
+                        "import org.immutables.value.Value;",
+                        "@Target({ElementType.PACKAGE, ElementType.TYPE})",
+                        "@Retention(value = RetentionPolicy.RUNTIME)",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "public @interface MyMetaAnnotation {}")
+                .addOutputLines(
+                        "MyMetaAnnotation.java",
+                        "import java.lang.annotation.ElementType;",
+                        "import java.lang.annotation.Retention;",
+                        "import java.lang.annotation.RetentionPolicy;",
+                        "import java.lang.annotation.Target;",
+                        "import org.immutables.value.Value;",
+                        "@Target({ElementType.PACKAGE, ElementType.TYPE})",
+                        "@Retention(value = RetentionPolicy.SOURCE)",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "public @interface MyMetaAnnotation {}")
                 .doTest();
     }
 
@@ -108,5 +210,9 @@ public class ImmutablesStyleTest {
 
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(ImmutablesStyle.class, getClass());
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(ImmutablesStyle.class, getClass());
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesStyleTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesStyleTest.java
@@ -32,7 +32,7 @@ public class ImmutablesStyleTest {
     }
 
     @Test
-    public void fixInlineAnnotation() {
+    public void fixInlineAnnotation_topLevel() {
         fix().addInputLines(
                         "Person.java",
                         "import org.immutables.value.Value;",
@@ -40,18 +40,37 @@ public class ImmutablesStyleTest {
                         "public interface Person {}")
                 .addOutputLines(
                         "Person.java",
+                        "import org.immutables.value.Value;",
+                        "@SuppressWarnings(\"ImmutablesStyle\")",
+                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "public interface Person {}")
+                .doTest();
+    }
+
+    @Test
+    public void fixInlineAnnotation_enclosed() {
+        fix().addInputLines(
+                        "Enclosing.java",
+                        "import org.immutables.value.Value;",
+                        "public class Enclosing {",
+                        "  @Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "  public interface Person {}",
+                        "}")
+                .addOutputLines(
+                        "Enclosing.java",
                         "import java.lang.annotation.ElementType;",
                         "import java.lang.annotation.Retention;",
                         "import java.lang.annotation.RetentionPolicy;",
                         "import java.lang.annotation.Target;",
                         "import org.immutables.value.Value;",
-                        "@PersonStyle",
-                        "public interface Person {}",
-                        "@Target(ElementType.TYPE)",
-                        "@Retention(RetentionPolicy.SOURCE)",
-                        "@SuppressWarnings({\"checkstyle:OuterTypeFilename\", \"checkstyle:OneTopLevelClass\"})",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "@interface PersonStyle {}")
+                        "public class Enclosing {",
+                        "  @Target(ElementType.TYPE)",
+                        "  @Retention(RetentionPolicy.SOURCE)",
+                        "  @Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
+                        "  @interface PersonStyle {}",
+                        "  @PersonStyle",
+                        "  public interface Person {}",
+                        "}")
                 .doTest();
     }
 

--- a/changelog/@unreleased/pr-1846.v2.yml
+++ b/changelog/@unreleased/pr-1846.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement automatic fixes for `ImmutablesStyle`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1846

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -40,6 +40,7 @@ public class BaselineErrorProneExtension {
             "ExecutorSubmitRunnableFutureIgnored",
             "ExtendsErrorOrThrowable",
             "FinalClass",
+            "ImmutablesStyle",
             "ImplicitPublicBuilderConstructor",
             "JavaTimeDefaultTimeZone",
             "JavaTimeSystemDefaultTimeZone",


### PR DESCRIPTION
## Before this PR
Lots of blocked baseline-upgrade excavators, which in turn block Gradle 7 rollout.

## After this PR
Autofix the `ImmutablesStyle` check in a naive way. I'm not thrilled with the code we produce, but I think it satisfies the classpath cleanliness concern without requiring manual intervention.
==COMMIT_MSG==
Implement automatic fixes for `ImmutablesStyle`
==COMMIT_MSG==

## Possible downsides?
The error-prone fix api doesn't allow us to create new files, so I've added suppressions for our `OuterTypeFilename` and `OneTopLevelClass` checkstyle rules.
Ideally we'd detect style configurations that match our style library and use that instead.
Ideally we'd aggregate identical style configurations into a single meta-annotation instead of creating one per class.

