### PR TITLE
witchcraft-logging functionality has been migrated

### DIFF
--- a/changelog/@unreleased/pr-1870.v2.yml
+++ b/changelog/@unreleased/pr-1870.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: witchcraft-logging functionality has been migrated to https://github.com/palantir/witchcraft-java-logging#gradle-plugin
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1870

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -44,7 +44,6 @@ import org.gradle.plugins.ide.idea.model.ModuleDependency
 class BaselineIdea extends AbstractBaselinePlugin {
 
     static SAVE_ACTIONS_PLUGIN_MINIMUM_VERSION = '1.9.0'
-    static WITCHCRAFT_LOGGING_PLUGIN_MINIMUM_VERSION = '1.6.0'
 
     void apply(Project project) {
         this.project = project
@@ -119,29 +118,6 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 configureExternalDependencies(node)
             }
             configureSaveActionsForIntellijImport(rootProject)
-        }
-
-        // recommend installing the witchcraft logging plugin
-        // to render json logs into human-readable text.
-        // Checking for the service distribution classes on the
-        // buildscript classpath isn't ideal, however from the
-        // root project we don't want to create dependencies
-        // onto submodules.
-        if (hasJavaServiceDistributionPluginLoaded()) {
-            ideaRootModel.project.ipr.withXml { XmlProvider provider ->
-                Node node = provider.asNode()
-                recommendWitchcraftLoggingPlugin(node)
-            }
-            recommendWitchcraftLoggingPluginForIntellijImport(rootProject)
-        }
-    }
-
-    private static boolean hasJavaServiceDistributionPluginLoaded() {
-        try {
-            Class.forName('com.palantir.gradle.dist.service.JavaServiceDistributionPlugin')
-            return true
-        } catch (ClassNotFoundException ignored) {
-            return false
         }
     }
 
@@ -554,24 +530,5 @@ class BaselineIdea extends AbstractBaselinePlugin {
                 'plugin',
                 [id: 'com.dubreuia'],
                 ['min-version': SAVE_ACTIONS_PLUGIN_MINIMUM_VERSION])
-    }
-
-    private static void recommendWitchcraftLoggingPlugin(Node rootNode) {
-        def externalDependencies =
-                GroovyXmlUtils.matchOrCreateChild(rootNode, 'component', [name: 'ExternalDependencies'])
-        GroovyXmlUtils.matchOrCreateChild(
-                externalDependencies,
-                'plugin',
-                [id: 'com.palantir.witchcraft.api.logging.idea'],
-                ['min-version': WITCHCRAFT_LOGGING_PLUGIN_MINIMUM_VERSION])
-    }
-
-    private static void recommendWitchcraftLoggingPluginForIntellijImport(Project project) {
-        if (!Boolean.getBoolean("idea.active")) {
-            return
-        }
-        XmlUtils.createOrUpdateXmlFile(
-                project.file(".idea/externalDependencies.xml"),
-                BaselineIdea.&recommendWitchcraftLoggingPlugin)
     }
 }


### PR DESCRIPTION
This has been excavated out and replaced by:
https://github.com/palantir/witchcraft-java-logging#gradle-plugin

The witchcraft-java-logging gradle plugin acts as a marker to
avoid our silly sls-packaging class availability check.

Revert "recommend witchcraft logging (#1863)"

This reverts commit 0d8bce022b0a8b43e337ac66d130dccc50d2dc24.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
witchcraft-logging functionality has been migrated to https://github.com/palantir/witchcraft-java-logging#gradle-plugin
==COMMIT_MSG==

