### PR TITLE
Allow projects to override library auto-detection

### DIFF
--- a/changelog/@unreleased/pr-2011.v2.yml
+++ b/changelog/@unreleased/pr-2011.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow projects to override library auto-detection
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2011

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
@@ -29,11 +29,13 @@ public class BaselineJavaVersionExtension {
 
     private final Property<JavaLanguageVersion> target;
     private final Property<JavaLanguageVersion> runtime;
+    private final Property<Boolean> overrideLibraryAutoDetection;
 
     @Inject
     public BaselineJavaVersionExtension(Project project) {
         target = project.getObjects().property(JavaLanguageVersion.class);
         runtime = project.getObjects().property(JavaLanguageVersion.class);
+        overrideLibraryAutoDetection = project.getObjects().property(Boolean.class);
     }
 
     /** Target {@link JavaLanguageVersion} for compilation. */
@@ -52,5 +54,17 @@ public class BaselineJavaVersionExtension {
 
     public final void setRuntime(int value) {
         runtime.set(JavaLanguageVersion.of(value));
+    }
+
+    /**
+     * Overrides auto-detection if a value is present to force this module to be a
+     * library ({@code true}) or a distribution {@code false}).
+     */
+    public final Property<Boolean> overrideLibraryAutoDetection() {
+        return overrideLibraryAutoDetection;
+    }
+
+    public final void library() {
+        overrideLibraryAutoDetection.set(true);
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -103,6 +103,25 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         getBytecodeVersion(compiledClass) == JAVA_17_BYTECODE
     }
 
+    def 'library target is used when no artifacts are published but project is overridden as a library'() {
+        when:
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 11
+            distributionTarget = 17
+        }
+        javaVersion {
+            library()
+        }
+        '''.stripIndent(true)
+        file('src/main/java/Main.java') << java11CompatibleCode
+        File compiledClass = new File(projectDir, "build/classes/java/main/Main.class")
+
+        then:
+        runTasksSuccessfully('compileJava')
+        getBytecodeVersion(compiledClass) == JAVA_11_BYTECODE
+    }
+
     def 'library target is used when nebula maven publishing plugin is applied'() {
         when:
         buildFile << '''


### PR DESCRIPTION
This is helpful for test modules which aren't published, but
may be consumed by either distribution code or library code.

==COMMIT_MSG==
Allow projects to override library auto-detection
==COMMIT_MSG==

The extension property dependencies feel a bit weird becuase the javaVersions plugin is responsible for making a determination whether a module is a library or dist, but it reads the override value from the submodules `javaVersion` extension.
I considered splitting the pieces apart and passing the full context along to each submodule, allowing it to make the determination, but the change was much larger and ultimately I'm not convinced it was easier to follow.

Ideally we'd use some third system to tag modules as distribution/asset/library/etc and simply read that metadata, but that's well out of scope for this change :-)