### PR TITLE
allow trailing comma in annotation arrays

### DIFF
--- a/changelog/@unreleased/pr-1904.v2.yml
+++ b/changelog/@unreleased/pr-1904.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: allow trailing comma in annotation arrays
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1904

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -69,7 +69,9 @@
             <property name="tokens" value="VARIABLE_DEF"/>
             <property name="allowSamelineMultipleAnnotations" value="true"/>
         </module>
-        <module name="AnnotationUseStyle"/> <!-- Java Style Guide: Annotations -->
+        <module name="AnnotationUseStyle"> <!-- Java Style Guide: Annotations -->
+            <property name="trailingArrayComma" value="ignore"/>
+        </module>
         <module name="ArrayTypeStyle"/> <!-- Java Style Guide: No C-style array declarations -->
         <module name="AvoidEscapedUnicodeCharacters"> <!-- Java Style Guide: Non-ASCII characters -->
             <property name="allowEscapesForControlCharacters" value="true"/>


### PR DESCRIPTION
## Before this PR
```
@JsonIgnoreProperties({
         "foo",
         "bar", // This comma is not allowed
})
```
It's better to allow it to minimize diffs.

## After this PR
==COMMIT_MSG==
allow trailing comma in annotation arrays
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None.