### PR TITLE
Streamline Throwable safety handling

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -25,14 +25,12 @@ import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.util.ASTHelpers;
 import com.palantir.baseline.errorprone.safety.Safety;
 import com.palantir.baseline.errorprone.safety.SafetyAnnotations;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
-import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import javax.lang.model.element.Modifier;
 
 @AutoService(BugChecker.class)
@@ -45,7 +43,6 @@ import javax.lang.model.element.Modifier;
                 + "tooling to work with as much information as possible. This check can be auto-fixed using "
                 + "`./gradlew classes testClasses -PerrorProneApply=SafeLoggingPropagation`")
 public final class SafeLoggingPropagation extends BugChecker implements BugChecker.ClassTreeMatcher {
-
     private static final Matcher<Tree> SAFETY_ANNOTATION_MATCHER = Matchers.anyOf(
             Matchers.isSameType(SafetyAnnotations.SAFE),
             Matchers.isSameType(SafetyAnnotations.UNSAFE),
@@ -58,8 +55,7 @@ public final class SafeLoggingPropagation extends BugChecker implements BugCheck
 
     @Override
     public Description matchClass(ClassTree classTree, VisitorState state) {
-        ClassSymbol classSymbol = ASTHelpers.getSymbol(classTree);
-        Safety existingClassSafety = SafetyAnnotations.getSafety(classSymbol, state);
+        Safety existingClassSafety = SafetyAnnotations.getSafety(classTree, state);
         Safety safety = SafetyAnnotations.getSafety(classTree.getExtendsClause(), state);
         for (Tree implemented : classTree.getImplementsClause()) {
             safety = safety.leastUpperBound(SafetyAnnotations.getSafety(implemented, state));

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
@@ -45,6 +45,9 @@ public final class SafetyAnnotations {
     public static final String UNSAFE = "com.palantir.logsafe.Unsafe";
     public static final String DO_NOT_LOG = "com.palantir.logsafe.DoNotLog";
 
+    private static final com.google.errorprone.suppliers.Supplier<Type> throwableSupplier =
+            Suppliers.typeFromClass(Throwable.class);
+
     private static final TypeArgumentHandlers SAFETY_IS_COMBINATION_OF_TYPE_ARGUMENTS = new TypeArgumentHandlers(
             new TypeArgumentHandler(Iterable.class),
             new TypeArgumentHandler(Iterator.class),
@@ -115,7 +118,10 @@ public final class SafetyAnnotations {
                 return Safety.SAFE;
             }
         }
-        return SAFETY_IS_COMBINATION_OF_TYPE_ARGUMENTS.getSafety(type, state, dejaVu);
+        Safety typeArgumentCombination = SAFETY_IS_COMBINATION_OF_TYPE_ARGUMENTS.getSafety(type, state, dejaVu);
+        return ASTHelpers.isSubtype(type, throwableSupplier.get(state), state)
+                ? Safety.UNSAFE.leastUpperBound(typeArgumentCombination)
+                : typeArgumentCombination;
     }
 
     private static final class TypeArgumentHandlers {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -819,6 +819,65 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testThrowableParameterIsUnsafe() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  void f(IllegalStateException e) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE' "
+                                + "but the parameter requires 'SAFE'.",
+                        "    fun(e);",
+                        "  }",
+                        "  private static void fun(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testThrowableStackTraceAsStringIsUnsafe() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.google.common.base.Throwables;",
+                        "class Test {",
+                        "  void f(IllegalStateException e) {",
+                        "    String strVal = Throwables.getStackTraceAsString(e);",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE' "
+                                + "but the parameter requires 'SAFE'.",
+                        "    fun(strVal);",
+                        "  }",
+                        "  private static void fun(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testCatchDoNotLog() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.google.common.base.Throwables;",
+                        "class Test {",
+                        "  void f() {",
+                        "    try {",
+                        "      action();",
+                        "    } catch (@DoNotLog RuntimeException e) {",
+                        "      // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG' "
+                                + "but the parameter requires 'UNSAFE'.",
+                        "      fun(e);",
+                        "      // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG' "
+                                + "but the parameter requires 'UNSAFE'.",
+                        "      fun(e.getMessage());",
+                        "    }",
+                        "  }",
+                        "  protected void action() {}",
+                        "  private static void fun(@Unsafe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testStringFormat() {
         helper().addSourceLines(
                         "Test.java",

--- a/changelog/@unreleased/pr-2224.v2.yml
+++ b/changelog/@unreleased/pr-2224.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Streamline Throwable safety handling
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2224


### PR DESCRIPTION
Throwable are considered unsafe, and getMessage returns the
safety of the throwable itself. This allows us to annotate
a catch block as `@DoNotLog` in cases that an exception
may contain credential information.

This change also includes the guava
`Throwables.getStackTraceAsString` utility as a safety-passthrough
method.

==COMMIT_MSG==
Streamline Throwable safety handling
==COMMIT_MSG==
