### PR TITLE
Gradle plugins don't enforce PublicConstructorForAbstractClass

### DIFF
--- a/changelog/@unreleased/pr-2009.v2.yml
+++ b/changelog/@unreleased/pr-2009.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Gradle plugins don't enforce PublicConstructorForAbstractClass which
+    can break gradle injection
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2009

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -194,6 +194,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                         errorProneOptions.check("PreferSafeLogger", CheckSeverity.OFF);
                         errorProneOptions.check("PreferSafeLoggingPreconditions", CheckSeverity.OFF);
                         errorProneOptions.check("PreconditionsConstantMessage", CheckSeverity.OFF);
+                        errorProneOptions.check("PublicConstructorForAbstractClass", CheckSeverity.OFF);
                     }));
         });
     }


### PR DESCRIPTION
It could break gradle magic injection

==COMMIT_MSG==
Gradle plugins don't enforce PublicConstructorForAbstractClass which can break gradle injection
==COMMIT_MSG==

