### PR TITLE
Configure tests to run concurrently

### DIFF
--- a/changelog/@unreleased/pr-1913.v2.yml
+++ b/changelog/@unreleased/pr-1913.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: When using the `baseline-testing` plugin, tests now run concurrently
+    by default.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1913

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -138,9 +138,7 @@ public final class BaselineTesting implements Plugin<Project> {
 
         // https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution
         task.systemProperty("junit.jupiter.execution.parallel.enabled", "true");
-
-        // Computes the desired parallelism based on the number of available processors/cores
-        task.systemProperty("junit.jupiter.execution.parallel.config.strategy", "dynamic");
+        task.systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent");
 
         // provide some stdout feedback when tests fail when running on CI and locally
         task.getTestLogging().getEvents().add(TestLogEvent.FAILED);


### PR DESCRIPTION
## Before this PR
Tests are run sequentially be default.

## After this PR
Tests are run concurrently by default.

It appears that the intention in https://github.com/palantir/gradle-baseline/pull/666 was to run tests concurrently by default. However, that PR was not sufficient - you must also set `junit.jupiter.execution.parallel.mode.default`.

https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution