### PR TITLE
Refine FilterOutputStreamSlowMultibyteWrite findings

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FilterOutputStreamSlowMultibyteWriteTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/FilterOutputStreamSlowMultibyteWriteTest.java
@@ -148,4 +148,38 @@ class FilterOutputStreamSlowMultibyteWriteTest {
                         "}")
                 .doTest();
     }
+
+    @Test
+    public void inheritedSingleAndMultiByteWrite() {
+        compilationHelper
+                .addSourceLines(
+                        "Super.java",
+                        "import java.io.*;",
+                        "abstract class Super extends FilterOutputStream {",
+                        "  Super() { super(new ByteArrayOutputStream()); }",
+                        "  public void write(int b) {}",
+                        "  public void write(byte[] b, int a, int c) {}",
+                        "}")
+                .addSourceLines("TestClass.java", "class TestClass extends Super {}")
+                .doTest();
+    }
+
+    @Test
+    public void singleAndMultiByteWrite() {
+        compilationHelper
+                .addSourceLines(
+                        "Super.java",
+                        "import java.io.*;",
+                        "  // BUG: Diagnostic contains:",
+                        "abstract class Super extends FilterOutputStream {",
+                        "  Super() { super(new ByteArrayOutputStream()); }",
+                        "}")
+                .addSourceLines(
+                        "TestClass.java",
+                        "class TestClass extends Super {",
+                        "  public void write(int b) {}",
+                        "  public void write(byte[] b, int a, int c) {}",
+                        "}")
+                .doTest();
+    }
 }

--- a/changelog/@unreleased/pr-2031.v2.yml
+++ b/changelog/@unreleased/pr-2031.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: |-
+    Refine FilterOutputStreamSlowMultibyteWrite findings
+
+    Avoid warning FilterOutputStreamSlowMultibyteWrite when intermediate
+    type overrides both single and multibyte write methods.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2031


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
FilterOutputStreamSlowMultibyteWrite would mistakenly warn on intermediate types that override both single and multibyte write methods.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Refine FilterOutputStreamSlowMultibyteWrite findings

Avoid warning FilterOutputStreamSlowMultibyteWrite when intermediate
type overrides both single and multibyte write methods.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

