### PR TITLE
JavaDoc uses UTF-8 encoding

### DIFF
--- a/changelog/@unreleased/pr-1879.v2.yml
+++ b/changelog/@unreleased/pr-1879.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: JavaDoc uses UTF-8 encoding by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1879

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEncoding.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEncoding.java
@@ -19,13 +19,17 @@ package com.palantir.baseline.plugins;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.javadoc.Javadoc;
 
 public final class BaselineEncoding implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getTasks().withType(JavaCompile.class).configureEach(javaCompileTask -> {
-            javaCompileTask.getOptions().setEncoding("UTF-8");
-        });
+        project.getTasks()
+                .withType(JavaCompile.class)
+                .configureEach(javaCompileTask -> javaCompileTask.getOptions().setEncoding("UTF-8"));
+        project.getTasks()
+                .withType(Javadoc.class)
+                .configureEach(javadocTask -> javadocTask.getOptions().setEncoding("UTF-8"));
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEncodingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineEncodingIntegrationTest.groovy
@@ -55,6 +55,10 @@ class BaselineEncodingIntegrationTest extends AbstractPluginTest {
 
     def javaFile = '''
         package test;
+
+        /**
+         * Test source file encoding with UTF-8 ☃ Javadoc.
+         */
         public class Test {
             private static final String VALUE = "•";
         }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
See https://github.com/palantir/tritium/issues/1192 where JavaDoc is failing to generate on system using default US-ASCII encoding


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
JavaDoc uses UTF-8 encoding by default
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

