### PR TITLE
Prevent instance methods of auth tokens from getting called in logging args

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreventTokenLoggingTests.java
@@ -260,18 +260,38 @@ public class PreventTokenLoggingTests {
     }
 
     @Test
+    public void testSafeArgAuthHeaderToString() {
+        failLogSafe("SafeArg.of(name, authHeader.toString());");
+    }
+
+    @Test
     public void testUnsafeArgAuthHeader() {
-        failLogSafe("UnsafeArg.of(name, bearerToken);");
+        failLogSafe("UnsafeArg.of(name, authHeader);");
+    }
+
+    @Test
+    public void testUnsafeArgAuthHeaderToString() {
+        failLogSafe("UnsafeArg.of(name, authHeader.toString());");
     }
 
     @Test
     public void testSafeArgBearerToken() {
-        failLogSafe("SafeArg.of(name, authHeader);");
+        failLogSafe("SafeArg.of(name, bearerToken);");
+    }
+
+    @Test
+    public void testSafeArgBearerTokenToString() {
+        failLogSafe("SafeArg.of(name, bearerToken.toString());");
     }
 
     @Test
     public void testUnsafeArgBearerToken() {
         failLogSafe("UnsafeArg.of(name, bearerToken);");
+    }
+
+    @Test
+    public void testUnsafeArgBearerTokenToString() {
+        failLogSafe("UnsafeArg.of(name, bearerToken.toString());");
     }
 
     @Test

--- a/changelog/@unreleased/pr-2113.v2.yml
+++ b/changelog/@unreleased/pr-2113.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Prevent instance methods of auth tokens from getting called in logging args
+  links:
+    - https://github.com/palantir/gradle-baseline/pull/2113

--- a/changelog/@unreleased/pr-2113.v2.yml
+++ b/changelog/@unreleased/pr-2113.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
-  description: Prevent instance methods of auth tokens from getting called in logging args
+  description: Prevent instance methods of auth tokens from getting called in logging
+    args
   links:
-    - https://github.com/palantir/gradle-baseline/pull/2113
+  - https://github.com/palantir/gradle-baseline/pull/2113


### PR DESCRIPTION
## Before this PR

Something like this would not get flagged by the existing error-prone check:

```java
void myMethod(AuthHeader header) {
    log.info("msg", SafeArg.of("h", header.toString()));
}
``` 

## After this PR

Instead of just checking that the type of the safe arg parameter is not an auth token, we can also verify that it is not the invocation of a method of an auth token.

Note that this only catches simple cases and can't handle indirections, e.g. `header.toString()` being called elsewhere and passed down to the arg. 

==COMMIT_MSG==
Prevent instance methods of auth tokens from getting called in logging args
==COMMIT_MSG==
