### PR TITLE
Fix SerializationUtils matcher

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousJavaDeserialization.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousJavaDeserialization.java
@@ -52,8 +52,8 @@ public final class DangerousJavaDeserialization extends BugChecker implements Bu
                     .withNoParameters(),
             Matchers.not(Matchers.enclosingMethod(READ_OBJECT)));
 
-    private static final Matcher<ExpressionTree> LANG3_SERIALIZATION_UTILS_DESERIALIZE = MethodMatchers.instanceMethod()
-            .onExactClassAny(
+    private static final Matcher<ExpressionTree> LANG3_SERIALIZATION_UTILS_DESERIALIZE = MethodMatchers.staticMethod()
+            .onClassAny(
                     "org.apache.commons.lang.SerializationUtils",
                     "org.apache.commons.lang3.SerializationUtils",
                     "org.springframework.util.SerializationUtils")

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousJavaDeserializationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousJavaDeserializationTest.java
@@ -51,4 +51,32 @@ class DangerousJavaDeserializationTest {
                         "}")
                 .doTest();
     }
+
+    @Test
+    void testCommonsLang() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.apache.commons.lang.SerializationUtils;",
+                        "class Test {",
+                        "   void f(byte[] data) {",
+                        "       // BUG: Diagnostic contains: serialization features for security reasons",
+                        "       SerializationUtils.deserialize(data);",
+                        "   }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testCommonsLang3() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.apache.commons.lang3.SerializationUtils;",
+                        "class Test {",
+                        "   void f(byte[] data) {",
+                        "       // BUG: Diagnostic contains: serialization features for security reasons",
+                        "       SerializationUtils.deserialize(data);",
+                        "   }",
+                        "}")
+                .doTest();
+    }
 }

--- a/changelog/@unreleased/pr-2164.v2.yml
+++ b/changelog/@unreleased/pr-2164.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix `SerializationUtils` matcher
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2164


### PR DESCRIPTION
previously looked for instance methods rather than static
methods.

==COMMIT_MSG==
Fix `SerializationUtils` matcher
==COMMIT_MSG==

