### PR TITLE
Add property to explicitly enable Error Prone

### DIFF
--- a/changelog/@unreleased/pr-2042.v2.yml
+++ b/changelog/@unreleased/pr-2042.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Error Prone can be explicitly enabled using the `com.palantir.baseline-error-prone.disable=false`
+    Gradle property.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2042

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -66,6 +66,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
     private static final String PROP_ERROR_PRONE_APPLY = "errorProneApply";
     private static final String PROP_REFASTER_APPLY = "refasterApply";
     private static final String DISABLE_PROPERTY = "com.palantir.baseline-error-prone.disable";
+    private static final String ENABLE_PROPERTY = "com.palantir.baseline-error-prone.enable";
 
     @Override
     public void apply(Project project) {
@@ -209,11 +210,11 @@ public final class BaselineErrorProne implements Plugin<Project> {
             JavaCompile javaCompile,
             ErrorProneOptions errorProneOptions) {
 
-        if (project.hasProperty(DISABLE_PROPERTY) || IntellijSupport.isRunningInIntellij()) {
-            log.info("Disabling baseline-error-prone for {} due to {}", project, DISABLE_PROPERTY);
-            errorProneOptions.getEnabled().set(false);
-        } else {
+        if (project.hasProperty(ENABLE_PROPERTY)) {
             errorProneOptions.getEnabled().set(true);
+        } else if (project.hasProperty(DISABLE_PROPERTY) || IntellijSupport.isRunningInIntellij()) {
+            log.info("Disabling baseline-error-prone for {}", project);
+            errorProneOptions.getEnabled().set(false);
         }
 
         errorProneOptions.getDisableWarningsInGeneratedCode().set(true);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -66,7 +66,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
     private static final String PROP_ERROR_PRONE_APPLY = "errorProneApply";
     private static final String PROP_REFASTER_APPLY = "refasterApply";
     private static final String DISABLE_PROPERTY = "com.palantir.baseline-error-prone.disable";
-    private static final String ENABLE_PROPERTY = "com.palantir.baseline-error-prone.enable";
 
     @Override
     public void apply(Project project) {
@@ -209,11 +208,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
             BaselineErrorProneExtension errorProneExtension,
             JavaCompile javaCompile,
             ErrorProneOptions errorProneOptions) {
-
-        if (project.hasProperty(ENABLE_PROPERTY)) {
-            errorProneOptions.getEnabled().set(true);
-        } else if (project.hasProperty(DISABLE_PROPERTY) || IntellijSupport.isRunningInIntellij()) {
-            log.info("Disabling baseline-error-prone for {}", project);
+        if (isDisabled(project)) {
             errorProneOptions.getEnabled().set(false);
         }
 
@@ -393,6 +388,15 @@ public final class BaselineErrorProne implements Plugin<Project> {
 
     private static boolean isErrorProneRefactoring(Project project) {
         return project.hasProperty(PROP_ERROR_PRONE_APPLY);
+    }
+
+    private static boolean isDisabled(Project project) {
+        Object disable = project.findProperty(DISABLE_PROPERTY);
+        if (disable == null) {
+            return IntellijSupport.isRunningInIntellij();
+        } else {
+            return !disable.equals("false");
+        }
     }
 
     private static boolean checkExplicitlyDisabled(ErrorProneOptions errorProneOptions, String check) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -96,13 +96,35 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         result.output.contains("[ArrayEquals] Reference equality used to compare arrays")
     }
 
-    def 'error-prone can be suppressed using property'() {
+    def 'error-prone can be disabled using property'() {
         when:
         buildFile << standardBuildFile
         file('src/main/java/test/Test.java') << invalidJavaFile
 
         then:
         BuildResult result = with('compileJava', '-Pcom.palantir.baseline-error-prone.disable').build()
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+    }
+
+    def 'error-prone is disabled in IntelliJ'() {
+        when:
+        buildFile << standardBuildFile
+        file('src/main/java/test/Test.java') << invalidJavaFile
+
+        then:
+        BuildResult result = with('compileJava', '-Didea.active=true').build()
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+    }
+
+    def 'error-prone can be enabled using property'() {
+        when:
+        buildFile << standardBuildFile
+        file('src/main/java/test/Test.java') << invalidJavaFile
+
+        then:
+        BuildResult result = with('compileJava', '-Pcom.palantir.baseline-error-prone.disable', '-Didea.active=true', '-Pcom.palantir.baseline-error-prone.enable').buildAndFail()
+        result.task(":compileJava").outcome == TaskOutcome.FAILED
+        result.output.contains("[ArrayEquals] Reference equality used to compare arrays")
     }
 
     def 'compileJava succeeds when error-prone finds no errors'() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -122,7 +122,7 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         file('src/main/java/test/Test.java') << invalidJavaFile
 
         then:
-        BuildResult result = with('compileJava', '-Pcom.palantir.baseline-error-prone.disable', '-Didea.active=true', '-Pcom.palantir.baseline-error-prone.enable').buildAndFail()
+        BuildResult result = with('compileJava', '-Pcom.palantir.baseline-error-prone.disable=false', '-Didea.active=true').buildAndFail()
         result.task(":compileJava").outcome == TaskOutcome.FAILED
         result.output.contains("[ArrayEquals] Reference equality used to compare arrays")
     }


### PR DESCRIPTION
See https://github.com/palantir/gradle-baseline/pull/2010#issuecomment-1012612199

## Before this PR
Error Prone is always disabled when running in IntelliJ.

## After this PR
Users can explicitly enable Error Prone, even when running in IntelliJ, by setting the `com.palantir.baseline-error-prone.disable=false` Gradle property.