### PR TITLE
Improve Zero Warmup Rate Limiter to Catch Int Literals

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ZeroWarmupRateLimiter.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ZeroWarmupRateLimiter.java
@@ -92,7 +92,7 @@ public final class ZeroWarmupRateLimiter extends BugChecker implements BugChecke
     }
 
     private static boolean isIntLiteralZero(ExpressionTree expressionTree, VisitorState state) {
-        Integer warmupTime = ASTHelpers.constValue(expressionTree, Integer.class);
-        return warmupTime != null && warmupTime.equals(0);
+        Number warmupTime = ASTHelpers.constValue(expressionTree, Number.class);
+        return warmupTime != null && (warmupTime.equals(0) || warmupTime.equals(0L));
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ZeroWarmupRateLimiter.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ZeroWarmupRateLimiter.java
@@ -35,6 +35,8 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -46,22 +48,29 @@ import java.time.Duration;
                 + "Tracked at https://github.com/google/guava/issues/2730")
 public final class ZeroWarmupRateLimiter extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
-    private static final Matcher<ExpressionTree> MATCHER = Matchers.methodInvocation(
+    private static final Matcher<ExpressionTree> DURATION_ZERO_MATCHER = Matchers.methodInvocation(
             MethodMatchers.staticMethod()
                     .onClass(RateLimiter.class.getName())
                     .named("create")
                     .withParameters("double", Duration.class.getName()),
             MatchType.LAST,
             ZeroWarmupRateLimiter::isDurationZero);
+    private static final Matcher<MethodInvocationTree> INT_LITERAL_ZERO_MATCHER = Matchers.allOf(
+            MethodMatchers.staticMethod()
+                    .onClass(RateLimiter.class.getName())
+                    .named("create")
+                    .withParameters("double", "long", TimeUnit.class.getName()),
+            Matchers.argument(1, ZeroWarmupRateLimiter::isIntLiteralZero));
+    private static final Matcher<MethodInvocationTree> MATCHER =
+            Matchers.anyOf(DURATION_ZERO_MATCHER, INT_LITERAL_ZERO_MATCHER);
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        List<? extends ExpressionTree> args = tree.getArguments();
         if (MATCHER.matches(tree, state)) {
             return buildDescription(tree)
                     .addFix(SuggestedFix.replace(
-                            state.getEndPosition(tree.getArguments().get(0)),
-                            state.getEndPosition(tree.getArguments().get(1)),
-                            ""))
+                            state.getEndPosition(args.get(0)), state.getEndPosition(args.get(args.size() - 1)), ""))
                     .build();
         }
         return Description.NO_MATCH;
@@ -80,5 +89,10 @@ public final class ZeroWarmupRateLimiter extends BugChecker implements BugChecke
                             .isSameType(varSymbol.owner.type, state.getTypeFromString(Duration.class.getName()));
         }
         return false;
+    }
+
+    private static boolean isIntLiteralZero(ExpressionTree expressionTree, VisitorState state) {
+        Integer warmupTime = ASTHelpers.constValue(expressionTree, Integer.class);
+        return warmupTime != null && warmupTime.equals(0);
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ZeroWarmupRateLimiterTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ZeroWarmupRateLimiterTest.java
@@ -67,7 +67,7 @@ class ZeroWarmupRateLimiterTest {
     }
 
     @Test
-    public void should_remove_long_literal_zero() {
+    public void should_remove_int_literal_zero() {
         fix().addInputLines(
                         "Test.java",
                         "import com.google.common.util.concurrent.RateLimiter;",
@@ -75,6 +75,29 @@ class ZeroWarmupRateLimiterTest {
                         "class Test {",
                         "  void f() {",
                         "    RateLimiter.create(10, 0, TimeUnit.SECONDS);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.util.concurrent.TimeUnit;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void should_remove_long_literal_zero() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.util.concurrent.TimeUnit;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10, 0L, TimeUnit.SECONDS);",
                         "  }",
                         "}")
                 .addOutputLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ZeroWarmupRateLimiterTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ZeroWarmupRateLimiterTest.java
@@ -67,6 +67,29 @@ class ZeroWarmupRateLimiterTest {
     }
 
     @Test
+    public void should_remove_long_literal_zero() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.util.concurrent.TimeUnit;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10, 0, TimeUnit.SECONDS);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.util.concurrent.TimeUnit;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void should_not_modify_existing_uses() {
         fix().addInputLines(
                         "Test.java",
@@ -75,6 +98,36 @@ class ZeroWarmupRateLimiterTest {
                         "class Test {",
                         "  void f() {",
                         "    RateLimiter.create(10, Duration.ofMillis(100));",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    public void should_not_modify_existing_uses_int_literal() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.util.concurrent.TimeUnit;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(10, 100, TimeUnit.SECONDS);",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    public void should_not_modify_existing_int_literal_zero_permits() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.google.common.util.concurrent.RateLimiter;",
+                        "import java.util.concurrent.TimeUnit;",
+                        "class Test {",
+                        "  void f() {",
+                        "    RateLimiter.create(0, 100, TimeUnit.SECONDS);",
                         "  }",
                         "}")
                 .expectUnchanged()

--- a/changelog/@unreleased/pr-1960.v2.yml
+++ b/changelog/@unreleased/pr-1960.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve Zero Warmup Rate Limiter to Catch Int Literals
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1960


### PR DESCRIPTION
## Before this PR
Follow up to https://github.com/palantir/gradle-baseline/pull/1958 to allow the rule to catch int literals passing in 0 as the warmup time.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

