### PR TITLE
Suggest putting jupiter on runtime only

### DIFF
--- a/changelog/@unreleased/pr-2021.v2.yml
+++ b/changelog/@unreleased/pr-2021.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Upon missing jupiter on classpath, suggest putting it on runtime rather
+    than implementation to avoid making checkUnusedDependenciesTest fail in return.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2021

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -93,7 +93,7 @@ public class CheckJUnitDependencies extends DefaultTask {
         // org.junit.jupiter.api.Test annotation, but as JUnit4 knows nothing about these, they'll silently not run
         // unless the user has wired up the dependency correctly.
         if (sourceSetMentionsJUnit5Api(ss)) {
-            String implementation = ss.getImplementationConfigurationName();
+            String implementation = ss.getRuntimeClasspathConfigurationName();
             Preconditions.checkState(
                     junitPlatformEnabled,
                     "Some tests mention JUnit5, but the '"

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -93,7 +93,7 @@ public class CheckJUnitDependencies extends DefaultTask {
         // org.junit.jupiter.api.Test annotation, but as JUnit4 knows nothing about these, they'll silently not run
         // unless the user has wired up the dependency correctly.
         if (sourceSetMentionsJUnit5Api(ss)) {
-            String implementation = ss.getRuntimeClasspathConfigurationName();
+            String runtime = ss.getRuntimeClasspathConfigurationName();
             Preconditions.checkState(
                     junitPlatformEnabled,
                     "Some tests mention JUnit5, but the '"
@@ -102,7 +102,7 @@ public class CheckJUnitDependencies extends DefaultTask {
                             + "useJUnitPlatform() enabled. This means tests may be silently not running! Please "
                             + "add the following:\n\n"
                             + "    "
-                            + implementation
+                            + runtime
                             + " 'org.junit.jupiter:junit-jupiter'\n");
         }
 


### PR DESCRIPTION
## Before this PR
checkUnusedDependenciesTest fails complaining org.junit.jupiter:junit-jupiter is unused and should be replaced by org.junit.jupiter:junit-jupiter-api. If one does that, checkJUnitDependencies fails and tells to put it back.

With this PR, a better solution is proposed in the error.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Suggest putting jupiter on runtime only in error
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

