### PR TITLE
FilterOutputStreamSlowMultibyteWrite warns

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `PreferImmutableStreamExCollections`: It's common to use toMap/toSet/toList() as the terminal operation on a stream, but would be extremely surprising to rely on the mutability of these collections. Prefer `toImmutableMap`, `toImmutableSet` and `toImmutableList`. (If the performance overhead of a stream is already acceptable, then the `UnmodifiableFoo` wrapper is likely tolerable).
 - `DangerousIdentityKey`: Key type does not override equals() and hashCode, so comparisons will be done on reference equality only.
 - `ConsistentOverrides`: Ensure values are bound to the correct variables when overriding methods
+- `FilterOutputStreamSlowMultibyteWrite`:Subclasses of FilterOutputStream should provide a more efficient implementation of `write(byte[], int, int)` to avoid slow writes.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FilterOutputStreamSlowMultibyteWrite.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/FilterOutputStreamSlowMultibyteWrite.java
@@ -20,6 +20,7 @@
 
 package com.palantir.baseline.errorprone;
 
+import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.SeverityLevel;
@@ -42,8 +43,11 @@ import com.sun.tools.javac.util.Name;
 import java.io.FilterOutputStream;
 import javax.lang.model.element.ElementKind;
 
+@AutoService(BugChecker.class)
 @BugPattern(
         name = "FilterOutputStreamSlowMultibyteWrite",
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
         summary = "Please also override `void write(byte[], int, int)`, "
                 + "otherwise multi-byte writes to this output stream are likely to be slow.",
         severity = SeverityLevel.WARNING,

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FilterOutputStreamSlowMultibyteWriteTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FilterOutputStreamSlowMultibyteWriteTest.java
@@ -33,8 +33,9 @@ class FilterOutputStreamSlowMultibyteWriteTest {
         compilationHelper
                 .addSourceLines(
                         "TestClass.java",
-                        "class TestClass extends java.io.FilterOutputStream {",
-                        "  TestClass() { super(null); }",
+                        "import java.io.*;",
+                        "class TestClass extends FilterOutputStream {",
+                        "  TestClass(OutputStream out) { super(out); }",
                         "  public void write(byte[] b, int a, int c) {}",
                         "  public void write(int b) {}",
                         "}")
@@ -46,9 +47,10 @@ class FilterOutputStreamSlowMultibyteWriteTest {
         compilationHelper
                 .addSourceLines(
                         "TestClass.java",
+                        "import java.io.*;",
                         "  // BUG: Diagnostic contains:",
-                        "class TestClass extends java.io.FilterOutputStream {",
-                        "  TestClass() { super(null); }",
+                        "class TestClass extends FilterOutputStream {",
+                        "  TestClass(OutputStream out) { super(out); }",
                         "}")
                 .doTest();
     }
@@ -58,10 +60,25 @@ class FilterOutputStreamSlowMultibyteWriteTest {
         compilationHelper
                 .addSourceLines(
                         "TestClass.java",
-                        "class TestClass extends java.io.FilterOutputStream {",
-                        "  TestClass() { super(null); }",
+                        "import java.io.*;",
+                        "class TestClass extends FilterOutputStream {",
+                        "  TestClass(OutputStream out) { super(out); }",
                         "  // BUG: Diagnostic contains:",
                         "  public void write(int b) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void close() {
+        compilationHelper
+                .addSourceLines(
+                        "TestClass.java",
+                        "import java.io.*;",
+                        "  // BUG: Diagnostic contains:",
+                        "final class TestClass extends FilterOutputStream {",
+                        "  TestClass(OutputStream out) { super(out); }",
+                        "  @Override public void close() throws IOException {}",
                         "}")
                 .doTest();
     }
@@ -71,8 +88,9 @@ class FilterOutputStreamSlowMultibyteWriteTest {
         compilationHelper
                 .addSourceLines(
                         "TestClass.java",
-                        "abstract class TestClass extends java.io.FilterOutputStream {",
-                        "  TestClass() { super(null); }",
+                        "import java.io.*;",
+                        "abstract class TestClass extends FilterOutputStream {",
+                        "  TestClass(OutputStream out) { super(out); }",
                         "  // BUG: Diagnostic contains:",
                         "  public abstract void write(int b);",
                         "}")
@@ -84,8 +102,9 @@ class FilterOutputStreamSlowMultibyteWriteTest {
         compilationHelper
                 .addSourceLines(
                         "TestClass.java",
-                        "abstract class TestClass extends java.io.FilterOutputStream {",
-                        "  TestClass() { super(null); }",
+                        "import java.io.*;",
+                        "abstract class TestClass extends FilterOutputStream {",
+                        "  TestClass(OutputStream out) { super(out); }",
                         "  // BUG: Diagnostic contains:",
                         "  public native void write(int b);",
                         "}")
@@ -97,8 +116,9 @@ class FilterOutputStreamSlowMultibyteWriteTest {
         compilationHelper
                 .addSourceLines(
                         "Super.java",
-                        "abstract class Super extends java.io.FilterOutputStream {",
-                        "  Super() { super(null); }",
+                        "import java.io.*;",
+                        "abstract class Super extends FilterOutputStream {",
+                        "  Super() { super(new ByteArrayOutputStream()); }",
                         "  public void write(byte[] b, int a, int c) {}",
                         "}")
                 .addSourceLines(
@@ -115,8 +135,9 @@ class FilterOutputStreamSlowMultibyteWriteTest {
         compilationHelper
                 .addSourceLines(
                         "Super.java",
-                        "abstract class Super extends java.io.FilterOutputStream {",
-                        "  Super() { super(null); }",
+                        "import java.io.*;",
+                        "abstract class Super extends FilterOutputStream {",
+                        "  Super() { super(new ByteArrayOutputStream()); }",
                         "  // BUG: Diagnostic contains:",
                         "  public void write(int b) {}",
                         "}")

--- a/changelog/@unreleased/pr-2026.v2.yml
+++ b/changelog/@unreleased/pr-2026.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    Enable FilterOutputStreamSlowMultibyteWrite at warning level to identify
+    inefficient FilterOuputStream implementations.
+
+    Subclasses of FilterOutputStream should provide a more efficient
+    implementation of `write(byte[], int, int)` to avoid slow writes.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2026


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
https://github.com/palantir/gradle-baseline/pull/2024 missed adding `@AutoService(BugChecker.class)` so the check wasn't registered with error-prone

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable FilterOutputStreamSlowMultibyteWrite at warning level to identify
inefficient FilterOuputStream implementations.

Subclasses of FilterOutputStream should provide a more efficient
implementation of `write(byte[], int, int)` to avoid slow writes.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

