### PR TITLE
Ignore default methods in StrictUnusedVariable

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -743,7 +743,8 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             checkArgument(sym.getKind() == ElementKind.PARAMETER);
             Symbol enclosingMethod = sym.owner;
 
-            return !enclosingMethod.getModifiers().contains(Modifier.ABSTRACT);
+            return !enclosingMethod.getModifiers().contains(Modifier.ABSTRACT)
+                    && !enclosingMethod.getModifiers().contains(Modifier.DEFAULT);
         }
 
         @Override

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -42,7 +42,6 @@ public class StrictUnusedVariableTest {
                         "import java.util.Optional;",
                         "interface Test {",
                         "  void method(String param);",
-                        "  // BUG: Diagnostic contains: Unused",
                         "  default void defaultMethod(String param) { }",
                         "}")
                 .doTest();

--- a/changelog/@unreleased/pr-2070.v2.yml
+++ b/changelog/@unreleased/pr-2070.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`StrictUnusedVariable` no longer flags parameters of default methods.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2070


### PR DESCRIPTION
Like abstract methods, default methods often have unused variables. These methods are intended to be overridden by implementations that may need those variables.

For example, a common pattern is something that looks like:
```java
interface ErrorHandler {
    default void onError(Throwable throwable) {}
}
```