### PR TITLE
RawTypes no longer flags implicit raw types from lambdas

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RawTypesTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RawTypesTest.java
@@ -305,6 +305,21 @@ class RawTypesTest {
                 .doTest();
     }
 
+    @Test
+    void testNegativeImplicitRawTypes() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.*;",
+                        "import java.util.function.*;",
+                        "import com.codahale.metrics.*;",
+                        "class Test {",
+                        "  void func(Metric metric) {",
+                        "    assertThat(metric).isInstanceOfSatisfying(Gauge.class, value -> {});",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(RawTypes.class, getClass());
     }

--- a/changelog/@unreleased/pr-2119.v2.yml
+++ b/changelog/@unreleased/pr-2119.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: RawTypes no longer flags implicit raw types from lambdas
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2119


### PR DESCRIPTION
See the confusing failures with no source location on
https://github.com/palantir/tritium/pull/1392 due to
assertions on Gauge values.

==COMMIT_MSG==
RawTypes no longer flags implicit raw types from lambdas
==COMMIT_MSG==

