### PR TITLE
Re-add null check for exclude rule

### DIFF
--- a/changelog/@unreleased/pr-1883.v2.yml
+++ b/changelog/@unreleased/pr-1883.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Re-add null check for exclude rule
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1883

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.plugins;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.baseline.tasks.CheckImplicitDependenciesParentTask;
 import com.palantir.baseline.tasks.CheckImplicitDependenciesTask;
@@ -231,10 +232,15 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     }
 
     private static Map<String, String> excludeRuleAsMap(ExcludeRule rule) {
-        return ImmutableMap.<String, String>builder()
-                .put("group", rule.getGroup())
-                .put("module", rule.getModule())
-                .build();
+        // Both 'ExcludeRule#getGroup' and 'ExcludeRule#getModule' can return null.
+        Builder<String, String> excludeRule = ImmutableMap.builder();
+        if (rule.getGroup() != null) {
+            excludeRule.put("group", rule.getGroup());
+        }
+        if (rule.getModule() != null) {
+            excludeRule.put("module", rule.getModule());
+        }
+        return excludeRule.build();
     }
 
     /** Given a {@code com/palantir/product/Foo.class} file, what other classes does it import/reference. */


### PR DESCRIPTION
## Before this PR
We removed this null-check in https://github.com/palantir/gradle-baseline/pull/1875 because intellij flags this as
> Condition 'rule.getGroup() != null' is always 'true'.
> Method 'getGroup' inherits annotation from package org.gradle.api.artifacts, thus 'non-null'.

However this does not seem to be true and an internal library failed to upgrade because `rule.getGroup()` returns null.

Stacktrace:
```
org.gradle.api.internal.tasks.TaskDependencyResolveException: Could not determine the dependencies of task ':checkUnusedDependenciesTest'.
Caused by: java.lang.NullPointerException: null value in entry: group=null
	at com.google.common.collect.CollectPreconditions.checkEntryNotNull(CollectPreconditions.java:32)
	at com.google.common.collect.ImmutableMap.entryOf(ImmutableMap.java:172)
	at com.google.common.collect.ImmutableMap$Builder.put(ImmutableMap.java:282)
	at com.palantir.baseline.plugins.BaselineExactDependencies.excludeRuleAsMap(BaselineExactDependencies.java:235)
	at com.palantir.baseline.plugins.BaselineExactDependencies.lambda$configureSourceSet$7(BaselineExactDependencies.java:173)
	at com.palantir.baseline.plugins.BaselineExactDependencies.lambda$configureSourceSet$8(BaselineExactDependencies.java:173)
	at org.gradle.internal.ImmutableActionSet$SetWithFewActions.execute(ImmutableActionSet.java:285)
       [...]
```

## After this PR
==COMMIT_MSG==
Re-add null check for exclude rule
==COMMIT_MSG==