### PR TITLE
Array assignment merges safety rather than replacing it

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -530,7 +530,9 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
         if (target instanceof LocalVariableNode) {
             updates.trySet(target, safety);
         } else if (target instanceof ArrayAccessNode) {
-            updates.trySet(((ArrayAccessNode) target).getArray(), safety);
+            Node arrayNode = ((ArrayAccessNode) target).getArray();
+            Safety arrayCombinedSafety = input.getValueOfSubNode(arrayNode).leastUpperBound(safety);
+            updates.trySet(arrayNode, arrayCombinedSafety);
         } else if (target instanceof FieldAccessNode) {
             FieldAccessNode fieldAccess = (FieldAccessNode) target;
             updates.set(fieldAccess, safety);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -710,6 +710,10 @@ class IllegalSafeLoggingArgumentTest {
                         "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG' "
                                 + "but the parameter requires 'SAFE'.",
                         "    fun(one);",
+                        "    one[2] = safeParam;",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG' "
+                                + "but the parameter requires 'SAFE'.",
+                        "    fun(one);",
                         "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG' "
                                 + "but the parameter requires 'SAFE'.",
                         "    fun(new Object[] {safeParam, unsafeParam, dnlParam});",

--- a/changelog/@unreleased/pr-2154.v2.yml
+++ b/changelog/@unreleased/pr-2154.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Array assignment merges safety rather than replacing it
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2154


### PR DESCRIPTION
==COMMIT_MSG==
Array assignment merges safety rather than replacing it
==COMMIT_MSG==

