### PR TITLE
improvement: suggested fixes for IllegalSafeLoggingArgument check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -40,8 +40,6 @@ import java.util.List;
  * Ensures that safe-logging annotated elements are handled correctly by annotated method parameters.
  * Potential future work:
  * <ul>
- *     <li>Suggest replacing {@code UnsafeArg.of(name, verifiableSafeValue)} with
- *     {@code SafeArg.of(name, verifiableSafeValue)}</li>
  *     <li>We could check return statements in methods annotated for
  *     safety to require consistency</li>
  *     <li>Enforce propagation of safety annotations from fields and types to types which encapsulate them.</li>

--- a/changelog/@unreleased/pr-2133.v2.yml
+++ b/changelog/@unreleased/pr-2133.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: suggested fixes for IllegalSafeLoggingArgument check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2133

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -42,6 +42,7 @@ public class BaselineErrorProneExtension {
             "ExecutorSubmitRunnableFutureIgnored",
             "ExtendsErrorOrThrowable",
             "FinalClass",
+            "IllegalSafeLoggingArgument",
             "ImmutablesStyle",
             "ImplicitPublicBuilderConstructor",
             "JavaTimeDefaultTimeZone",


### PR DESCRIPTION
Follow-up to #2127.
In cases where validation would fail specifically due to calls to `SafeArg#of` where the argument was marked as `Unsafe`, suggest using `UnsafeArg#of` instead

==COMMIT_MSG==
suggested fixes for IllegalSafeLoggingArgument check
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

