### PR TITLE
Finalize java-versions extension values on read

### DIFF
--- a/changelog/@unreleased/pr-2107.v2.yml
+++ b/changelog/@unreleased/pr-2107.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Finalize java-versions extension values on read to prevent changes
+    due to interactions from other plugins
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2107

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionExtension.java
@@ -36,6 +36,9 @@ public class BaselineJavaVersionExtension {
         target = project.getObjects().property(JavaLanguageVersion.class);
         runtime = project.getObjects().property(JavaLanguageVersion.class);
         overrideLibraryAutoDetection = project.getObjects().property(Boolean.class);
+        target.finalizeValueOnRead();
+        runtime.finalizeValueOnRead();
+        overrideLibraryAutoDetection.finalizeValueOnRead();
     }
 
     /** Target {@link JavaLanguageVersion} for compilation. */

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineJavaVersionsExtension.java
@@ -40,6 +40,9 @@ public class BaselineJavaVersionsExtension {
         distributionTarget.convention(libraryTarget);
         // runtime defaults to the distribution value
         runtime.convention(distributionTarget);
+        libraryTarget.finalizeValueOnRead();
+        distributionTarget.finalizeValueOnRead();
+        runtime.finalizeValueOnRead();
     }
 
     /** Target {@link JavaLanguageVersion} for compilation of libraries that are published. */


### PR DESCRIPTION
==COMMIT_MSG==
Finalize java-versions extension values on read to prevent changes due to interactions from other plugins
==COMMIT_MSG==

