### PR TITLE
Disable intellij's ClassCanBeRecord inspection

### DIFF
--- a/changelog/@unreleased/pr-2225.v2.yml
+++ b/changelog/@unreleased/pr-2225.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable intellij's ClassCanBeRecord inspection
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2225

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -445,6 +445,8 @@ class BaselineIdea extends AbstractBaselinePlugin {
                     </inspection_tool>
                         
                     <inspection_tool class="PlaceholderCountMatchesArgumentCount" enabled="false" level="WARNING" enabled_by_default="false" />
+                    
+                    <inspection_tool class="ClassCanBeRecord" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
 
                     <inspection_tool class="UnstableApiUsage" enabled="true" level="WARNING" enabled_by_default="true">
                         <option name="unstableApiAnnotations">


### PR DESCRIPTION
## Before this PR

When using JDK 17+, Intellij's `ClassCanBeRecord` inspection gets suggested for all classes with only `final` fields that get set through the constructor. However in many cases, this is not desired as this weakens the visibility of the fields by adding public getters. I would argue that for all classes that use dependency injection, this is not desired.

Example class which gets flagged:

```java
class MyResource {
  private final Store store;
  private final OtherService otherService;

  MyResource(Store store, OtherService otherService) {
    this.store = store;
    this.otherService = otherService
  }
}
```

Given that this gets flagged in Intellij as a warning with the default action to automatically convert the class, I think its best to disable this inspection.

## After this PR
==COMMIT_MSG==
Disable intellij's ClassCanBeRecord inspection
==COMMIT_MSG==

## Possible downsides?
In some cases it might be desirable (e.g. data classes). But maybe we should handle this using an explicit error-prone check?