### PR TITLE
Automatically fix upstream `LongDoubleConversion`

### DIFF
--- a/changelog/@unreleased/pr-2199.v2.yml
+++ b/changelog/@unreleased/pr-2199.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Automatically fix upstream [LongDoubleConversion](https://errorprone.info/bugpattern/LongDoubleConversion)
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2199
+  - https://errorprone.info/bugpattern/LongDoubleConversion

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -84,6 +84,7 @@ public class BaselineErrorProneExtension {
             // Built-in checks
             "ArrayEquals",
             "BadImport",
+            "LongDoubleConversion",
             "LoopOverCharArray",
             "MissingBraces",
             "MissingOverride",


### PR DESCRIPTION
The fix is safe, and makes the code more obvious:
```diff
- double value = System.currentTimeMillis();
+ double value = (double) System.currentTimeMillis();
```

==COMMIT_MSG==
Automatically fix upstream `LongDoubleConversion`
==COMMIT_MSG==