### PR TITLE
Fix PreferSafeLogger edge case that produced non-compiling code

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLogger.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferSafeLogger.java
@@ -102,6 +102,9 @@ public final class PreferSafeLogger extends BugChecker implements BugChecker.Var
                     if (sym.equals(ASTHelpers.getSymbol(receiver))) {
                         if (!isSafeSlf4jInteraction(tree, state)) {
                             foundUnknownUsage.set(true);
+                        } else {
+                            // Scan arguments for findings that may not compile
+                            scan(tree.getArguments(), null);
                         }
                         return null;
                     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggerTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferSafeLoggerTest.java
@@ -210,4 +210,48 @@ class PreferSafeLoggerTest {
                 .expectUnchanged()
                 .doTest();
     }
+
+    @Test
+    void testGetNameInArgUnmodified() {
+        // getName is not supported by SafeLogger, so we shouldn't make changes that won't compile.
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void action() {",
+                        "    log.info(\"foo\", SafeArg.of(\"name\", log.getName()));",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    void testIsTraceEnabledInArg() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                        "  private static final Logger log = LoggerFactory.getLogger(Test.class);",
+                        "  void action() {",
+                        "    log.info(\"foo\", SafeArg.of(\"name\", log.isTraceEnabled()));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.palantir.logsafe.logger.SafeLogger;",
+                        "import com.palantir.logsafe.logger.SafeLoggerFactory;",
+                        "import org.slf4j.*;",
+                        "class Test {",
+                        "  private static final SafeLogger log = SafeLoggerFactory.get(Test.class);",
+                        "  void action() {",
+                        "    log.info(\"foo\", SafeArg.of(\"name\", log.isTraceEnabled()));",
+                        "  }",
+                        "}")
+                .doTest();
+    }
 }

--- a/changelog/@unreleased/pr-1851.v2.yml
+++ b/changelog/@unreleased/pr-1851.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix PreferSafeLogger edge case that produced suggested fixes that didn't
+    compile without human interaction.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1851


### PR DESCRIPTION
In most cases we wouldn't go this far to ensure green builds, these
are easy enough to manually update. However, it's important that
automation can roll out the new facade without blocking for devs
to make changes, and we can follow-up with a strict check later
on to migrate the rest.

==COMMIT_MSG==
Fix PreferSafeLogger edge case that produced suggested fixes that didn't compile without human interaction.
==COMMIT_MSG==