### PR TITLE
Improve coordination between java-versions and idea ipr

### DIFF
--- a/changelog/@unreleased/pr-2012.v2.yml
+++ b/changelog/@unreleased/pr-2012.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Improve coordination between java-versions and idea ipr allowing project
+    iprs to be successfully imported
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2012


### PR DESCRIPTION
## Before this PR
ipr imports failed to build due to skewed bytecode versions, requiring manual edits to ipr files and UI costomization.

## After this PR
"it just works"
==COMMIT_MSG==
Improve coordination between java-versions and idea ipr allowing project iprs to be successfully imported
==COMMIT_MSG==

## Possible downsides?
I don't actually know groovy, and write java with a different extension. I suspect there's some clever syntax that makes this easier ¯\_(ツ)_/¯

