### PR TITLE
Fix MalformedInputException in checkJUnitDependencies

### DIFF
--- a/changelog/@unreleased/pr-1932.v2.yml
+++ b/changelog/@unreleased/pr-1932.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix `MalformedInputException` when checking non-utf8 files for correct
+    junit dependencies.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1932

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -163,6 +163,7 @@ public class CheckJUnitDependencies extends DefaultTask {
     }
 
     private boolean sourceSetMentionsJUnit4(SourceSet ss) {
+        // getAllJava() includes groovy sources too
         return !ss.getAllJava()
                 .filter(file -> fileContainsSubstring(
                         file,

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -164,7 +164,7 @@ public class CheckJUnitDependencies extends DefaultTask {
     }
 
     private boolean sourceSetMentionsJUnit4(SourceSet ss) {
-        return !ss.getAllSource()
+        return !ss.getAllJava()
                 .filter(file -> fileContainsSubstring(
                         file,
                         l -> l.contains("org.junit.Test")
@@ -174,7 +174,7 @@ public class CheckJUnitDependencies extends DefaultTask {
     }
 
     private boolean sourceSetMentionsJUnit5Api(SourceSet ss) {
-        return !ss.getAllSource()
+        return !ss.getAllJava()
                 .filter(file -> fileContainsSubstring(file, l -> l.contains("org.junit.jupiter.api.")))
                 .isEmpty();
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import com.palantir.baseline.plugins.BaselineTesting;
 import com.palantir.baseline.util.VersionUtils;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
@@ -181,11 +180,9 @@ public class CheckJUnitDependencies extends DefaultTask {
 
     private boolean fileContainsSubstring(File file, Predicate<String> substring) {
         try (Stream<String> lines = Files.lines(file.toPath())) {
-            boolean hit = lines.anyMatch(substring::test);
-            getProject().getLogger().debug("[{}] {}", hit ? "hit" : "miss", file);
-            return hit;
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to check file " + file, e);
+            return lines.anyMatch(substring);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to check file for junit dependencies: " + file, e);
         }
     }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline
 
+
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.lang.Unroll
@@ -208,5 +209,17 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
 
         def result4 = runTasksSuccessfully('test', '-Drecreate=true')
         result4.wasExecuted(':test')
+    }
+
+    def 'does not crash with non-utf8 resources'() {
+        when:
+        buildFile << standardBuildFile
+        file('src/test/resources/some-binary').newOutputStream().withCloseable {
+            // Invalid unicode sequence identifier
+            it.write([0xA0, 0xA1] as byte[])
+        }
+
+        then:
+        runTasksSuccessfully('checkJUnitDependencies')
     }
 }


### PR DESCRIPTION
## Before this PR
In #1929, I had originally changed searching in `sourceSet.getAllJava()` to `sourceSet.getAllSource()` to make sure we were looking in `.groovy` files as well as java. I left it in there by accident. However, this has had the downside of searching through the resources too, which may contain non-utf8 encoded files. This leads to this kind of error:

```
java.io.UncheckedIOException: java.nio.charset.MalformedInputException: Input length = 1
```

as it tries to decode non-utf8 files into utf8.

Additionally, I never proved out whether groovy files are included in `getAllSource` and not `getAllJava`. Looking at the `GroovyBasePlugin` it actually puts the groovy source into the java source sets:

```java
sourceSet.getAllJava().source(groovySource);
sourceSet.getAllSource().source(groovySource);
```

## After this PR
==COMMIT_MSG==
Fix `MalformedInputException` when checking non-utf8 files for correct junit dependencies.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

