### PR TITLE
Fix missing setProperty error when using Gradle 6

### DIFF
--- a/changelog/@unreleased/pr-1884.v2.yml
+++ b/changelog/@unreleased/pr-1884.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix missing setProperty error when using Gradle 6
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1884

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/AbstractBaselinePlugin.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/AbstractBaselinePlugin.groovy
@@ -26,7 +26,7 @@ import org.gradle.api.Project
  *
  * Note that we need to extend {@link GroovyObjectSupport} to still support projects using Gradle 6 and thus Groovy 2.x
  * because Baseline is now using Gradle 7 and thus Groovy 3.x. Otherwise, Groovy plugins (i.e. {@link BaselineIdea})
- * fail when setting properties. For more info, see ADD-PR-LINK.
+ * fail when setting properties. For more info, see https://github.com/palantir/gradle-baseline/pull/1884.
  */
 abstract class AbstractBaselinePlugin extends GroovyObjectSupport implements Plugin<Project> {
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/AbstractBaselinePlugin.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/AbstractBaselinePlugin.groovy
@@ -17,15 +17,18 @@
 package com.palantir.baseline.plugins
 
 import com.palantir.baseline.BaselineParameters
+import java.nio.file.Paths
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-import java.nio.file.Paths
-
 /**
  * The super class of all Baseline plugins.
+ *
+ * Note that we need to extend {@link GroovyObjectSupport} to still support projects using Gradle 6 and thus Groovy 2.x
+ * because Baseline is now using Gradle 7 and thus Groovy 3.x. Otherwise, Groovy plugins (i.e. {@link BaselineIdea})
+ * fail when setting properties. For more info, see ADD-PR-LINK.
  */
-abstract class AbstractBaselinePlugin implements Plugin<Project> {
+abstract class AbstractBaselinePlugin extends GroovyObjectSupport implements Plugin<Project> {
 
     /** The {@link Project} that this plugin has been applied to; must be set in the {@link Project#apply} method. */
     protected Project project


### PR DESCRIPTION
## Before this PR
With https://github.com/palantir/gradle-baseline/pull/1875, baseline is build using Gradle 7 and transitively Groovy 3.x.
As a result, projects that still use Gradle 6 and thus Groovy 2.x fail with the following error when applying the `BaselinEclipse` or `BaselineIdea` plugin (both are the only plugins that are still Groovy and not Java classes) ([example](https://app.circleci.com/pipelines/github/palantir/palantir-java-format/1637/workflows/66e85fa7-da35-47cf-8ec0-5a74b6f09e12/jobs/9879)):

```
Caused by: java.lang.AbstractMethodError: Receiver class com.palantir.baseline.plugins.BaselineEclipse does not define or inherit an implementation of the resolved method 'abstract void setProperty(java.lang.String, java.lang.Object)' of interface groovy.lang.GroovyObject.
	at com.palantir.baseline.plugins.BaselineEclipse.apply(BaselineEclipse.groovy:69)
	at com.palantir.baseline.plugins.BaselineEclipse.apply(BaselineEclipse.groovy)
	at org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget.applyImperative(ImperativeOnlyPluginTarget.java:43)
```

Haven't gotten completely on the bottom of this but the issue seems to be that going from Groovy 2.x to 3.x `GroovyObjectSupport` is no longer provided per default.

Relevant issue: https://issues.apache.org/jira/browse/GROOVY-4855
 
## After this PR

Adding `extends GroovyObjectSupport` adds default implementations of Groovy methods including `setProperty`.

Tested it on two internal repos and compiled again.

==COMMIT_MSG==
Fix missing setProperty error when using Gradle 6
==COMMIT_MSG==
