### PR TITLE
Fix BaselineModuleJvmArgs without toolchains

### DIFF
--- a/changelog/@unreleased/pr-2148.v2.yml
+++ b/changelog/@unreleased/pr-2148.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix BaselineModuleJvmArgs without toolchains
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2148


### PR DESCRIPTION
Otherwise the plugin interacts poorly with
`BaselineReleaseCompatibility` because `--release` and internal
module exports/opens cannot be used at the same time.

==COMMIT_MSG==
Fix BaselineModuleJvmArgs without toolchains
==COMMIT_MSG==

