### PR TITLE
Support `--add-opens` in addition to `--add-exports`

### DIFF
--- a/changelog/@unreleased/pr-1956.v2.yml
+++ b/changelog/@unreleased/pr-1956.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support `--add-opens` in addition to `--add-exports`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1956

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 
     annotationProcessor 'org.inferred:freebuilder'
     compileOnly 'org.inferred:freebuilder'
+    annotationProcessor 'org.immutables:value'
+    compileOnly 'org.immutables:value::annotations'
 }
 
 tasks.test.dependsOn tasks.findByPath(':gradle-baseline-java-config:publishToMavenLocal')


### PR DESCRIPTION
## Before this PR
No way to configure `--add-opens`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support `--add-opens` in addition to `--add-exports`
==COMMIT_MSG==

## Possible downsides?
More config and complexity

