### PR TITLE
Compilation supports add-exports/add-opens with toolchains

### DIFF
--- a/changelog/@unreleased/pr-2136.v2.yml
+++ b/changelog/@unreleased/pr-2136.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Compilation supports add-exports/add-opens with toolchains
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2136

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaVersion.java
@@ -23,6 +23,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -93,6 +94,15 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                         javaToolchainSpec.getLanguageVersion().set(targetVersionProvider);
                     }
                 }));
+                // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
+                javaCompile.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        ((JavaCompile) task)
+                                .setSourceCompatibility(
+                                        targetVersionProvider.get().toString());
+                    }
+                });
             }
         });
 
@@ -117,6 +127,15 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                         javaToolchainSpec.getLanguageVersion().set(targetVersionProvider);
                     }
                 }));
+                // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
+                groovyCompile.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        ((GroovyCompile) task)
+                                .setSourceCompatibility(
+                                        targetVersionProvider.get().toString());
+                    }
+                });
             }
         });
 
@@ -129,6 +148,15 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                         javaToolchainSpec.getLanguageVersion().set(targetVersionProvider);
                     }
                 }));
+                // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
+                scalaCompile.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        ((ScalaCompile) task)
+                                .setSourceCompatibility(
+                                        targetVersionProvider.get().toString());
+                    }
+                });
             }
         });
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -68,32 +68,31 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
 
             // javac isn't provided `--add-exports` args for the time being due to
             // https://github.com/gradle/gradle/issues/18824
-            if (project.hasProperty("add.exports.to.javac")) {
-                project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
-                    JavaCompile javaCompile = project.getTasks()
-                            .named(sourceSet.getCompileJavaTaskName(), JavaCompile.class)
-                            .get();
-                    javaCompile
-                            .getOptions()
-                            .getCompilerArgumentProviders()
-                            // Use an anonymous class because tasks with lambda inputs cannot be cached
-                            .add(new CommandLineArgumentProvider() {
-                                @Override
-                                public Iterable<String> asArguments() {
-                                    // Annotation processors are executed at compile time
-                                    ImmutableList<String> arguments =
-                                            collectAnnotationProcessorArgs(project, extension, sourceSet);
-                                    project.getLogger()
-                                            .debug(
-                                                    "BaselineModuleJvmArgs compiling {} on {} with exports: {}",
-                                                    javaCompile.getName(),
-                                                    project,
-                                                    arguments);
-                                    return arguments;
-                                }
-                            });
-                });
-            }
+            // However, we set sourceCompatibility in BaselineJavaVersion to opt out of the '-release' flag.
+            project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
+                JavaCompile javaCompile = project.getTasks()
+                        .named(sourceSet.getCompileJavaTaskName(), JavaCompile.class)
+                        .get();
+                javaCompile
+                        .getOptions()
+                        .getCompilerArgumentProviders()
+                        // Use an anonymous class because tasks with lambda inputs cannot be cached
+                        .add(new CommandLineArgumentProvider() {
+                            @Override
+                            public Iterable<String> asArguments() {
+                                // Annotation processors are executed at compile time
+                                ImmutableList<String> arguments =
+                                        collectAnnotationProcessorArgs(project, extension, sourceSet);
+                                project.getLogger()
+                                        .debug(
+                                                "BaselineModuleJvmArgs compiling {} on {} with exports: {}",
+                                                javaCompile.getName(),
+                                                project,
+                                                arguments);
+                                return arguments;
+                            }
+                        });
+            });
 
             project.getTasks().withType(Test.class, new Action<Test>() {
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
@@ -52,6 +52,29 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         buildFile << standardBuildFile
     }
 
+    def 'Compiles with locally defined exports'() {
+        when:
+        buildFile << '''
+        application {
+            mainClass = 'com.Example'
+        }
+        moduleJvmArgs {
+           exports = ['jdk.compiler/com.sun.tools.javac.code']
+        }
+        '''.stripIndent(true)
+        writeJavaSourceFile('''
+        package com;
+        public class Example {
+            public static void main(String[] args) {
+                com.sun.tools.javac.code.Symbol.class.toString();
+            }
+        }
+        '''.stripIndent(true))
+
+        then:
+        runTasksSuccessfully('compileJava')
+    }
+
     def 'Runs with locally defined exports'() {
         when:
         buildFile << '''


### PR DESCRIPTION
Using workaround suggested by:
https://github.com/gradle/gradle/issues/18824#issuecomment-1026909824

==COMMIT_MSG==
Compilation supports add-exports/add-opens with toolchains
==COMMIT_MSG==