### PR TITLE
Suppress existing `ProxyNonConstantType` failures to ease rollout

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ProxyNonConstantTypeTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ProxyNonConstantTypeTest.java
@@ -36,6 +36,28 @@ class ProxyNonConstantTypeTest {
     }
 
     @Test
+    void testGuavaReflectionNewProxySuppression() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.google.common.reflect.Reflection;",
+                        "class Test {",
+                        "  void f() {",
+                        "    Reflection.newProxy(Test.class, null);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.google.common.reflect.Reflection;",
+                        "class Test {",
+                        "  @SuppressWarnings(\"ProxyNonConstantType\")",
+                        "  void f() {",
+                        "    Reflection.newProxy(Test.class, null);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testConstantInterfacesInline() {
         helper().addSourceLines(
                         "Test.java",
@@ -63,6 +85,28 @@ class ProxyNonConstantTypeTest {
     }
 
     @Test
+    void testConstantInterfacesDynamicSuppression() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import java.lang.reflect.Proxy;",
+                        "class Test {",
+                        "  void f(Class<?> iface) {",
+                        "    Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{iface}, null);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.lang.reflect.Proxy;",
+                        "class Test {",
+                        "  @SuppressWarnings(\"ProxyNonConstantType\")",
+                        "  void f(Class<?> iface) {",
+                        "    Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{iface}, null);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testIgnoresTestCode() {
         helper().addSourceLines(
                         "Foo.java",
@@ -80,5 +124,9 @@ class ProxyNonConstantTypeTest {
 
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(ProxyNonConstantType.class, getClass());
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(ProxyNonConstantType.class, getClass());
     }
 }

--- a/changelog/@unreleased/pr-1850.v2.yml
+++ b/changelog/@unreleased/pr-1850.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Suppress existing `ProxyNonConstantType` failures to ease rollout
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1850

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -57,6 +57,7 @@ public class BaselineErrorProneExtension {
             "PreferSafeLoggableExceptions",
             "PreferSafeLoggingPreconditions",
             "PreferStaticLoggers",
+            "ProxyNonConstantType",
             "PublicConstructorForAbstractClass",
             "ReadReturnValueIgnored",
             "RedundantMethodReference",


### PR DESCRIPTION
This check is primarily meant to prevent future badness, in most
cases existing uses cannot be easily removed.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Suppress existing `ProxyNonConstantType` failures to ease rollout
==COMMIT_MSG==

## Possible downsides?
Some low-hanging/unused cases may not be resolved.

