### PR TITLE
Fix errors setting test framework due to finalized property

### DIFF
--- a/changelog/@unreleased/pr-1974.v2.yml
+++ b/changelog/@unreleased/pr-1974.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix errors setting test framework due to finalized property
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1974

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -187,6 +187,7 @@ public final class BaselineTesting implements Plugin<Project> {
         // finalize this value. This result in errors when trying to set the test framework at a later point.
         // For Gradle 7.3, we can actually access the test framework as a property without finalizing its value which
         // allows us to check if it's already configured.
+        // See: https: // github.com/palantir/gradle-baseline/pull/1974
         if (GradleVersion.current().compareTo(GradleVersion.version("7.3")) < 0) {
             return task.getOptions() instanceof JUnitPlatformOptions;
         }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -205,7 +205,7 @@ public final class BaselineTesting implements Plugin<Project> {
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(
                     String.format(
-                            "Error calling Test#getTestFrameworkProvider reflectively on Gradle version %s",
+                            "Error calling Test#getTestFrameworkProperty reflectively on Gradle version %s",
                             GradleVersion.current()),
                     e);
         }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.baseline.tasks.CheckJUnitDependencies;
 import com.palantir.baseline.tasks.CheckUnusedDependenciesTask;
 import com.palantir.baseline.util.VersionUtils;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.Optional;
@@ -203,7 +202,7 @@ public final class BaselineTesting implements Plugin<Project> {
             Method getTestFrameworkProperty = Test.class.getMethod("getTestFrameworkProperty");
             return (Property<org.gradle.api.internal.tasks.testing.TestFramework>)
                     getTestFrameworkProperty.invoke(task);
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             throw new RuntimeException(
                     String.format(
                             "Error calling Test#getTestFrameworkProvider reflectively on Gradle version %s",

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/GradleTestVersions.java
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/GradleTestVersions.java
@@ -21,7 +21,7 @@ import com.palantir.baseline.plugins.Baseline;
 
 public final class GradleTestVersions {
     public static final ImmutableList<String> VERSIONS =
-            ImmutableList.of(Baseline.MIN_GRADLE_VERSION.getVersion(), "7.1.1");
+            ImmutableList.of(Baseline.MIN_GRADLE_VERSION.getVersion(), "7.1.1", "7.3");
 
     private GradleTestVersions() {}
 }


### PR DESCRIPTION
## Before this PR

Using baseline on Gradle 7.3 would fail with ([circle](https://app.circleci.com/pipelines/github/palantir/gradle-baseline/2911/workflows/917953bc-bfe6-4b90-9f67-45e3d1e10429/jobs/30225/steps), [PR](https://github.com/palantir/gradle-baseline/pull/1969)):
```
The value for task ':test' property 'testFrameworkProperty' is final and cannot be changed any further.
```

This is because starting with Gradle 7.3, the test framework property is now getting finalized after getting set initially ([ref](https://github.com/gradle/gradle/blob/a520acd9912c9d5f0e548338b32ef77d66f76058/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java#L917-L934)).

Finalizing the property actually happens in our precondition where we call `Test#getOptions`:
https://github.com/palantir/gradle-baseline/blob/8013b3becc5ef623b08cd7e361137111e0be6ee8/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java#L179-L180

This is because the public getters all initialize and finalize the property with a default if nothing is set yet ([ref](https://github.com/gradle/gradle/blob/a520acd9912c9d5f0e548338b32ef77d66f76058/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java#L913-L915)). Thus, when we later explicitly try to set the test framework ([ref](https://github.com/palantir/gradle-baseline/blob/8013b3becc5ef623b08cd7e361137111e0be6ee8/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java#L153)), Gradle fails because the property is finalized now.

## After this PR

Unfortunately before Gradle 7.3, I couldn't find a public method that allows us to figure out if and what kind of test framework is configured without finalizing a test framework.

However with Gradle 7.3, they added a public getter for getting the `Property<TestFramework>` which we can use to check if a test framework is configured without finalizing it.

==COMMIT_MSG==
Fix errors setting test framework due to finalized property
==COMMIT_MSG==

## Possible downsides?
`Test#getTestFrameworkProperty` is marked as incubating so not sure how stable it is.