### PR TITLE
Fix: handle java 17 incompatibility in DangerousIdentityKey

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousIdentityKey.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousIdentityKey.java
@@ -64,7 +64,8 @@ public final class DangerousIdentityKey extends MoreAbstractAsKeyOfSetOrMap {
     private static boolean implementsMethod(Types types, Type type, Name methodName, VisitorState state) {
         MethodSymbol equals =
                 (MethodSymbol) state.getSymtab().objectType.tsym.members().findFirst(methodName);
-        return !Iterables.isEmpty(types.membersClosure(type, false)
+
+        return !Iterables.isEmpty(ASTHelpers.scope(types.membersClosure(type, false))
                 .getSymbolsByName(methodName, m -> m != equals && m.overrides(equals, type.tsym, types, false)));
     }
 }

--- a/changelog/@unreleased/pr-2058.v2.yml
+++ b/changelog/@unreleased/pr-2058.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle java 17 removal of :com/sun/tools/javac/util/Filter in DangerousIdentityKey
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2058


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Handle java 17 removal of :com/sun/tools/javac/util/Filter in DangerousIdentityKey
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

