### PR TITLE
Ignore junit-jupiter even when test deps not resolved

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -193,6 +193,9 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             // this is liberally applied to ease the Java8 -> 11 transition
                             task.ignore("javax.annotation", "javax.annotation-api");
 
+                            // this is typically used instead of junit-jupiter-api to simplify configuration
+                            task.ignore("org.junit.jupiter", "junit-jupiter");
+
                             // pick up ignores configured globally on the parent task
                             task.ignore(checkUnusedDependencies.get().getIgnore());
                         });

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineTesting.java
@@ -19,7 +19,6 @@ package com.palantir.baseline.plugins;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.baseline.tasks.CheckJUnitDependencies;
-import com.palantir.baseline.tasks.CheckUnusedDependenciesTask;
 import com.palantir.baseline.util.VersionUtils;
 import java.lang.reflect.Method;
 import java.util.Objects;
@@ -33,7 +32,6 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
@@ -96,15 +94,6 @@ public final class BaselineTesting implements Plugin<Project> {
                 "Detected 'org:junit.jupiter:junit-jupiter', enabling useJUnitPlatform() on {}",
                 maybeTestTask.get().getName());
         enableJunit5ForTestTask(maybeTestTask.get());
-
-        // Also wire up a test ignore for this source set
-        project.getPlugins().withType(BaselineExactDependencies.class, exactDeps -> {
-            TaskContainer tasks = project.getTasks();
-            tasks.named(
-                    BaselineExactDependencies.checkUnusedDependenciesNameForSourceSet(ss),
-                    CheckUnusedDependenciesTask.class,
-                    task -> task.ignore("org.junit.jupiter", "junit-jupiter"));
-        });
     }
 
     public static Optional<Test> getTestTaskForSourceSet(Project proj, SourceSet ss) {


### PR DESCRIPTION
## Before this PR
Running `./gradlew check -x test` locally fails with the following error:
```
* What went wrong:
Execution failed for task ':my-project:checkUnusedDependenciesTest'.
> Found 1 dependencies unused during compilation, please delete them from 'my-project/build.gradle' or choose one of the suggested fixes:
        org.junit.jupiter:junit-jupiter
                Did you mean:
                        org.junit.jupiter:junit-jupiter-api

```

https://github.com/palantir/gradle-baseline/pull/1929 changed the behavior of the `BaselineTesting` plugin to require test dependencies to be resolved for the `junit-jupiter` dependency to be ignored. Because configurations are resolved lazily, if the test configuration is not needed before running the `checkUnusedDependenciesTest`, then `junit-jupiter` will not be ignored.

## After this PR
The `junit-jupiter` is unconditionally ignored.

## Possible downsides?
We might miss some unused `junit-jupiter` dependencies in non-test source sets. But I think it's pretty unlikely someone will depend on `junit-jupiter` in a non-test source set.

I tried various approaches of moving this logic out in `BaselineTesting`, but ran into some issues because the `BaselineExactDependencies` plugin is added before the individual tasks are configured, which caused errors when trying to add the ignore.
```
Caused by: org.gradle.api.UnknownTaskException: Task with name 'checkUnusedDependenciesTest' not found in project ':my-project'.
```