### PR TITLE
Only enforce constant strings when log format has arguments.

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessage.java
@@ -63,7 +63,10 @@ public final class Slf4jConstantLogMessage extends BugChecker implements MethodI
         int argumentCount = (MARKER.matches(tree.getArguments().get(0), state) ? args.size() - 2 : args.size() - 1);
 
         /* A message with no arguments isn't treated as a format; nor one where the only argument is a Throwable */
-        if (argumentCount == 0 || (argumentCount == 1 && THROWABLE.matches(tree.getArguments().get(tree.getArguments().size() - 1), state))) {
+        if (argumentCount == 0
+                || (argumentCount == 1
+                        && THROWABLE.matches(
+                                tree.getArguments().get(tree.getArguments().size() - 1), state))) {
             return Description.NO_MATCH;
         }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessageTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/Slf4jConstantLogMessageTests.java
@@ -51,16 +51,17 @@ public final class Slf4jConstantLogMessageTests {
 
     @Test
     public void testNonCompileTimeConstantExpression() throws Exception {
-        test("log.trace(\"constant\" + param);");
-        test("log.debug(\"constant\" + param);");
-        test("log.info(\"constant\" + param);");
-        test("log.warn(\"constant\" + param);");
-        test("log.error(\"constant\" + param);");
-        test("log.trace(new DummyMarker(), \"constant\" + param);");
-        test("log.debug(new DummyMarker(), \"constant\" + param);");
-        test("log.info(new DummyMarker(), \"constant\" + param);");
-        test("log.warn(new DummyMarker(), \"constant\" + param);");
-        test("log.error(new DummyMarker(), \"constant\" + param);");
+        test("log.trace(\"constant\" + param, \"argument\");");
+        test("log.debug(\"constant\" + param, \"argument\");");
+        test("log.info(\"constant\" + param, \"argument\");");
+        test("log.warn(\"constant\" + param, \"argument\");");
+        test("log.error(\"constant\" + param, \"argument\");");
+        test("log.trace(new DummyMarker(), \"constant\" + param, \"argument\");");
+        test("log.debug(new DummyMarker(), \"constant\" + param, \"argument\");");
+        test("log.info(new DummyMarker(), \"constant\" + param, \"argument\");");
+        test("log.warn(new DummyMarker(), \"constant\" + param, \"argument\");");
+        test("log.error(new DummyMarker(), \"constant\" + param, \"argument\");");
+        test("log.error(new DummyMarker(), \"constant\" + param, \"argument\", new Throwable());");
     }
 
     @Test
@@ -121,6 +122,22 @@ public final class Slf4jConstantLogMessageTests {
                         "    log.info(new DummyMarker(), \"constant\");",
                         "    log.warn(new DummyMarker(), \"constant\");",
                         "    log.error(new DummyMarker(), \"constant\");",
+                        "}",
+                        "",
+                        "void f(String param) {",
+                        "    // Logging of a non-constant, but with no arguments so it's a message",
+                        "    log.trace(\"constant\" + param);",
+                        "    log.debug(\"constant\" + param);",
+                        "    log.info(\"constant\" + param);",
+                        "    log.warn(\"constant\" + param);",
+                        "    log.error(\"constant\" + param);",
+                        "    log.trace(new DummyMarker(), \"constant\" + param);",
+                        "    log.debug(new DummyMarker(), \"constant\" + param);",
+                        "    log.info(new DummyMarker(), \"constant\" + param);",
+                        "    log.warn(new DummyMarker(), \"constant\" + param);",
+                        "    log.error(new DummyMarker(), \"constant\" + param);",
+                        "",
+                        "    log.error(new DummyMarker(), \"constant\" + param, new Throwable());",
                         "  }",
                         "",
                         "  class DummyMarker implements Marker {",


### PR DESCRIPTION
If a single string is passed to SLF4J's logging messages, either with or
without a Marker before or a Throwable after, then it's a literal message,
rather than a format. Permit that usage without complaint.

## Before this PR
I'm looking to identify cases in a codebase where an SLF4J format is not hardcoded, and this checker is referenced as a solution to https://github.com/google/error-prone/issues/565 . However, I found too many false positives for the case where the log message was just a message, rather than being used as a format string.

## After this PR
Cases with or without a `Marker`, with or without a `Throwable`, but with no arguments on top of the message no longer cause warnings.

## Possible downsides?
Non-constant messages aren't wrong, but it's still a very reasonable to want prevent them as part of a style guide. This change treats them as generally acceptable, with no way to preserve the current behaviour.
