### PR TITLE
Automatically fix AssertNoArgs

### DIFF
--- a/changelog/@unreleased/pr-1967.v2.yml
+++ b/changelog/@unreleased/pr-1967.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Automatically fix AssertNoArgs
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1967

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -28,6 +28,7 @@ public class BaselineErrorProneExtension {
      */
     private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
+            "AssertNoArgs",
             "AvoidNewHashMapInt",
             "CatchBlockLogException",
             // TODO(ckozak): re-enable pending scala check


### PR DESCRIPTION
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Automatically fix AssertNoArgs
==COMMIT_MSG==

## Possible downsides?
Some risk that this will flag projects on older versions of safe-logging if baseline upgrades first. In that case, we'd still be producing warnings, so either way isn't ideal.
