### PR TITLE
auto-apply MethodCanBeStatic

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CompileTimeConstantViolatesLiskovSubstitution.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CompileTimeConstantViolatesLiskovSubstitution.java
@@ -95,7 +95,7 @@ public final class CompileTimeConstantViolatesLiskovSubstitution extends BugChec
         return Description.NO_MATCH;
     }
 
-    private boolean anySuperMethodsMissingParameterAnnotation(
+    private static boolean anySuperMethodsMissingParameterAnnotation(
             Set<MethodSymbol> superMethods, int parameterIndex, VisitorState state) {
         for (MethodSymbol superMethod : superMethods) {
             VarSymbol parameter = superMethod.getParameters().get(parameterIndex);
@@ -106,7 +106,7 @@ public final class CompileTimeConstantViolatesLiskovSubstitution extends BugChec
         return false;
     }
 
-    private boolean anySuperMethodsHaveParameterAnnotation(
+    private static boolean anySuperMethodsHaveParameterAnnotation(
             Set<MethodSymbol> superMethods, int parameterIndex, VisitorState state) {
         for (MethodSymbol superMethod : superMethods) {
             VarSymbol parameter = superMethod.getParameters().get(parameterIndex);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitialization.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesBuilderMissingInitialization.java
@@ -119,7 +119,8 @@ public final class ImmutablesBuilderMissingInitialization extends BugChecker imp
                 .filter(symbol -> symbol.getSimpleName().toString().startsWith(FIELD_INIT_BITS_PREFIX))
                 .map(Symbol::toString)
                 .map(initBitsName -> removeFromStart(initBitsName, FIELD_INIT_BITS_PREFIX))
-                .map(fieldName -> GET_PREFIXES.stream().reduce(fieldName, ImmutablesBuilderMissingInitialization::removeFromStart))
+                .map(fieldName -> GET_PREFIXES.stream()
+                        .reduce(fieldName, ImmutablesBuilderMissingInitialization::removeFromStart))
                 .map(CaseFormat.UPPER_UNDERSCORE.converterTo(CaseFormat.LOWER_CAMEL))
                 .collect(Collectors.toSet());
 
@@ -214,7 +215,10 @@ public final class ImmutablesBuilderMissingInitialization extends BugChecker imp
                         && !symbol.isAnonymous()
                         && symbol.getParameters().size() == 1)
                 .map(symbol -> symbol.getSimpleName().toString())
-                .reduce(fields, ImmutablesBuilderMissingInitialization::removeFieldsPotentiallyInitializedBy, Sets::intersection)
+                .reduce(
+                        fields,
+                        ImmutablesBuilderMissingInitialization::removeFieldsPotentiallyInitializedBy,
+                        Sets::intersection)
                 .isEmpty();
     }
 
@@ -222,7 +226,8 @@ public final class ImmutablesBuilderMissingInitialization extends BugChecker imp
      * Takes a set of uninitialized fields, and returns a set containing the fields that cannot have been initialized by
      * the method methodName.
      */
-    private static Set<String> removeFieldsPotentiallyInitializedBy(Set<String> uninitializedFields, String methodName) {
+    private static Set<String> removeFieldsPotentiallyInitializedBy(
+            Set<String> uninitializedFields, String methodName) {
         String methodNameLowerCase = methodName.toLowerCase();
         return uninitializedFields.stream()
                 .filter(fieldName -> !methodNameLowerCase.endsWith(fieldName.toLowerCase()))

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalFlatMapOfNullable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalFlatMapOfNullable.java
@@ -84,7 +84,7 @@ public final class OptionalFlatMapOfNullable extends BugChecker implements BugCh
                 .build();
     }
 
-    private Optional<ExpressionTree> finalExpression(LambdaExpressionTree lambdaExpressionTree) {
+    private static Optional<ExpressionTree> finalExpression(LambdaExpressionTree lambdaExpressionTree) {
         Tree body = lambdaExpressionTree.getBody();
         switch (lambdaExpressionTree.getBodyKind()) {
             case EXPRESSION:

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionConstructors.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferCollectionConstructors.java
@@ -268,7 +268,7 @@ public final class PreferCollectionConstructors extends BugChecker implements Bu
                 .build();
     }
 
-    private Class<?> findCollectionClassToUse(VisitorState state, ExpressionTree tree) {
+    private static Class<?> findCollectionClassToUse(VisitorState state, ExpressionTree tree) {
         for (Map.Entry<Matcher<ExpressionTree>, Class<?>> entry : classMap.entrySet()) {
             Matcher<ExpressionTree> matcher = entry.getKey();
             if (matcher.matches(tree, state)) {
@@ -282,7 +282,7 @@ public final class PreferCollectionConstructors extends BugChecker implements Bu
         return null;
     }
 
-    private boolean isFirstArgCollection(VisitorState state, ExpressionTree tree) {
+    private static boolean isFirstArgCollection(VisitorState state, ExpressionTree tree) {
         List<JCExpression> args = ((JCMethodInvocation) tree).args;
         if (args.isEmpty()) {
             return false;

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -93,7 +93,7 @@ public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocati
                 .build();
     }
 
-    private List<Integer> getBadArgIndices(VisitorState state, List<? extends ExpressionTree> args, int from, int to) {
+    private static List<Integer> getBadArgIndices(VisitorState state, List<? extends ExpressionTree> args, int from, int to) {
         ImmutableList.Builder<Integer> badArgsBuilder = ImmutableList.builder();
         for (int i = from; i <= to; i++) {
             if (!ARG.matches(args.get(i), state)) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -93,7 +93,8 @@ public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocati
                 .build();
     }
 
-    private static List<Integer> getBadArgIndices(VisitorState state, List<? extends ExpressionTree> args, int from, int to) {
+    private static List<Integer> getBadArgIndices(
+            VisitorState state, List<? extends ExpressionTree> args, int from, int to) {
         ImmutableList.Builder<Integer> badArgsBuilder = ImmutableList.builder();
         for (int i = from; i <= to; i++) {
             if (!ARG.matches(args.get(i), state)) {

--- a/changelog/@unreleased/pr-1848.v2.yml
+++ b/changelog/@unreleased/pr-1848.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: baseline-error-prone now treats the `MethodCanBeStatic` check as WARN
+    (previously it was a SUGGESTION) and auto-fixes it.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1848

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -78,6 +78,7 @@ public class BaselineErrorProneExtension {
             "ArrayEquals",
             "BadImport",
             "MissingBraces",
+            "MethodCanBeStatic",
             "MissingOverride",
             "ObjectsHashCodePrimitive",
             "PreferJavaTimeOverload",

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -236,6 +236,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "URLEqualsHashCode",
                 "BoxedPrimitiveEquality",
                 "ReferenceEquality");
+        errorProneOptions.warn("MethodCanBeStatic");
         // Relax some checks for test code
         if (errorProneOptions.getCompilingTestOnlyCode().get()) {
             errorProneOptions.disable("UnnecessaryLambda");


### PR DESCRIPTION
## Before this PR

I frequently make a code-review suggestion that a method could be static. It occurred to me that this should probably be automated, and indeed Google's error-prone already includes https://errorprone.info/bugpattern/MethodCanBeStatic - but this is a SUGGESTION by default.

I tried it out on an internal project (AS) by running `./gradlew classes -PerrorProneApply=MethodCanBeStatic` and it produced a +135-137 line diff. https://github/foundry/a-s/pull/2915

## After this PR
==COMMIT_MSG==
Automatically apply MethodCanBeStatic
==COMMIT_MSG==

## Possible downsides?
- some lambda references become slightly more verbose, which might trip one-liners onto multiple lines:

```diff
- .map(this::asPredicate)
+.map(InMemoryTestCatalog::asPredicate)
```
- making lots of java changes would mean baseline excavators require approval, which might slow down adoption
- I don't want people to think that static methods are preferred to instance methods in _all_ cases (because they don't really allow dependency injection, interfaces, encapsulation etc)