### PR TITLE
Ensure spock 2/nebula-test 10 tests actually run

### DIFF
--- a/changelog/@unreleased/pr-1929.v2.yml
+++ b/changelog/@unreleased/pr-1929.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Ensure nebula-test 10/Spock 2 test run by automatically setting `useJUnitPlatform()`
+    on test tasks. Add extra verification to the `checkJUnitDependencies` task for
+    nebula-test 10/Spock 2 tests.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1929

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -140,7 +140,6 @@ public final class BaselineTesting implements Plugin<Project> {
 
     private static boolean requiresJunitPlatform(ModuleComponentIdentifier dep) {
         return isDep(dep, "org.junit.jupiter", "junit-jupiter")
-                // || (isDep(dep, "com.netflix.nebula", "nebula-test") && majorVersionNumber(dep.getVersion()) >= 10)
                 || (isDep(dep, "org.spockframework", "spock-core")
                         && VersionUtils.majorVersionNumber(dep.getVersion()) >= 2);
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -29,7 +29,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -66,8 +66,8 @@ public final class BaselineTesting implements Plugin<Project> {
             TaskProvider<CheckJUnitDependencies> checkJUnitDependencies =
                     project.getTasks().register("checkJUnitDependencies", CheckJUnitDependencies.class);
 
-            project.getExtensions()
-                    .getByType(JavaPluginExtension.class)
+            project.getConvention()
+                    .getPlugin(JavaPluginConvention.class)
                     .getSourceSets()
                     .configureEach(sourceSet -> {
                         getTestTaskForSourceSet(project, sourceSet).ifPresent(testTask -> {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/util/VersionUtils.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/util/VersionUtils.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.util;
+
+import com.google.common.base.Splitter;
+import org.gradle.api.GradleException;
+
+public final class VersionUtils {
+    public static int majorVersionNumber(String version) {
+        return Integer.parseInt(Splitter.on('.')
+                .splitToStream(version)
+                .findFirst()
+                .orElseThrow(() -> new GradleException("Cannot find major version number for version " + version)));
+    }
+
+    private VersionUtils() {}
+}

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -36,7 +36,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         dependencies {
             testImplementation 'junit:junit:4.12'
         }
-    '''.stripIndent()
+    '''.stripIndent(true)
 
     def junit4Test = '''
         package test;
@@ -47,7 +47,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
             @Test
             public void test() {}
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
     def junit5Test = '''
         package test;
@@ -58,7 +58,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
             @Test
             public void test() {}
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
     def '#gradleVersionNumber: capable of running both junit4 and junit5 tests'() {
         when:
@@ -72,7 +72,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
                 because 'allows JUnit 3 and JUnit 4 tests to run\'
             }
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
         file('src/test/java/test/TestClass4.java') << junit4Test
         file('src/test/java/test/TestClass5.java') << junit5Test
 
@@ -91,7 +91,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         plugins {
             id 'org.unbroken-dome.test-sets' version '4.0.0'
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
         buildFile << standardBuildFile
         buildFile << '''
 
@@ -102,12 +102,36 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         dependencies {
             integrationTestImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
         file('src/integrationTest/java/test/TestClass5.java') << junit5Test
 
         then:
         runTasksSuccessfully('integrationTest')
         fileExists("build/reports/tests/integrationTest/classes/test.TestClass5.html")
+    }
+    
+    def 'runs nebula-test version 10+ tests that require junit platform'() {
+        buildFile << standardBuildFile
+        
+        buildFile << '''
+            apply plugin: 'groovy'
+            dependencies {
+                testImplementation 'com.netflix.nebula:nebula-test:10.0.0'
+            }
+        '''.stripIndent(true)
+
+        file('src/test/groovy/test/Test.groovy') << '''
+            package test
+            class Test extends spock.lang.Specification {
+                def test() {}
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('test')
+
+        then:
+        true
     }
 
     def 'checkJUnitDependencies ensures mixture of junit4 and 5 tests => legacy must be present'() {
@@ -116,7 +140,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         plugins {
             id 'org.unbroken-dome.test-sets' version '4.0.0'
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
         buildFile << standardBuildFile
         buildFile << '''
         testSets {
@@ -126,7 +150,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         dependencies {
             integrationTestImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
         file('src/integrationTest/java/test/TestClass2.java') << junit4Test
         file('src/integrationTest/java/test/TestClass5.java') << junit5Test
 
@@ -142,7 +166,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         dependencies {
             testImplementation "junit:junit:4.12"
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
         file('src/test/java/test/TestClass2.java') << junit4Test
         file('src/test/java/test/TestClass5.java') << junit5Test
 
@@ -160,7 +184,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
             testImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
             testImplementation 'com.netflix.nebula:nebula-test:7.3.0'
         }
-        '''.stripIndent()
+        '''.stripIndent(true)
 
         then:
         ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -163,7 +163,7 @@ class BaselineTestingIntegrationTest extends AbstractPluginTest {
 
         then:
         BuildResult result = with('checkJUnitDependencies').buildAndFail()
-        result.output.contains 'Tests may be silently not running! Spock dependency detected'
+        result.output.contains 'Tests may be silently not running! Spock 1.x dependency detected'
     }
 
     def 'running -Drecreate=true will re-run tests even if no code changes'() {


### PR DESCRIPTION
## Before this PR
[Nebula test 10 upgraded Spock to version 2](https://github.com/nebula-plugins/nebula-test/releases/tag/v10.0.0), which is required for Gradle 7/Groovy 3 support.

Spock 2 has a breaking change that means it no longer runs using JUnit 4, but instead uses the JUnit Platform. In Gradle, you need to opt into the JUnit Platform by setting some configuration:

```gradle
test {
    useJUnitPlatform()
}
```

If you don't do this, your tests will be silently not be run 😢 . For many of our repos that use nebula-test, they got upgraded to 10 automatically and the tests just stopped running.

## After this PR
==COMMIT_MSG==
Ensure nebula-test 10/Spock 2 test run by automatically setting `useJUnitPlatform()` on test tasks. Add extra verification to the `checkJUnitDependencies` task for nebula-test 10/Spock 2 tests.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

