### PR TITLE
Add check for Immutables reference equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `OptionalFlatMapOfNullable`: Optional.map functions may return null to safely produce an empty result.
 - `ExtendsErrorOrThrowable`: Avoid extending Error (or subclasses of it) or Throwable directly.
 - `ImmutablesStyle`: Disallow the use of inline immutables style annotations to avoid forcing compile dependencies on consumers.
+- `ImmutablesReferenceEquality`: Comparison of Immutables value using reference equality instead of value equality.
 - `TooManyArguments`: Prefer Interface that take few arguments rather than many.
 - `ObjectsHashCodeUnnecessaryVarargs`: java.util.Objects.hash(non-varargs) should be replaced with java.util.Objects.hashCode(value) to avoid unnecessary varargs array allocations.
 - `PreferStaticLoggers`: Prefer static loggers over instance loggers.

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesReferenceEquality.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesReferenceEquality.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.LinkType;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.AbstractReferenceEquality;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Type;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        linkType = LinkType.CUSTOM,
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        severity = SeverityLevel.WARNING,
+        summary = "Comparison of Immutables value using reference equality instead of value equality.")
+public final class ImmutablesReferenceEquality extends AbstractReferenceEquality {
+
+    @Override
+    protected boolean matchArgument(ExpressionTree tree, VisitorState state) {
+        Type type = ASTHelpers.getType(tree);
+        if (!(type.tsym instanceof ClassSymbol)) {
+            return false;
+        }
+
+        ClassSymbol symbol = (ClassSymbol) type.tsym;
+
+        return ASTHelpers.hasAnnotation(symbol, "org.immutables.value.Value.Immutable", state);
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesReferenceEquality.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesReferenceEquality.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import com.sun.tools.javac.code.Type;
 @BugPattern(
         linkType = LinkType.CUSTOM,
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
-        severity = SeverityLevel.WARNING,
+        severity = SeverityLevel.ERROR,
         summary = "Comparison of Immutables value using reference equality instead of value equality.")
 public final class ImmutablesReferenceEquality extends AbstractReferenceEquality {
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesReferenceEqualityTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesReferenceEqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesReferenceEqualityTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesReferenceEqualityTest.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+public class ImmutablesReferenceEqualityTest {
+
+    @Test
+    public void test() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.immutables.value.Value;",
+                        "class Test {",
+                        "  static boolean f(Foo foo1, Foo foo2) {",
+                        "    // BUG: Diagnostic contains: foo1.equals(foo2)",
+                        "    return foo1 == foo2;",
+                        "  }",
+                        "  @Value.Immutable",
+                        "  interface Foo {}",
+                        "}")
+                .doTest();
+    }
+
+    private CompilationTestHelper helper() {
+        return CompilationTestHelper.newInstance(ImmutablesReferenceEquality.class, getClass());
+    }
+}

--- a/changelog/@unreleased/pr-2210.v2.yml
+++ b/changelog/@unreleased/pr-2210.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add `ImmutablesReferenceEquality` check that checks for comparison
+    of Immutables values using reference equality.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2210


### PR DESCRIPTION
The `ReferenceEquality` check does not apply when using an Immutables definition because the definition does not [implement equals](https://github.com/google/error-prone/blob/f174a804a74b7ef413f946cd44977ad3059c2eee/core/src/main/java/com/google/errorprone/bugpatterns/ReferenceEquality.java#L68-L70).

