### PR TITLE
Make errorprone utility classes public

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreASTHelpers.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreASTHelpers.java
@@ -36,7 +36,7 @@ public final class MoreASTHelpers {
 
     /** Removes any type that is a subtype of another type in the set. */
     @SuppressWarnings("ReferenceEquality")
-    static ImmutableList<Type> flattenTypesForAssignment(ImmutableList<Type> input, VisitorState state) {
+    public static ImmutableList<Type> flattenTypesForAssignment(ImmutableList<Type> input, VisitorState state) {
         ImmutableList<Type> types =
                 input.stream().map(type -> broadenAnonymousType(type, state)).collect(ImmutableList.toImmutableList());
         ImmutableList.Builder<Type> deduplicatedBuilder = ImmutableList.builderWithExpectedSize(types.size());
@@ -77,7 +77,7 @@ public final class MoreASTHelpers {
     }
 
     /** Gets thrown exceptions from a {@link TryTree} excluding those thrown from {@link CatchTree}. */
-    static ImmutableSet<Type> getThrownExceptionsFromTryBody(TryTree tree, VisitorState state) {
+    public static ImmutableSet<Type> getThrownExceptionsFromTryBody(TryTree tree, VisitorState state) {
         ImmutableSet.Builder<Type> results = ImmutableSet.builder();
         results.addAll(ASTHelpers.getThrownExceptions(tree.getBlock(), state));
         tree.getResources().forEach(resource -> {
@@ -104,7 +104,7 @@ public final class MoreASTHelpers {
     }
 
     /** Returns either the input type, or the types that make up the union in the case of a union type. */
-    static ImmutableList<Type> expandUnion(@Nullable Type type) {
+    public static ImmutableList<Type> expandUnion(@Nullable Type type) {
         if (type == null) {
             return ImmutableList.of();
         }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreASTHelpers.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreASTHelpers.java
@@ -32,7 +32,7 @@ import javax.annotation.Nullable;
 
 /** Utility functionality that does not exist in {@link com.google.errorprone.util.ASTHelpers}. */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
-final class MoreASTHelpers {
+public final class MoreASTHelpers {
 
     /** Removes any type that is a subtype of another type in the set. */
     @SuppressWarnings("ReferenceEquality")

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreAbstractAsKeyOfSetOrMap.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreAbstractAsKeyOfSetOrMap.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.function.IntPredicate;
 
 /** Extension atop {@link AbstractAsKeyOfSetOrMap} to apply to caches and collectors. */
-abstract class MoreAbstractAsKeyOfSetOrMap extends AbstractAsKeyOfSetOrMap {
+public abstract class MoreAbstractAsKeyOfSetOrMap extends AbstractAsKeyOfSetOrMap {
 
     private static final Matcher<ExpressionTree> GUAVA_CACHE_BUILDER = MethodMatchers.instanceMethod()
             .onDescendantOf("com.google.common.cache.CacheBuilder")

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreMatchers.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreMatchers.java
@@ -40,7 +40,7 @@ public final class MoreMatchers {
      * @see Matchers#isSubtypeOf(Class)
      * @see <a href="https://github.com/google/error-prone/issues/1397">error-prone#1397</a>
      */
-    static <T extends Tree> Matcher<T> isSubtypeOf(Class<?> baseType) {
+    public static <T extends Tree> Matcher<T> isSubtypeOf(Class<?> baseType) {
         return Matchers.allOf(Matchers.isSubtypeOf(baseType), Matchers.not(Matchers.kindIs(Tree.Kind.NULL_LITERAL)));
     }
 
@@ -51,7 +51,7 @@ public final class MoreMatchers {
      * @see Matchers#isSubtypeOf(String)
      * @see <a href="https://github.com/google/error-prone/issues/1397">error-prone#1397</a>
      */
-    static <T extends Tree> Matcher<T> isSubtypeOf(String baseTypeString) {
+    public static <T extends Tree> Matcher<T> isSubtypeOf(String baseTypeString) {
         return Matchers.allOf(
                 Matchers.isSubtypeOf(baseTypeString), Matchers.not(Matchers.kindIs(Tree.Kind.NULL_LITERAL)));
     }
@@ -60,7 +60,7 @@ public final class MoreMatchers {
      * Matches enclosing classes on {@link ClassTree} blocks. This differs from {@link Matchers#enclosingClass(Matcher)}
      * which matches the input {@link ClassTree}, not the enclosing class.
      */
-    static <T extends ClassTree> Matcher<T> classEnclosingClass(Matcher<ClassTree> matcher) {
+    public static <T extends ClassTree> Matcher<T> classEnclosingClass(Matcher<ClassTree> matcher) {
         return (Matcher<T>) (classTree, state) -> {
             TreePath currentPath = state.getPath().getParentPath();
             while (currentPath != null) {
@@ -79,7 +79,7 @@ public final class MoreMatchers {
      * modifier. For example, all components nested in an interface are public by default, but they don't necessarily
      * use the public keyword.
      */
-    static <T extends Tree> Matcher<T> hasExplicitModifier(Modifier modifier) {
+    public static <T extends Tree> Matcher<T> hasExplicitModifier(Modifier modifier) {
         return (Matcher<T>) (tree, state) -> {
             if (tree instanceof ClassTree) {
                 return containsModifier(((ClassTree) tree).getModifiers(), state, modifier);
@@ -108,7 +108,7 @@ public final class MoreMatchers {
     }
 
     /** Matches a {@link MethodTree} by method signature. */
-    static Matcher<MethodTree> hasSignature(String signature) {
+    public static Matcher<MethodTree> hasSignature(String signature) {
         return (methodTree, state) -> {
             Symbol.MethodSymbol symbol = ASTHelpers.getSymbol(methodTree);
             if (symbol == null) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreMatchers.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreMatchers.java
@@ -31,7 +31,7 @@ import java.util.Locale;
 import javax.lang.model.element.Modifier;
 
 /** Additional {@link Matcher} factory methods shared by baseline checks. */
-final class MoreMatchers {
+public final class MoreMatchers {
 
     /**
      * Delegates to {@link Matchers#isSubtypeOf(Class)}, but adds a defensive check against null literals to work around

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
@@ -25,7 +25,7 @@ import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 
-final class TestCheckUtils {
+public final class TestCheckUtils {
 
     private TestCheckUtils() {
         // utility class

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/TestCheckUtils.java
@@ -32,7 +32,7 @@ public final class TestCheckUtils {
     }
 
     /** Note that this is a relatively expensive check and should be executed after simpler validation. */
-    static boolean isTestCode(VisitorState state) {
+    public static boolean isTestCode(VisitorState state) {
         TreePath path = state.getPath();
         for (Tree ancestor : path) {
             if (ancestor instanceof ClassTree && hasTestCases.matches((ClassTree) ancestor, state)) {

--- a/changelog/@unreleased/pr-1989.v2.yml
+++ b/changelog/@unreleased/pr-1989.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make errorprone utility classes public
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1989


### PR DESCRIPTION
## Before this PR
Utility classes are private, which means we can't use them in errorprone rules defined in other repos.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make errorprone utility classes public
==COMMIT_MSG==

## Possible downsides?
This makes them part of the public API, so breaking these APIs has more consequences.