### PR TITLE
Prefer project modules on dependency resolution per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,25 @@
 
 _Baseline is a family of Gradle plugins for configuring Java projects with sensible defaults for code-style, static analysis, dependency versioning, CircleCI and IntelliJ IDEA/Eclipse integration._
 
-| Plugin                                        | Description            |
-|-----------------------------------------------|------------------------|
-| `com.palantir.baseline-idea`                  | Configures [Intellij IDEA](https://www.jetbrains.com/idea/) with code style and copyright headers
-| `com.palantir.baseline-eclipse`               | Configures [Eclipse](https://www.eclipse.org/downloads/) with code style and copyright headers
-| `com.palantir.baseline-error-prone`           | Static analysis for your Java code using Google's [error-prone](http://errorprone.info/).
-| `com.palantir.baseline-checkstyle`            | Enforces consistent Java formatting using [checkstyle](http://checkstyle.sourceforge.io/)
-| `com.palantir.baseline-format`                | Formats your java files to comply with checkstyle
-| `com.palantir.baseline-scalastyle`            | Enforces formatting using [scalastyle](https://github.com/scalastyle/scalastyle)
-| `com.palantir.baseline-class-uniqueness`      | Analyses your classpath to ensure no fully-qualified class is defined more than once.
-| `com.palantir.baseline-circleci`              | [CircleCI](https://circleci.com/) integration using `$CIRCLE_ARTIFACTS` and `$CIRCLE_TEST_REPORTS` dirs
-| `com.palantir.baseline-config`                | Config files for the above plugins
-| `com.palantir.baseline-reproducibility`       | Sensible defaults to ensure Jar, Tar and Zip tasks can be reproduced
-| `com.palantir.baseline-exact-dependencies`    | Ensures projects explicitly declare all the dependencies they rely on, no more and no less
-| `com.palantir.baseline-encoding`              | Ensures projects use the UTF-8 encoding in compile tasks.
-| `com.palantir.baseline-release-compatibility` | Ensures projects targeting older JREs only compile against classes and methods available in those JREs.
-| `com.palantir.baseline-testing`               | Configures test tasks to dump heap dumps (hprof files) for convenient debugging
-| `com.palantir.baseline-immutables`            | Enables incremental compilation for the [Immutables](http://immutables.github.io/) annotation processor.
-| `com.palantir.baseline-java-versions`         | Configures JDK versions in a consistent way via Gradle Toolchains.
+| Plugin                                         | Description            |
+|------------------------------------------------|------------------------|
+| `com.palantir.baseline-idea`                   | Configures [Intellij IDEA](https://www.jetbrains.com/idea/) with code style and copyright headers
+| `com.palantir.baseline-eclipse`                | Configures [Eclipse](https://www.eclipse.org/downloads/) with code style and copyright headers
+| `com.palantir.baseline-error-prone`            | Static analysis for your Java code using Google's [error-prone](http://errorprone.info/).
+| `com.palantir.baseline-checkstyle`             | Enforces consistent Java formatting using [checkstyle](http://checkstyle.sourceforge.io/)
+| `com.palantir.baseline-format`                 | Formats your java files to comply with checkstyle
+| `com.palantir.baseline-scalastyle`             | Enforces formatting using [scalastyle](https://github.com/scalastyle/scalastyle)
+| `com.palantir.baseline-class-uniqueness`       | Analyses your classpath to ensure no fully-qualified class is defined more than once.
+| `com.palantir.baseline-circleci`               | [CircleCI](https://circleci.com/) integration using `$CIRCLE_ARTIFACTS` and `$CIRCLE_TEST_REPORTS` dirs
+| `com.palantir.baseline-config`                 | Config files for the above plugins
+| `com.palantir.baseline-reproducibility`        | Sensible defaults to ensure Jar, Tar and Zip tasks can be reproduced
+| `com.palantir.baseline-exact-dependencies`     | Ensures projects explicitly declare all the dependencies they rely on, no more and no less
+| `com.palantir.baseline-encoding`               | Ensures projects use the UTF-8 encoding in compile tasks.
+| `com.palantir.baseline-release-compatibility`  | Ensures projects targeting older JREs only compile against classes and methods available in those JREs.
+| `com.palantir.baseline-testing`                | Configures test tasks to dump heap dumps (hprof files) for convenient debugging
+| `com.palantir.baseline-immutables`             | Enables incremental compilation for the [Immutables](http://immutables.github.io/) annotation processor.
+| `com.palantir.baseline-java-versions`          | Configures JDK versions in a consistent way via Gradle Toolchains.
+| `com.palantir.baseline-prefer-project-modules` | Configures Gradle to prefer project modules over external modules on dependency resolution per default.
 
 See also the [Baseline Java Style Guide and Best Practices](./docs).
 

--- a/changelog/@unreleased/pr-2056.v2.yml
+++ b/changelog/@unreleased/pr-2056.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Prefer project modules on dependency resolution per default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2056

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -90,6 +90,10 @@ gradlePlugin {
             id = 'com.palantir.baseline-enable-preview-flag'
             implementationClass = 'com.palantir.baseline.plugins.BaselineEnablePreviewFlag'
         }
+        baselinePreferProjectModules {
+            id = 'com.palantir.baseline-prefer-project-modules'
+            implementationClass = 'com.palantir.baseline.plugins.BaselinePreferProjectModules'
+        }
     }
 }
 
@@ -129,6 +133,9 @@ pluginBundle {
         }
         baselineEnablePreviewFlag {
             displayName = 'Palantir Baseline --enable-preview Flag Plugin'
+        }
+        baselinePreferProjectModules {
+            displayName = 'Palantir Baseline Prefer Project Modules Plugin'
         }
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -61,6 +61,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineJavaParameters.class);
             proj.getPluginManager().apply(BaselineImmutables.class);
             proj.getPluginManager().apply(BaselineModuleJvmArgs.class);
+            proj.getPluginManager().apply(BaselinePreferProjectModules.class);
         });
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselinePreferProjectModules.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselinePreferProjectModules.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ResolutionStrategy;
+
+/**
+ * Prefer project modules that are part of this build over external modules on dependency resolution.
+ */
+public final class BaselinePreferProjectModules implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getConfigurations()
+                .configureEach(
+                        configuration -> configuration.resolutionStrategy(ResolutionStrategy::preferProjectModules));
+    }
+}


### PR DESCRIPTION
## Before this PR
Every so often we run into support issues due to [Gradle's version ordering](https://docs.gradle.org/current/userguide/single_versions.html#version_ordering) semantics not being strictly compliant with our [sls-version ordering](https://github.com/palantir/sls-version-java#sls-product-version-specification).

E.g. based on the sls-spec, `1.264.0 < 1.264.0-90-g2f01179` holds true but according to Gradle's version ordering, the opposite is true, `1.264.0-90-g2f01179 < 1.264.0`.

Using its default resolution strategy, Gradle will try to substitute artifacts of local projects. However this can fail when the version ordering does not align because according to Gradle's version ordering, the module is relying on a version from the future.

As a result, Gradle fails on dependency resolution which errors such as:

```
A problem occurred configuring root project 'my-project'.
> Could not compute lock state from configuration 'unifiedClasspath' due to unresolved dependencies:
   * project :my-sub-proj (requested: 'project :my-sub-proj' because: requested)
        Failures:
           - Could not resolve project :my-sub-proj.
           - Unable to find a variant of com.palantir.my-sub-proj:1.264.0 providing the requested capability gcv:path=:my-sub-proj scope=PRODUCTION:0:
     - Variant compile provides com.palantir:my-sub-proj:1.264.0
     - Variant runtime provides com.palantir:my-sub-proj:1.264.0
     [...]
```

## After this PR

Prefer project modules that are part of this build over external modules on dependency resolution per default ([docs](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolutionStrategy.html)).

This avoids the above conflict by always choosing the local project module on conflict.

==COMMIT_MSG==
Prefer project modules on dependency resolution per default
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

