### PR TITLE
BaselineJavaVersions handles the lazy 'nebula.maven-publish' plugin

### DIFF
--- a/changelog/@unreleased/pr-1986.v2.yml
+++ b/changelog/@unreleased/pr-1986.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: BaselineJavaVersions handles the lazy 'nebula.maven-publish' plugin
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1986


### PR DESCRIPTION
## Before this PR
Whether a component is considered a library or distribution could change part-way through evaluation when the lazy `nebula.maven-publish` plugin was applied.

## After this PR
==COMMIT_MSG==
BaselineJavaVersions handles the lazy 'nebula.maven-publish' plugin
==COMMIT_MSG==

## Possible downsides?
This pattern could appear elsewhere and require similar remediation. Ideally we would have addressed the root cause.
