### PR TITLE
baseline-error-prone supports java8

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -50,3 +50,8 @@ group = originalGroup + '-internal'
 publishing.publications.maven {
     groupId = originalGroup
 }
+
+javaVersion {
+    target = 8
+    runtime = 11
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.5.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.1.0'
         classpath 'com.gradle.publish:plugin-publish-plugin:0.18.0'
-        classpath 'com.palantir.baseline:gradle-baseline-java:4.43.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:4.42.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.9.0'
     }
 }

--- a/changelog/@unreleased/pr-1992.v2.yml
+++ b/changelog/@unreleased/pr-1992.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: baseline-error-prone supports java8
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/1992


### PR DESCRIPTION
==COMMIT_MSG==
baseline-error-prone supports java8
==COMMIT_MSG==

