### PR TITLE
Allow class types in DangerousIdentityKey

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousIdentityKey.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousIdentityKey.java
@@ -22,6 +22,7 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
@@ -42,10 +43,20 @@ public final class DangerousIdentityKey extends MoreAbstractAsKeyOfSetOrMap {
 
     @Override
     protected boolean isBadType(Type type, VisitorState state) {
-        // Only flag final types, otherwise we'll encounter false positives when presented with overrides.
-        if (type == null || !type.isFinal()) {
+        if (type == null) {
             return false;
         }
+
+        // Ignore non-final types, otherwise we'll encounter false positives when presented with overrides.
+        if (!type.isFinal()) {
+            return false;
+        }
+
+        // Ignore class types
+        if (ASTHelpers.isSameType(type, state.getSymtab().classType, state)) {
+            return false;
+        }
+
         return !implementsMethod(state.getTypes(), type, state.getNames().equals, state)
                 || !implementsMethod(state.getTypes(), type, state.getNames().hashCode, state);
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousIdentityKeyTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousIdentityKeyTest.java
@@ -123,6 +123,20 @@ public final class DangerousIdentityKeyTest {
     }
 
     @Test
+    public void testValidClass() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "class Test {",
+                        "    private Object test() {",
+                        "        return new HashSet<Class<String>>();",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testInvalidNoEquals() {
         compilationHelper
                 .addSourceLines(

--- a/changelog/@unreleased/pr-2036.v2.yml
+++ b/changelog/@unreleased/pr-2036.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`DangerousIdentityKey` now allows `Class` to be used as a map or set
+    key.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2036


### PR DESCRIPTION
## Before this PR
Using `Class` as a map or set key is disallowed by `DangerousIdentityKey`

## After this PR
Using `Class` as a map or set key is not disallowed by `DangerousIdentityKey`

There should only ever be one instance of a given `Class` type. Equality comparisons are only way to perform exact class comparison (things like `instanceof` consider inheritance).
