### PR TITLE
Feature: Zero Warmup Guava RateLimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferImmutableStreamExCollections`: It's common to use toMap/toSet/toList() as the terminal operation on a stream, but would be extremely surprising to rely on the mutability of these collections. Prefer `toImmutableMap`, `toImmutableSet` and `toImmutableList`. (If the performance overhead of a stream is already acceptable, then the `UnmodifiableFoo` wrapper is likely tolerable).
 - `DangerousIdentityKey`: Key type does not override equals() and hashCode, so comparisons will be done on reference equality only.
 - `ConsistentOverrides`: Ensure values are bound to the correct variables when overriding methods
-- 'NoWarmupRateLimiter': Ensures Guava RateLimiter initializers specify a warm-up duration.
+- `NoWarmupRateLimiter`: Ensures Guava RateLimiter initializers specify a warm-up duration.
 
 ### Programmatic Application
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferImmutableStreamExCollections`: It's common to use toMap/toSet/toList() as the terminal operation on a stream, but would be extremely surprising to rely on the mutability of these collections. Prefer `toImmutableMap`, `toImmutableSet` and `toImmutableList`. (If the performance overhead of a stream is already acceptable, then the `UnmodifiableFoo` wrapper is likely tolerable).
 - `DangerousIdentityKey`: Key type does not override equals() and hashCode, so comparisons will be done on reference equality only.
 - `ConsistentOverrides`: Ensure values are bound to the correct variables when overriding methods
-- `NoWarmupRateLimiter`: Ensure Guava RateLimiter initializers specifies a warm-up duration.
+- `NoWarmupRateLimiter`: Ensure Guava RateLimiter initializers specify a warm-up duration.
 
 ### Programmatic Application
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferImmutableStreamExCollections`: It's common to use toMap/toSet/toList() as the terminal operation on a stream, but would be extremely surprising to rely on the mutability of these collections. Prefer `toImmutableMap`, `toImmutableSet` and `toImmutableList`. (If the performance overhead of a stream is already acceptable, then the `UnmodifiableFoo` wrapper is likely tolerable).
 - `DangerousIdentityKey`: Key type does not override equals() and hashCode, so comparisons will be done on reference equality only.
 - `ConsistentOverrides`: Ensure values are bound to the correct variables when overriding methods
+- 'NoWarmupRateLimiter': Ensures Guava RateLimiter initializers specify a warm-up duration.
 
 ### Programmatic Application
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferImmutableStreamExCollections`: It's common to use toMap/toSet/toList() as the terminal operation on a stream, but would be extremely surprising to rely on the mutability of these collections. Prefer `toImmutableMap`, `toImmutableSet` and `toImmutableList`. (If the performance overhead of a stream is already acceptable, then the `UnmodifiableFoo` wrapper is likely tolerable).
 - `DangerousIdentityKey`: Key type does not override equals() and hashCode, so comparisons will be done on reference equality only.
 - `ConsistentOverrides`: Ensure values are bound to the correct variables when overriding methods
+- `NoWarmupRateLimiter`: Ensure Guava RateLimiter initializers specifies a warm-up duration.
 
 ### Programmatic Application
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferImmutableStreamExCollections`: It's common to use toMap/toSet/toList() as the terminal operation on a stream, but would be extremely surprising to rely on the mutability of these collections. Prefer `toImmutableMap`, `toImmutableSet` and `toImmutableList`. (If the performance overhead of a stream is already acceptable, then the `UnmodifiableFoo` wrapper is likely tolerable).
 - `DangerousIdentityKey`: Key type does not override equals() and hashCode, so comparisons will be done on reference equality only.
 - `ConsistentOverrides`: Ensure values are bound to the correct variables when overriding methods
-- `NoWarmupRateLimiter`: Ensure Guava RateLimiter initializers specify a warm-up duration.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/NoWarmupRateLimiter.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/NoWarmupRateLimiter.java
@@ -37,10 +37,11 @@ import java.util.List;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = LinkType.CUSTOM,
         severity = SeverityLevel.WARNING,
-        summary = "The default Guava RateLimiter without specifying a warm-up time creates a limiter with 0 permits, "
-                + "and starts acquiring them. This causes an unexpected behavior, where at the beginning of the rate "
-                + "limiter's lifetime, the rate is much lower than specified. Zero warm-up time should be preferred "
-                + "to no warm-up time to ensure a max amount of permits are available at the start.")
+        summary = "Ensures Guava RateLimiter initializers specify a warm-up duration. The default Guava RateLimiter "
+                + "without specifying a warm-up time creates a limiter with 0 permits, and starts acquiring them. "
+                + "This causes an unexpected behavior, where at the beginning of the rate limiter's lifetime, the "
+                + "rate is much lower than specified. Zero warm-up time should be preferred to no warm-up time to "
+                + "ensure a max amount of permits are available at the start.")
 public final class NoWarmupRateLimiter extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
     private static final String DURATION_NAME = "java.time.Duration";

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/NoWarmupRateLimiter.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/NoWarmupRateLimiter.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.LinkType;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.List;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "NoWarmupRateLimiter",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = LinkType.CUSTOM,
+        severity = SeverityLevel.WARNING,
+        summary = "The default Guava RateLimiter without specifying a warm-up time creates a limiter with 0 permits, "
+                + "and starts acquiring them. This causes an unexpected behavior, where at the beginning of the rate "
+                + "limiter's lifetime, the rate is much lower than specified. Zero warm-up time should be preferred "
+                + "to no warm-up time to ensure a max amount of permits are available at the start.")
+public final class NoWarmupRateLimiter extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final String DURATION_NAME = "java.time.Duration";
+    private static final String RATE_LIMITER_NAME = "com.google.common.util.concurrent.RateLimiter";
+    private static final Matcher<ExpressionTree> RATELIMITER_CREATE_METHOD = MethodMatchers.staticMethod()
+            .onClass(RATE_LIMITER_NAME)
+            .named("create")
+            .withParameters("double");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (RATELIMITER_CREATE_METHOD.matches(tree, state)) {
+            List<? extends ExpressionTree> args = tree.getArguments();
+            if (args.size() > 1) {
+                return Description.NO_MATCH;
+            }
+            SuggestedFix.Builder fix = SuggestedFix.builder();
+            String durationType = SuggestedFixes.qualifyType(state, fix, DURATION_NAME);
+            fix.replace(args.get(0), String.format("%s, %s.ZERO", state.getSourceForNode(args.get(0)), durationType));
+            return buildDescription(tree)
+                    .setMessage("RateLimiter.create() does not include a warmup time. "
+                            + "Consider including Duration.ZERO as the default warmup.")
+                    .addFix(fix.build())
+                    .build();
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NoWarmupRateLimiterTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NoWarmupRateLimiterTest.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.baseline.errorprone;
 
-import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +42,7 @@ public class NoWarmupRateLimiterTest {
                         "  }",
                         "",
                         "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+                .doTest();
     }
 
     @Test
@@ -69,7 +68,7 @@ public class NoWarmupRateLimiterTest {
                         "  }",
                         "",
                         "}")
-                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+                .doTest();
     }
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NoWarmupRateLimiterTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/NoWarmupRateLimiterTest.java
@@ -1,0 +1,114 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+public class NoWarmupRateLimiterTest {
+
+    @Test
+    public void should_explicitly_initialize_warmup() {
+        getRefactoringValidatorHelper()
+                .addInputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10);",
+                        "  }",
+                        "",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.time.Duration;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10, Duration.ZERO);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void should_explicitly_initialize_warmup_import_exists() {
+        getRefactoringValidatorHelper()
+                .addInputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.time.Duration;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10);",
+                        "  }",
+                        "",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.time.Duration;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10, Duration.ZERO);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void pass_explicitly_initialize_warmup_single_arg() {
+        getCompilationTestHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.time.Duration;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10, Duration.ZERO);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void pass_explicitly_initialize_warmup_double_args() {
+        getCompilationTestHelper()
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.util.concurrent.TimeUnit;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10, 100, TimeUnit.SECONDS);",
+                        "  }",
+                        "",
+                        "}")
+                .doTest();
+    }
+
+    private RefactoringValidator getRefactoringValidatorHelper() {
+        return RefactoringValidator.of(NoWarmupRateLimiter.class, getClass());
+    }
+
+    private CompilationTestHelper getCompilationTestHelper() {
+        return CompilationTestHelper.newInstance(NoWarmupRateLimiter.class, getClass());
+    }
+}

--- a/changelog/@unreleased/pr-1950.v2.yml
+++ b/changelog/@unreleased/pr-1950.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Zero Warmup Guava RateLimiter
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1950

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -47,6 +47,7 @@ public class BaselineErrorProneExtension {
             "LambdaMethodReference",
             "LoggerEnclosingClass",
             "LogsafeArgName",
+            "NoWarmupRateLimiter",
             "ObjectsHashCodeUnnecessaryVarargs",
             "OptionalFlatMapOfNullable",
             "OptionalOrElseMethodInvocation",


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
This addresses #1946
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
 Adds a new rule NoWarmupRateLimiter that catches `RateLimite.create ` calls with no explicit warmup arguments.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

