### PR TITLE
Improvement: Disable errorprone in intellij

### DIFF
--- a/changelog/@unreleased/pr-2010.v2.yml
+++ b/changelog/@unreleased/pr-2010.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable errorprone in intellij
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2010

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/IntellijSupport.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/IntellijSupport.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline;
+
+public final class IntellijSupport {
+    private static final String INTELLIJ_ACTIVE = "idea.active";
+
+    public static boolean isRunningInIntellij() {
+        return System.getProperties().getProperty(INTELLIJ_ACTIVE) != null;
+    }
+
+    private IntellijSupport() {}
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -22,6 +22,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MoreCollectors;
+import com.palantir.baseline.IntellijSupport;
 import com.palantir.baseline.extensions.BaselineErrorProneExtension;
 import com.palantir.baseline.extensions.BaselineJavaVersionExtension;
 import com.palantir.baseline.tasks.CompileRefasterTask;
@@ -208,7 +209,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
             JavaCompile javaCompile,
             ErrorProneOptions errorProneOptions) {
 
-        if (project.hasProperty(DISABLE_PROPERTY)) {
+        if (project.hasProperty(DISABLE_PROPERTY) || IntellijSupport.isRunningInIntellij()) {
             log.info("Disabling baseline-error-prone for {} due to {}", project, DISABLE_PROPERTY);
             errorProneOptions.getEnabled().set(false);
         } else {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -17,6 +17,7 @@
 package com.palantir.baseline.plugins
 
 import com.google.common.collect.ImmutableMap
+import com.palantir.baseline.IntellijSupport
 import com.palantir.baseline.util.GitUtils
 import groovy.transform.CompileStatic
 import groovy.xml.XmlUtil
@@ -124,7 +125,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
     }
 
     private void configureProjectForIntellijImport(Project project) {
-        if (Boolean.getBoolean("idea.active")) {
+        if (IntellijSupport.isRunningInIntellij()) {
             addCodeStyleIntellijImport()
             addCheckstyleIntellijImport(project)
             addCopyrightIntellijImport()
@@ -447,7 +448,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
     }
 
     private static void configureSaveActionsForIntellijImport(Project project) {
-        if (!Boolean.getBoolean("idea.active")) {
+        if (!IntellijSupport.isRunningInIntellij()) {
             return
         }
         XmlUtils.createOrUpdateXmlFile(


### PR DESCRIPTION
## Before this PR
Running test/compilation from intellij with gradle integration was pretty painful since it would cause all errorprone rules to run. This slowed down overall compilation but also made it hard for you to quickly iterate on a test, or hack together a proof of concept

## After this PR
==COMMIT_MSG==
Disable errorprone in intellij
==COMMIT_MSG==

This _will not_ impact CI in any way and should only make the gradle integration's behaviour closer to working with a `*ipr` file

cc @iamdanfox 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

