### PR TITLE
Fix junit-reports in CircleCI

### DIFF
--- a/changelog/@unreleased/pr-2189.v2.yml
+++ b/changelog/@unreleased/pr-2189.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix the `com.palantir.baseline-circleci` plugin so that compilation
+    failures are once again parsed as XML and can be surfaced at the top of CircleCI
+    builds.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2189

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
@@ -19,6 +19,7 @@ package com.palantir.baseline.plugins;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.palantir.gradle.junit.JunitReportsExtension;
+import com.palantir.gradle.junit.JunitReportsPlugin;
 import com.palantir.gradle.junit.JunitReportsRootPlugin;
 import java.io.File;
 import java.io.IOException;
@@ -40,6 +41,7 @@ public final class BaselineCircleCi implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(JunitReportsRootPlugin.class);
+        project.getPluginManager().apply(JunitReportsPlugin.class);
 
         configurePluginsForReports(project);
         configurePluginsForArtifacts(project);


### PR DESCRIPTION
## Before this PR

There's a thread in #dev-foundry-infra where Alexis flagged that it's a little inconvenient to see what the compile failures are in CircleCI.

I thought we were hoisting this information to the top of the build by parsing the junit xml, but empirically it has not been working on the Apollo codebase.


In fact, I found this refactor from May 2021 (so almost exactly a year ago) which introduced a brand new `JunitReportsRootPlugin` in addition to the existing `JunitReportsPlugin`.

We used to be applying the `JunitReportsPlugin` automatically but this was changed (I assume unintentionally) here:

https://github.com/palantir/gradle-baseline/pull/1764/files#diff-1ac4be5b278bc51e4c5bdc114f5bc34d9edbe25c509c2af49cdb6d64a2cd5fe0L42

## After this PR
==COMMIT_MSG==
Fix the `com.palantir.baseline-circleci` plugin so that compilation failures are once again parsed as XML and can be surfaced at the top of CircleCI builds.
==COMMIT_MSG==

## Possible downsides?

- I have added no tests here, so it might regress

