### PR TITLE
StrictUnusedVariable exception for SafeLogger

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchBlockLogException.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CatchBlockLogException.java
@@ -53,7 +53,7 @@ public final class CatchBlockLogException extends BugChecker implements BugCheck
     private static final long serialVersionUID = 1L;
 
     private static final Matcher<ExpressionTree> logMethod = MethodMatchers.instanceMethod()
-            .onDescendantOf("org.slf4j.Logger")
+            .onDescendantOfAny("org.slf4j.Logger", "com.palantir.logsafe.logger.SafeLogger")
             .withNameMatching(Pattern.compile("trace|debug|info|warn|error"));
 
     private static final Matcher<Tree> containslogMethod =

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -152,7 +152,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
     /** The set of types exempting a field of type extending them. */
     private static final ImmutableSet<String> EXEMPTING_FIELD_SUPER_TYPES =
-            ImmutableSet.of("org.junit.rules.TestRule", "org.slf4j.Logger");
+            ImmutableSet.of("org.junit.rules.TestRule", "org.slf4j.Logger", "com.palantir.logsafe.logger.SafeLogger");
 
     private static final ImmutableList<String> SPECIAL_FIELDS = ImmutableList.of(
             "serialVersionUID",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -339,4 +339,20 @@ public class StrictUnusedVariableTest {
                 .expectUnchanged()
                 .doTest(TestMode.TEXT_MATCH);
     }
+
+    @Test
+    public void allows_unused_loggers() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import org.slf4j.*;",
+                        "import com.palantir.logsafe.logger.*;",
+                        "class Test {",
+                        "  private static final Logger slf4j = LoggerFactory.getLogger(Test.class);",
+                        "  private static final SafeLogger logsafe = SafeLoggerFactory.get(Test.class);",
+                        "  // BUG: Diagnostic contains: Unused",
+                        "  private static final String str = \"str\";",
+                        "}")
+                .doTest();
+    }
 }

--- a/changelog/@unreleased/pr-1853.v2.yml
+++ b/changelog/@unreleased/pr-1853.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Add a `StrictUnusedVariable` exception for `SafeLogger` matching the
+    existing exception for slf4j. Update CatchBlockLogException to be SafeLogger aware
+    as well.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1853


### PR DESCRIPTION
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add a `StrictUnusedVariable` exception for `SafeLogger` matching the existing exception for slf4j. Update CatchBlockLogException to be SafeLogger aware as well.
==COMMIT_MSG==

## Possible downsides?
none
