### PR TITLE
Rename LogsafeArgument to LogsafeThrowableArgument

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeThrowableArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LogsafeThrowableArgument.java
@@ -35,7 +35,7 @@ import java.util.List;
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.WARNING,
         summary = "Args with type Throwable are not allowed.")
-public final class LogsafeArgument extends BugChecker implements MethodInvocationTreeMatcher {
+public final class LogsafeThrowableArgument extends BugChecker implements MethodInvocationTreeMatcher {
 
     private static final Matcher<ExpressionTree> MATCHER = Matchers.staticMethod()
             .onClassAny("com.palantir.logsafe.SafeArg", "com.palantir.logsafe.UnsafeArg")

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeThrowableArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/LogsafeThrowableArgumentTest.java
@@ -19,7 +19,7 @@ package com.palantir.baseline.errorprone;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
 
-class LogsafeArgumentTest {
+class LogsafeThrowableArgumentTest {
 
     @Test
     void testNormalUsage() {
@@ -66,6 +66,6 @@ class LogsafeArgumentTest {
     }
 
     private CompilationTestHelper helper() {
-        return CompilationTestHelper.newInstance(LogsafeArgument.class, getClass());
+        return CompilationTestHelper.newInstance(LogsafeThrowableArgument.class, getClass());
     }
 }

--- a/changelog/@unreleased/pr-2216.v2.yml
+++ b/changelog/@unreleased/pr-2216.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Rename LogsafeArgument to LogsafeThrowableArgument
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2216


### PR DESCRIPTION
## Before this PR
`LogsafeArgument` failure name is not obvious.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Rename LogsafeArgument to LogsafeThrowableArgument
==COMMIT_MSG==

