### PR TITLE
BaselineJavaVersions consistent JDK control via gradle toolchains

### DIFF
--- a/changelog/@unreleased/pr-1920.v2.yml
+++ b/changelog/@unreleased/pr-1920.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: BaselineJavaVersions consistent JDK control via gradle toolchains on
+    an opt-in basis
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1920

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.extensions;
+
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+
+public class BaselineJavaVersionExtension {
+
+    private final Property<JavaLanguageVersion> target;
+    private final Property<JavaLanguageVersion> runtime;
+
+    @Inject
+    public BaselineJavaVersionExtension(Project project) {
+        target = project.getObjects().property(JavaLanguageVersion.class);
+        runtime = project.getObjects().property(JavaLanguageVersion.class);
+        // Runtime defaults to the target value
+        runtime.set(target);
+    }
+
+    /** Target {@link JavaLanguageVersion} for compilation. */
+    public final Property<JavaLanguageVersion> target() {
+        return target;
+    }
+
+    public final void setTarget(JavaLanguageVersion value) {
+        target.set(value);
+    }
+
+    /** Runtime {@link JavaLanguageVersion} for testing and distributions. */
+    public final Property<JavaLanguageVersion> runtime() {
+        return runtime;
+    }
+
+    public final void setRuntime(JavaLanguageVersion value) {
+        runtime.set(value);
+    }
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
@@ -21,6 +21,10 @@ import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
+/**
+ * Extension named {@code javaVersion} used to set the
+ * target and runtime java versions used for a single project.
+ */
 public class BaselineJavaVersionExtension {
 
     private final Property<JavaLanguageVersion> target;

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
@@ -34,8 +34,6 @@ public class BaselineJavaVersionExtension {
     public BaselineJavaVersionExtension(Project project) {
         target = project.getObjects().property(JavaLanguageVersion.class);
         runtime = project.getObjects().property(JavaLanguageVersion.class);
-        // Runtime defaults to the target value
-        runtime.convention(target);
     }
 
     /** Target {@link JavaLanguageVersion} for compilation. */

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
@@ -31,7 +31,7 @@ public class BaselineJavaVersionExtension {
         target = project.getObjects().property(JavaLanguageVersion.class);
         runtime = project.getObjects().property(JavaLanguageVersion.class);
         // Runtime defaults to the target value
-        runtime.set(target);
+        runtime.convention(target);
     }
 
     /** Target {@link JavaLanguageVersion} for compilation. */

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
@@ -43,8 +43,8 @@ public class BaselineJavaVersionExtension {
         return target;
     }
 
-    public final void setTarget(JavaLanguageVersion value) {
-        target.set(value);
+    public final void setTarget(int value) {
+        target.set(JavaLanguageVersion.of(value));
     }
 
     /** Runtime {@link JavaLanguageVersion} for testing and distributions. */
@@ -52,7 +52,7 @@ public class BaselineJavaVersionExtension {
         return runtime;
     }
 
-    public final void setRuntime(JavaLanguageVersion value) {
-        runtime.set(value);
+    public final void setRuntime(int value) {
+        runtime.set(JavaLanguageVersion.of(value));
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.extensions;
+
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+
+public class BaselineJavaVersionsExtension {
+
+    private final Property<JavaLanguageVersion> libraryTarget;
+    private final Property<JavaLanguageVersion> distributionTarget;
+    private final Property<JavaLanguageVersion> runtime;
+
+    @Inject
+    public BaselineJavaVersionsExtension(Project project) {
+        this.libraryTarget = project.getObjects().property(JavaLanguageVersion.class);
+        this.distributionTarget = project.getObjects().property(JavaLanguageVersion.class);
+        this.runtime = project.getObjects().property(JavaLanguageVersion.class);
+        // distribution defaults to the library value
+        distributionTarget.set(libraryTarget);
+        // runtime defaults to the distribution value
+        runtime.set(distributionTarget);
+    }
+
+    /** Target {@link JavaLanguageVersion} for compilation of libraries that are published. */
+    public final Property<JavaLanguageVersion> libraryTarget() {
+        return libraryTarget;
+    }
+
+    public final void setLibraryTarget(JavaLanguageVersion value) {
+        libraryTarget.set(value);
+    }
+
+    public final void setLibraryTarget(int value) {
+        setLibraryTarget(JavaLanguageVersion.of(value));
+    }
+
+    /**
+     * Target {@link JavaLanguageVersion} for compilation of code used within distributions,
+     * but not published externally.
+     */
+    public final Property<JavaLanguageVersion> distributionTarget() {
+        return distributionTarget;
+    }
+
+    public final void setDistributionTarget(JavaLanguageVersion value) {
+        distributionTarget.set(value);
+    }
+
+    public final void setDistributionTarget(int value) {
+        setDistributionTarget(JavaLanguageVersion.of(value));
+    }
+
+    /** Runtime {@link JavaLanguageVersion} for testing and packaging distributions. */
+    public final Property<JavaLanguageVersion> runtime() {
+        return runtime;
+    }
+
+    public final void setRuntime(JavaLanguageVersion value) {
+        runtime.set(value);
+    }
+
+    public final void setRuntime(int value) {
+        setRuntime(JavaLanguageVersion.of(value));
+    }
+
+    public final boolean isEmpty() {
+        return !libraryTarget().isPresent()
+                && !distributionTarget().isPresent()
+                && !runtime().isPresent();
+    }
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
@@ -21,6 +21,10 @@ import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
+/**
+ * Extension named {@code javaVersions} on the root project used to configure all java modules
+ * with consistent java toolchains.
+ */
 public class BaselineJavaVersionsExtension {
 
     private final Property<JavaLanguageVersion> libraryTarget;

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
@@ -33,9 +33,9 @@ public class BaselineJavaVersionsExtension {
         this.distributionTarget = project.getObjects().property(JavaLanguageVersion.class);
         this.runtime = project.getObjects().property(JavaLanguageVersion.class);
         // distribution defaults to the library value
-        distributionTarget.set(libraryTarget);
+        distributionTarget.convention(libraryTarget);
         // runtime defaults to the distribution value
-        runtime.set(distributionTarget);
+        runtime.convention(distributionTarget);
     }
 
     /** Target {@link JavaLanguageVersion} for compilation of libraries that are published. */
@@ -78,11 +78,5 @@ public class BaselineJavaVersionsExtension {
 
     public final void setRuntime(int value) {
         setRuntime(JavaLanguageVersion.of(value));
-    }
-
-    public final boolean isEmpty() {
-        return !libraryTarget().isPresent()
-                && !distributionTarget().isPresent()
-                && !runtime().isPresent();
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
@@ -47,12 +47,8 @@ public class BaselineJavaVersionsExtension {
         return libraryTarget;
     }
 
-    public final void setLibraryTarget(JavaLanguageVersion value) {
-        libraryTarget.set(value);
-    }
-
     public final void setLibraryTarget(int value) {
-        setLibraryTarget(JavaLanguageVersion.of(value));
+        libraryTarget.set(JavaLanguageVersion.of(value));
     }
 
     /**
@@ -63,12 +59,8 @@ public class BaselineJavaVersionsExtension {
         return distributionTarget;
     }
 
-    public final void setDistributionTarget(JavaLanguageVersion value) {
-        distributionTarget.set(value);
-    }
-
     public final void setDistributionTarget(int value) {
-        setDistributionTarget(JavaLanguageVersion.of(value));
+        distributionTarget.set(JavaLanguageVersion.of(value));
     }
 
     /** Runtime {@link JavaLanguageVersion} for testing and packaging distributions. */
@@ -76,11 +68,7 @@ public class BaselineJavaVersionsExtension {
         return runtime;
     }
 
-    public final void setRuntime(JavaLanguageVersion value) {
-        runtime.set(value);
-    }
-
     public final void setRuntime(int value) {
-        setRuntime(JavaLanguageVersion.of(value));
+        runtime.set(JavaLanguageVersion.of(value));
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -43,6 +43,7 @@ public final class Baseline implements Plugin<Project> {
 
         rootProject.getPluginManager().apply(BaselineConfig.class);
         rootProject.getPluginManager().apply(BaselineCircleCi.class);
+        rootProject.getPluginManager().apply(BaselineJavaVersions.class);
         rootProject.allprojects(proj -> {
             proj.getPluginManager().apply(BaselineCheckstyle.class);
             proj.getPluginManager().apply(BaselineScala.class);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -43,7 +43,6 @@ public final class Baseline implements Plugin<Project> {
 
         rootProject.getPluginManager().apply(BaselineConfig.class);
         rootProject.getPluginManager().apply(BaselineCircleCi.class);
-        rootProject.getPluginManager().apply(BaselineJavaVersions.class);
         rootProject.allprojects(proj -> {
             proj.getPluginManager().apply(BaselineCheckstyle.class);
             proj.getPluginManager().apply(BaselineScala.class);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MoreCollectors;
 import com.palantir.baseline.extensions.BaselineErrorProneExtension;
+import com.palantir.baseline.extensions.BaselineJavaVersionExtension;
 import com.palantir.baseline.tasks.CompileRefasterTask;
 import java.io.File;
 import java.util.AbstractList;
@@ -136,6 +137,19 @@ public final class BaselineErrorProne implements Plugin<Project> {
                                         .setBootClasspath(new LazyConfigurationList(errorProneFiles)));
                             });
         }
+
+        project.getPluginManager().withPlugin("com.palantir.baseline-java-version", unused -> {
+            BaselineJavaVersionExtension versionExtension =
+                    project.getExtensions().getByType(BaselineJavaVersionExtension.class);
+            project.getDependencies()
+                    .addProvider(
+                            ErrorPronePlugin.JAVAC_CONFIGURATION_NAME,
+                            versionExtension
+                                    .target()
+                                    .map(target -> target.asInt() == 8
+                                            ? "com.google.errorprone:javac:" + ERROR_PRONE_JAVAC_VERSION
+                                            : null));
+        });
 
         project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
             ((ExtensionAware) javaCompile.getOptions())

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import com.palantir.baseline.extensions.BaselineJavaVersionExtension;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+public final class BaselineJavaVersion implements Plugin<Project> {
+
+    public static final String EXTENSION_NAME = "javaVersion";
+
+    @Override
+    public void apply(Project project) {
+        BaselineJavaVersionExtension extension =
+                project.getExtensions().create(EXTENSION_NAME, BaselineJavaVersionExtension.class, project);
+        project.getTasks().withType(JavaCompile.class).configureEach(task -> {
+            if (extension.target().isPresent()) {
+                String stringValue = extension.target().get().toString();
+                task.setSourceCompatibility(stringValue);
+                task.setTargetCompatibility(stringValue);
+            }
+        });
+    }
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
@@ -17,19 +17,14 @@
 package com.palantir.baseline.plugins;
 
 import com.palantir.baseline.extensions.BaselineJavaVersionExtension;
-import java.util.Objects;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.scala.ScalaCompile;
-import org.gradle.api.tasks.testing.Test;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
@@ -102,40 +97,6 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                             javaToolchainSpec.getLanguageVersion().set(extension.target());
                         }
                     }));
-                }
-            });
-
-            TaskCollection<?> testTask = project.getTasks().matching(new Spec<Task>() {
-                @Override
-                public boolean isSatisfiedBy(Task element) {
-                    return "test".equals(element.getName()) && element instanceof Test;
-                }
-            });
-            Task testTargetVersion = project.getTasks().create("testTargetVersion", Test.class, new Action<Test>() {
-                @Override
-                public void execute(Test test) {
-                    // additional test task is only run if runtime and target versions differ
-                    test.onlyIf(new Spec<Task>() {
-                        @Override
-                        public boolean isSatisfiedBy(Task element) {
-                            return !Objects.equals(
-                                            extension.target().get(),
-                                            extension.runtime().get())
-                                    && !testTask.isEmpty();
-                        }
-                    });
-                    test.getJavaLauncher().set(javaToolchainService.launcherFor(new Action<JavaToolchainSpec>() {
-                        @Override
-                        public void execute(JavaToolchainSpec javaToolchainSpec) {
-                            javaToolchainSpec.getLanguageVersion().set(extension.target());
-                        }
-                    }));
-                }
-            });
-            testTask.configureEach(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    task.dependsOn(testTargetVersion);
                 }
             });
         });

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
@@ -25,8 +25,10 @@ import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
+import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
@@ -60,6 +62,34 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                             javaToolchainSpec.getLanguageVersion().set(extension.target());
                         }
                     }));
+                }
+            });
+
+            project.getTasks().withType(GroovyCompile.class, new Action<GroovyCompile>() {
+                @Override
+                public void execute(GroovyCompile groovyCompile) {
+                    groovyCompile
+                            .getJavaLauncher()
+                            .set(javaToolchainService.launcherFor(new Action<JavaToolchainSpec>() {
+                                @Override
+                                public void execute(JavaToolchainSpec javaToolchainSpec) {
+                                    javaToolchainSpec.getLanguageVersion().set(extension.target());
+                                }
+                            }));
+                }
+            });
+
+            project.getTasks().withType(ScalaCompile.class, new Action<ScalaCompile>() {
+                @Override
+                public void execute(ScalaCompile scalaCompile) {
+                    scalaCompile
+                            .getJavaLauncher()
+                            .set(javaToolchainService.launcherFor(new Action<JavaToolchainSpec>() {
+                                @Override
+                                public void execute(JavaToolchainSpec javaToolchainSpec) {
+                                    javaToolchainSpec.getLanguageVersion().set(extension.target());
+                                }
+                            }));
                 }
             });
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
@@ -200,11 +200,19 @@ public final class BaselineJavaVersion implements Plugin<Project> {
 
         @TaskAction
         public final void checkJavaVersions() {
-            if (getTargetVersion().get().asInt() > getRuntimeVersion().get().asInt()) {
+            JavaLanguageVersion target = getTargetVersion().get();
+            JavaLanguageVersion runtime = getRuntimeVersion().get();
+            getLogger()
+                    .debug(
+                            "BaselineJavaVersion configured project {} with target version {} and runtime version {}",
+                            getProject(),
+                            target,
+                            runtime);
+            if (target.asInt() > runtime.asInt()) {
                 throw new GradleException(String.format(
                         "The requested compilation target Java version (%s) must not "
                                 + "exceed the requested runtime Java version (%s)",
-                        getTargetVersion().get(), getRuntimeVersion().get()));
+                        target, runtime));
             }
         }
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
@@ -51,12 +51,13 @@ public final class BaselineJavaVersion implements Plugin<Project> {
         project.getPluginManager().withPlugin("java", unused -> {
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
 
-            // Set the default project toolchain to the compilation target version, this indirectly
-            // sets the value returned by 'getTargetCompatibility'
+            // Set the default project toolchain to the runtime target version, this indirectly
+            // sets the value returned by 'getTargetCompatibility', which is used by sls-packaging
+            // to request a specific java feature release.
             javaPluginExtension.toolchain(new Action<JavaToolchainSpec>() {
                 @Override
                 public void execute(JavaToolchainSpec javaToolchainSpec) {
-                    javaToolchainSpec.getLanguageVersion().set(extension.target());
+                    javaToolchainSpec.getLanguageVersion().set(extension.runtime());
                 }
             });
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersions.java
@@ -1,0 +1,79 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import com.palantir.baseline.extensions.BaselineJavaVersionExtension;
+import com.palantir.baseline.extensions.BaselineJavaVersionsExtension;
+import java.util.Objects;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.publish.Publication;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.ivy.IvyPublication;
+import org.gradle.api.publish.maven.MavenPublication;
+
+public final class BaselineJavaVersions implements Plugin<Project> {
+
+    public static final String EXTENSION_NAME = "javaVersions";
+
+    @Override
+    public void apply(Project project) {
+        if (!Objects.equals(project, project.getRootProject())) {
+            throw new GradleException("BaselineJavaVersions may only be applied to the root project");
+        }
+        BaselineJavaVersionsExtension rootExtension =
+                project.getExtensions().create(EXTENSION_NAME, BaselineJavaVersionsExtension.class, project);
+        project.allprojects(proj -> {
+            proj.getPluginManager().withPlugin("java", unused -> {
+                proj.getPluginManager().apply(BaselineJavaVersion.class);
+                BaselineJavaVersionExtension projectVersions =
+                        proj.getExtensions().getByType(BaselineJavaVersionExtension.class);
+                if (!projectVersions.target().isPresent()) {
+                    projectVersions.target().set(proj.provider(() -> {
+                        PublishingExtension publishing = proj.getExtensions().findByType(PublishingExtension.class);
+                        boolean library = publishing == null
+                                || publishing.getPublications().stream()
+                                        .anyMatch(pub -> isLibraryPublication(proj, pub));
+                        return library
+                                ? rootExtension.libraryTarget().get()
+                                : rootExtension.distributionTarget().get();
+                    }));
+                }
+            });
+        });
+    }
+
+    private static boolean isLibraryPublication(Project project, Publication publication) {
+        if (publication instanceof MavenPublication) {
+            MavenPublication mavenPublication = (MavenPublication) publication;
+            return mavenPublication.getArtifacts().stream().anyMatch(artifact -> "jar".equals(artifact.getExtension()));
+        }
+        if (publication instanceof IvyPublication) {
+            IvyPublication ivyPublication = (IvyPublication) publication;
+            return ivyPublication.getArtifacts().stream().anyMatch(artifact -> "jar".equals(artifact.getExtension()));
+        }
+        // Default to true for unknown publication types to avoid setting higher jvm targets than necessary
+        project.getLogger()
+                .warn(
+                        "Unknown publication '{}' of type '{}'. Assuming project {} is a library",
+                        publication,
+                        publication.getClass().getName(),
+                        project.getName());
+        return true;
+    }
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersions.java
@@ -46,10 +46,10 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                     proj.getExtensions().getByType(BaselineJavaVersionExtension.class);
             projectVersions
                     .target()
-                    .set(proj.provider(() -> isLibrary(proj)
+                    .convention(proj.provider(() -> isLibrary(proj)
                             ? rootExtension.libraryTarget().get()
                             : rootExtension.distributionTarget().get()));
-            projectVersions.runtime().set(rootExtension.runtime());
+            projectVersions.runtime().convention(rootExtension.runtime());
         }));
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersions.java
@@ -47,6 +47,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                     .set(proj.provider(() -> isLibrary(proj)
                             ? rootExtension.libraryTarget().get()
                             : rootExtension.distributionTarget().get()));
+            projectVersions.runtime().set(rootExtension.runtime());
         }));
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReleaseCompatibility.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReleaseCompatibility.java
@@ -59,6 +59,11 @@ public final class BaselineReleaseCompatibility extends AbstractBaselinePlugin {
         @Override
         public Iterable<String> asArguments() {
             if (javaCompile.getProject().getPlugins().hasPlugin(BaselineJavaVersion.class)) {
+                log.debug(
+                        "BaselineReleaseCompatibility is a no-op for {} in {} because the {} plugin is present",
+                        javaCompile.getName(),
+                        javaCompile.getProject(),
+                        BaselineJavaVersion.class);
                 return Collections.emptyList();
             }
             JavaVersion compilerVersion = JavaVersion.current();
@@ -102,11 +107,6 @@ public final class BaselineReleaseCompatibility extends AbstractBaselinePlugin {
             }
 
             return ImmutableList.of("--release", target.getMajorVersion());
-        }
-
-        // The --release flag was added in Java 9: https://openjdk.java.net/jeps/247
-        private static boolean supportsReleaseFlag(JavaVersion jdkVersion) {
-            return jdkVersion.isJava9Compatible();
         }
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReleaseCompatibility.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineReleaseCompatibility.java
@@ -17,7 +17,6 @@
 package com.palantir.baseline.plugins;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.baseline.extensions.BaselineJavaVersionExtension;
 import java.util.Collections;
 import java.util.Optional;
 import org.gradle.api.JavaVersion;
@@ -25,7 +24,6 @@ import org.gradle.api.Project;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
-import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +58,9 @@ public final class BaselineReleaseCompatibility extends AbstractBaselinePlugin {
 
         @Override
         public Iterable<String> asArguments() {
+            if (javaCompile.getProject().getPlugins().hasPlugin(BaselineJavaVersion.class)) {
+                return Collections.emptyList();
+            }
             JavaVersion compilerVersion = JavaVersion.current();
             if (!compilerVersion.isJava9Compatible()) {
                 log.debug(
@@ -77,17 +78,6 @@ public final class BaselineReleaseCompatibility extends AbstractBaselinePlugin {
                         javaCompile.getName(),
                         javaCompile.getProject());
                 return Collections.emptyList();
-            }
-
-            BaselineJavaVersionExtension maybeExtension =
-                    javaCompile.getProject().getExtensions().findByType(BaselineJavaVersionExtension.class);
-            if (maybeExtension != null) {
-                JavaLanguageVersion maybeTarget = maybeExtension.target().getOrNull();
-                if (maybeTarget != null) {
-                    return ImmutableList.of("--release", Integer.toString(maybeTarget.asInt()));
-                } else {
-                    log.debug("BaselineJavaVersionExtension.target was not set");
-                }
             }
 
             Optional<JavaVersion> taskTarget =

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.tasks;
 
+import com.palantir.baseline.extensions.BaselineJavaVersionExtension;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -58,6 +59,14 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
         this.shouldFix = objectFactory.property(Boolean.class);
         this.shouldFix.set(false);
 
+        onlyIf(new Spec<Task>() {
+            @Override
+            public boolean isSatisfiedBy(Task task) {
+                BaselineJavaVersionExtension version =
+                        getProject().getExtensions().findByType(BaselineJavaVersionExtension.class);
+                return version == null || !version.target().isPresent();
+            }
+        });
         onlyIf(new Spec<Task>() {
             @Override
             public boolean isSatisfiedBy(Task element) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckExplicitSourceCompatibilityTask.java
@@ -16,7 +16,7 @@
 
 package com.palantir.baseline.tasks;
 
-import com.palantir.baseline.extensions.BaselineJavaVersionExtension;
+import com.palantir.baseline.plugins.BaselineJavaVersion;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -62,9 +62,7 @@ public class CheckExplicitSourceCompatibilityTask extends DefaultTask {
         onlyIf(new Spec<Task>() {
             @Override
             public boolean isSatisfiedBy(Task task) {
-                BaselineJavaVersionExtension version =
-                        getProject().getExtensions().findByType(BaselineJavaVersionExtension.class);
-                return version == null || !version.target().isPresent();
+                return !getProject().getPlugins().hasPlugin(BaselineJavaVersion.class);
             }
         });
         onlyIf(new Spec<Task>() {

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-java-version.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-java-version.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineJavaVersion

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-java-versions.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-java-versions.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineJavaVersions

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -61,9 +61,13 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         }
         '''.stripIndent(true)
 
+    def setup() {
+        setFork(true)
+        buildFile << standardBuildFile
+    }
+
     def 'java 11 compilation fails targeting java 8'() {
         when:
-        buildFile << standardBuildFile
         buildFile << '''
         javaVersions {
             libraryTarget = 8
@@ -78,7 +82,6 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
 
     def 'java 11 compilation succeeds targeting java 11'() {
         when:
-        buildFile << standardBuildFile
         buildFile << '''
         javaVersions {
             libraryTarget = 11
@@ -94,7 +97,6 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
 
     def 'java 11 execution succeeds on java 11'() {
         when:
-        buildFile << standardBuildFile
         buildFile << '''
         javaVersions {
             libraryTarget = 11
@@ -111,7 +113,6 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
 
     def 'java 11 execution succeeds on java 17'() {
         when:
-        buildFile << standardBuildFile
         buildFile << '''
         javaVersions {
             libraryTarget = 11
@@ -129,7 +130,6 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
 
     def 'java 8 execution succeeds on java 8'() {
         when:
-        buildFile << standardBuildFile
         buildFile << '''
         javaVersions {
             libraryTarget = 8
@@ -144,7 +144,6 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
 
     def 'java 8 execution succeeds on java 11'() {
         when:
-        buildFile << standardBuildFile
         buildFile << '''
         javaVersions {
             libraryTarget = 8
@@ -162,7 +161,6 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
 
     def 'JavaPluginConvention.getTargetCompatibility() produces the runtime java version'() {
         when:
-        buildFile << standardBuildFile
         buildFile << '''
         javaVersions {
             libraryTarget = 11

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -159,7 +159,7 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         getBytecodeVersion(compiledClass) == JAVA_8_BYTECODE
     }
 
-    def 'JavaPluginConvention.getTargetCompatibility() produces the target java version'() {
+    def 'JavaPluginConvention.getTargetCompatibility() produces the runtime java version'() {
         when:
         buildFile << '''
         javaVersions {
@@ -177,7 +177,7 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
 
         then:
         ExecutionResult result = runTasksSuccessfully('printTargetCompatibility')
-        result.standardOutput.contains '[[[11]]]'
+        result.standardOutput.contains '[[[17]]]'
     }
 
     def 'verification should fail when target exceeds the runtime version'() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -180,6 +180,33 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         result.standardOutput.contains '[[[11]]]'
     }
 
+    def 'verification should fail when target exceeds the runtime version'() {
+        when:
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 17
+            runtime = 11
+        }
+        '''.stripIndent(true)
+
+        then:
+        ExecutionResult result = runTasksWithFailure('checkJavaVersions')
+        result.standardError.contains 'The requested compilation target'
+    }
+
+    def 'verification should succeed when target and runtime versions match'() {
+        when:
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 17
+            runtime = 17
+        }
+        '''.stripIndent(true)
+
+        then:
+        runTasksSuccessfully('checkJavaVersions')
+    }
+
     private static final int BYTECODE_IDENTIFIER = (int) 0xCAFEBABE
 
     // See http://illegalargumentexception.blogspot.com/2009/07/java-finding-class-versions.html

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -1,0 +1,151 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline
+
+
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+import spock.lang.Unroll
+
+class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
+    def standardBuildFile = '''
+        plugins {
+            id 'java-library'
+            id 'application'
+        }
+        
+        apply plugin: 'com.palantir.baseline-java-versions'
+        
+        repositories {
+            mavenCentral()
+        }
+        
+        application {
+            mainClass = 'Main'
+        }
+    '''.stripIndent(true)
+
+    def java8CompatibleCode = '''
+        public class Main { 
+            public static void main(String[] args) {
+                System.out.println("jdk8 features on runtime " + System.getProperty("java.specification.version"));
+            }
+        }
+        '''.stripIndent(true)
+
+    def java11CompatibleCode = '''
+        import java.util.Optional;
+        
+        public class Main { 
+            public static void main(String[] args) {
+                Optional.of(args).isEmpty();
+                System.out.println("jdk11 features on runtime " + System.getProperty("java.specification.version"));
+            }
+        }
+        '''.stripIndent(true)
+
+    def 'java 11 compilation fails targeting java 8'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 8
+            runtime = 11
+        }
+        '''.stripIndent(true)
+        file('src/main/java/Main.java') << java11CompatibleCode
+
+        then:
+        runTasksWithFailure('compileJava')
+    }
+
+    def 'java 11 compilation succeeds targeting java 11'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 11
+        }
+        '''.stripIndent(true)
+        file('src/main/java/Main.java') << java11CompatibleCode
+
+        then:
+        runTasksSuccessfully('compileJava')
+    }
+
+    def 'java 11 execution succeeds on java 11'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 11
+        }
+        '''.stripIndent(true)
+        file('src/main/java/Main.java') << java11CompatibleCode
+
+        then:
+        ExecutionResult result = runTasksSuccessfully('run')
+        result.standardOutput.contains 'jdk11 features on runtime 11'
+    }
+
+    def 'java 11 execution succeeds on java 17'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 11
+            runtime = 17
+        }
+        '''.stripIndent(true)
+        file('src/main/java/Main.java') << java11CompatibleCode
+
+        then:
+        ExecutionResult result = runTasksSuccessfully('run')
+        result.standardOutput.contains 'jdk11 features on runtime 17'
+    }
+
+    def 'java 8 execution succeeds on java 8'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 8
+        }
+        '''.stripIndent(true)
+        file('src/main/java/Main.java') << java8CompatibleCode
+
+        then:
+        ExecutionResult result = runTasksSuccessfully('run')
+        result.standardOutput.contains 'jdk8 features on runtime 1.8'
+    }
+
+    def 'java 8 execution succeeds on java 11'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 8
+            runtime = 11
+        }
+        '''.stripIndent(true)
+        file('src/main/java/Main.java') << java8CompatibleCode
+
+        then:
+        ExecutionResult result = runTasksSuccessfully('run')
+        result.standardOutput.contains 'jdk8 features on runtime 11'
+    }
+}

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -159,7 +159,7 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         getBytecodeVersion(compiledClass) == JAVA_8_BYTECODE
     }
 
-    def 'JavaPluginConvention.getTargetCompatibility() produces the runtime java version'() {
+    def 'JavaPluginConvention.getTargetCompatibility() produces the target java version'() {
         when:
         buildFile << '''
         javaVersions {
@@ -177,7 +177,7 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
 
         then:
         ExecutionResult result = runTasksSuccessfully('printTargetCompatibility')
-        result.standardOutput.contains '[[[17]]]'
+        result.standardOutput.contains '[[[11]]]'
     }
 
     private static final int BYTECODE_IDENTIFIER = (int) 0xCAFEBABE


### PR DESCRIPTION
## Goal

Root of each project declares java versions in this form:

```gradle
javaVersions {
    libraryTarget = 11
    distributionTarget = 15
}
```

or to target 15 but run using the new 17 release:
```gradle
javaVersions {
    libraryTarget = 11
    distributionTarget = 15
    runtime = 17
}
```

As opposed to setting `sourceCompatibility` and `targetCompatibility` on a per-project basis. We can detect which modules are libraries vs distributions and do the right things. Rolling out new java releases becomes much simpler as we can update this single block instead of hunting through every gradle file. Once this is backed by resolvable toolchains we'll no longer need to sequence CI template updates with services trying new releases.

Needs test coverage.
Eventually will use toolchains, unsure if we should implement that in the initial implementation, or later (likely later so implementation can occur in parallel to config rollout)
Needs support for toolchain configuration (custom jdk repositories for internal things?).

Currently the `runtime` version is unused. Eventually it will be used for JavaExec/Test/distributions.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
BaselineJavaVersions consistent JDK control via gradle toolchains on an opt-in basis
==COMMIT_MSG==
