### PR TITLE
Idea integration results in correct copyright xml files

### DIFF
--- a/changelog/@unreleased/pr-2016.v2.yml
+++ b/changelog/@unreleased/pr-2016.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Idea integration results in correct copyright xml files without duplicate
     entries
   links:

--- a/changelog/@unreleased/pr-2016.v2.yml
+++ b/changelog/@unreleased/pr-2016.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Idea integration results in correct copyright xml files without duplicate
+    entries
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2016

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -273,7 +273,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
                     // Replace the extension by xml for the actual file
                     project.file(".idea/copyright/" + xmlFileName),
                     {node ->
-                        addCopyrightFile(node, file, fileName)
+                        createOrUpdateCopyrightFile(node, file, fileName)
                     },
                     copyrightManagerNode)
         }
@@ -308,6 +308,19 @@ class BaselineIdea extends AbstractBaselinePlugin {
             </copyright>
             """.stripIndent()
         ))
+    }
+
+    private static void createOrUpdateCopyrightFile(Node node, File file, String fileName) {
+        def copyrightText = XmlUtil.escapeControlCharacters(XmlUtil.escapeXml(file.text.trim()))
+        // Ensure that subsequent runs don't produce duplicate entries
+        Node copyrightNode = GroovyXmlUtils.matchOrCreateChild(node, "copyright")
+        Node noticeNode = GroovyXmlUtils.matchOrCreateChild(copyrightNode, "option", ["name": "notice"])
+        // Update the copyright text if it has changed
+        noticeNode.attributes().put("value", copyrightText)
+        GroovyXmlUtils.matchOrCreateChild(copyrightNode, "option", ["name": "keyword"], ["value": "Copyright"])
+        GroovyXmlUtils.matchOrCreateChild(copyrightNode, "option", ["name": "allowReplaceKeyword"], ["value": ""])
+        GroovyXmlUtils.matchOrCreateChild(copyrightNode, "option", ["name": "myName"], ["value": fileName])
+        GroovyXmlUtils.matchOrCreateChild(copyrightNode, "option", ["name": "myLocal"], ["value": true])
     }
 
     private void addEclipseFormat(node) {


### PR DESCRIPTION
Previously we had:

```xml
<component name="CopyrightManager">
  <copyright>
    <option name="notice" value="(c) Copyright ${today.year} Palantir
Technologies Inc. All rights reserved.&#10;&#10;Licensed under the
Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not
use this file except in compliance with the License.&#10;You may obtain
a copy of the License at&#10;&#10;
http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by
applicable law or agreed to in writing, software&#10;distributed under
the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT
WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See
the License for the specific language governing permissions
and&#10;limitations under the License."/>
    <option name="keyword" value="Copyright"/>
    <option name="allowReplaceKeyword" value=""/>
    <option name="myName" value="001_apache-2.0.txt"/>
    <option name="myLocal" value="true"/>
  </copyright>
  <copyright>
    <option name="notice" value="(c) Copyright ${today.year} Palantir
Technologies Inc. All rights reserved.&#10;&#10;Licensed under the
Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not
use this file except in compliance with the License.&#10;You may obtain
a copy of the License at&#10;&#10;
http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by
applicable law or agreed to in writing, software&#10;distributed under
the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT
WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See
the License for the specific language governing permissions
and&#10;limitations under the License."/>
    <option name="keyword" value="Copyright"/>
    <option name="allowReplaceKeyword" value=""/>
    <option name="myName" value="001_apache-2.0.txt"/>
    <option name="myLocal" value="true"/>
  </copyright>
  <copyright>
    <option name="notice" value="(c) Copyright ${today.year} Palantir
Technologies Inc. All rights reserved.&#10;&#10;Licensed under the
Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not
use this file except in compliance with the License.&#10;You may obtain
a copy of the License at&#10;&#10;
http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by
applicable law or agreed to in writing, software&#10;distributed under
the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT
WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See
the License for the specific language governing permissions
and&#10;limitations under the License."/>
    <option name="keyword" value="Copyright"/>
    <option name="allowReplaceKeyword" value=""/>
    <option name="myName" value="001_apache-2.0.txt"/>
    <option name="myLocal" value="true"/>
  </copyright>
  <copyright>
    <option name="notice" value="(c) Copyright ${today.year} Palantir
Technologies Inc. All rights reserved.&#10;&#10;Licensed under the
Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not
use this file except in compliance with the License.&#10;You may obtain
a copy of the License at&#10;&#10;
http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by
applicable law or agreed to in writing, software&#10;distributed under
the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT
WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See
the License for the specific language governing permissions
and&#10;limitations under the License."/>
    <option name="keyword" value="Copyright"/>
    <option name="allowReplaceKeyword" value=""/>
    <option name="myName" value="001_apache-2.0.txt"/>
    <option name="myLocal" value="true"/>
  </copyright>
</component>
```

==COMMIT_MSG==
Idea integration results in correct copyright xml files without duplicate entries
==COMMIT_MSG==
