### PR TITLE
Fix index-out-of-bounds analyzing type parameters on raw types

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -88,10 +88,14 @@ public final class IllegalSafeLoggingArgument extends BugChecker
             // List<String> -> Collection<E> gives us Collection<String>
             Type boundToMethodOwner = state.getTypes().asSuper(receiver, methodSymbol.owner);
             List<TypeVariableSymbol> ownerTypeVars = methodSymbol.owner.getTypeParameters();
-            for (int i = 0; i < ownerTypeVars.size(); i++) {
-                TypeVariableSymbol ownerVar = ownerTypeVars.get(i);
-                if (Objects.equals(ownerVar, typeVar.tsym)) {
-                    return boundToMethodOwner.getTypeArguments().get(i);
+            // Validate that the type parameters match -- it's possible raw types are used, and
+            // no type variables are bound. See IllegalSafeLoggingArgumentTest.testRawTypes.
+            if (ownerTypeVars.size() == boundToMethodOwner.getTypeArguments().size()) {
+                for (int i = 0; i < ownerTypeVars.size(); i++) {
+                    TypeVariableSymbol ownerVar = ownerTypeVars.get(i);
+                    if (Objects.equals(ownerVar, typeVar.tsym)) {
+                        return boundToMethodOwner.getTypeArguments().get(i);
+                    }
                 }
             }
         }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1173,6 +1173,23 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testRawTypes() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.function.*;",
+                        "@SuppressWarnings(\"rawtypes\")",
+                        "interface Test<T extends CharSequence> {",
+                        "  Iface iface();",
+                        "  default void f(@Unsafe String value) {",
+                        "    iface().accept(value);",
+                        "  }",
+                        "  interface Iface<T> extends Consumer<T> {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testSafeArgOfUnsafe_recommendsUnsafeArgOf() {
         refactoringHelper()
                 .addInputLines(

--- a/changelog/@unreleased/pr-2197.v2.yml
+++ b/changelog/@unreleased/pr-2197.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix index-out-of-bounds analyzing type parameters on raw types
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2197


### PR DESCRIPTION
==COMMIT_MSG==
Fix index-out-of-bounds analyzing type parameters on raw types
==COMMIT_MSG==

