### PR TITLE
Add shaded junit5 deps as excluded name

### DIFF
--- a/changelog/@unreleased/pr-1972.v2.yml
+++ b/changelog/@unreleased/pr-1972.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Stop idea recommending autocompletions from `org.junit.jupiter.params.shadow`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1972

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -433,6 +433,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             <component name="JavaProjectCodeInsightSettings">
               <excluded-names>
                 <name>shadow</name><!-- from gradle-shadow-jar -->
+                <name>org.junit.jupiter.params.shadow</name><!-- shaded deps from junit5 -->
                 <name>org.gradle.internal.impldep</name>
                 <name>autovalue.shaded</name>
                 <name>org.inferred.freebuilder.shaded</name>


### PR DESCRIPTION
## Before this PR
Whenever I used `@Nested` with junit 5, I accidentally import `org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Nested`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Stop idea recommending autocompletions from `org.junit.jupiter.params.shadow`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

