### PR TITLE
configure codeStyles for intellij import

### DIFF
--- a/changelog/@unreleased/pr-2015.v2.yml
+++ b/changelog/@unreleased/pr-2015.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: It's no longer necessary to import an ipr before using gradle integration,
+    code styles are imported correctly out of the box.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2015

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -183,10 +183,13 @@ class BaselineIdea extends AbstractBaselinePlugin {
                     def codeScheme = GroovyXmlUtils.matchOrCreateChild(it, "code_scheme", [name: 'Project'])
                     codeScheme.attributes().putIfAbsent("version", 173)
                     def javaCodeStyleSettings = GroovyXmlUtils.matchOrCreateChild(codeScheme, "JavaCodeStyleSettings")
-                    // Just add the default configuration nodes on top of whatever nodes already exist
-                    // We could be better about this, but IDEA will mostly resolve the duplicates here for us
+                    // Avoid re-adding duplicate options to the project. This allows users to override settings based
+                    // on preference.
                     ideaStyleSettings.value.option.forEach { ideaStyleSetting ->
-                        javaCodeStyleSettings.append(ideaStyleSetting)
+                        def settingName = ideaStyleSetting.attributes().get("name")
+                        if (settingName != null && javaCodeStyleSettings["option"].find { it.attributes().get("name") == settingName } == null) {
+                            javaCodeStyleSettings.append(ideaStyleSetting)
+                        }
                     }
                 },
                 {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -141,7 +141,8 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
 
         def ideaStyleSettings = new File(projectDir, ".idea/codeStyles/Project.xml").text
         ideaStyleSettings.startsWith('<component name="ProjectCodeStyleConfiguration">')
-        ideaStyleSettings.contains('<code_scheme name="Project">')
+        ideaStyleSettings.contains('<code_scheme name="Project" version="173">')
+        ideaStyleSettings.contains('<JavaCodeStyleSettings>')
         ideaStyleSettings.contains('<option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true"/>')
         ideaStyleSettings.endsWith("""
               </code_scheme>


### PR DESCRIPTION
Based in part upon #1231 (Thanks @dansanduleac!)

## Before this PR
Import `.ipr`, then migrate to gradle integration

## After this PR
==COMMIT_MSG==
It's no longer necessary to import an ipr before using gradle integration, code styles are imported correctly out of the box.
==COMMIT_MSG==

## Possible downsides?
Maybe I messed up?

