### PR TITLE
Propagate additional safety information

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -45,6 +45,7 @@ import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.util.Name;
 import java.util.List;
 import javax.lang.model.element.Modifier;
 import org.checkerframework.errorprone.javacutil.TreePathUtil;
@@ -70,6 +71,9 @@ public final class SafeLoggingPropagation extends BugChecker
             Matchers.not(Matchers.anyOf(Matchers.hasModifier(Modifier.STATIC), Matchers.methodIsConstructor()));
     private static final Matcher<MethodTree> GETTER_METHOD_MATCHER =
             Matchers.allOf(NON_STATIC_NON_CTOR, Matchers.not(METHOD_RETURNS_VOID), Matchers.methodHasNoParameters());
+
+    private static final com.google.errorprone.suppliers.Supplier<Name> TO_STRING_NAME =
+            VisitorState.memoize(state -> state.getName("toString"));
 
     @Override
     public Description matchClass(ClassTree classTree, VisitorState state) {
@@ -140,7 +144,7 @@ public final class SafeLoggingPropagation extends BugChecker
 
     private Description matchBasedOnToString(ClassTree classTree, ClassSymbol classSymbol, VisitorState state) {
         MethodSymbol toStringSymbol = ASTHelpers.resolveExistingMethod(
-                state, classSymbol, state.getName("toString"), ImmutableList.of(), ImmutableList.of());
+                state, classSymbol, TO_STRING_NAME.get(state), ImmutableList.of(), ImmutableList.of());
         if (toStringSymbol == null) {
             return Description.NO_MATCH;
         }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -224,6 +224,9 @@ public final class SafeLoggingPropagation extends BugChecker
             return Description.NO_MATCH;
         }
         Safety combinedReturnSafety = method.accept(new ReturnStatementSafetyScanner(method), state);
+        if (combinedReturnSafety == null) {
+            return Description.NO_MATCH;
+        }
         return handleSafety(method, method.getModifiers(), state, methodDeclaredSafety, combinedReturnSafety);
     }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -196,6 +196,20 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
+    void testMethodDoesNotReturn() {
+        // Ensure we don't fail when no return statement safety info is collected
+        fix().addInputLines(
+                        "Test.java",
+                        "abstract class Test {",
+                        "  @Override public String toString() {",
+                        "    throw new RuntimeException();",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
     void testRecordWithUnsafeTypes() {
         fix("--release", "15", "--enable-preview")
                 .addInputLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -143,6 +143,59 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
+    void testPropagationBasedOnToString() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "abstract class Test {",
+                        "  @DoNotLog",
+                        "  abstract String token();",
+                        "  @Override @DoNotLog public String toString() {",
+                        "    return \"Test\" + token();",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "@DoNotLog",
+                        "abstract class Test {",
+                        "  @DoNotLog",
+                        "  abstract String token();",
+                        "  @Override @DoNotLog public String toString() {",
+                        "    return \"Test\" + token();",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testPropagationReplacementBasedOnToString() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "@Unsafe",
+                        "abstract class Test {",
+                        "  @DoNotLog",
+                        "  abstract String token();",
+                        "  @Override @DoNotLog public String toString() {",
+                        "    return \"Test\" + token();",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "@DoNotLog",
+                        "abstract class Test {",
+                        "  @DoNotLog",
+                        "  abstract String token();",
+                        "  @Override @DoNotLog public String toString() {",
+                        "    return \"Test\" + token();",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testRecordWithUnsafeTypes() {
         fix("--release", "15", "--enable-preview")
                 .addInputLines(

--- a/changelog/@unreleased/pr-2230.v2.yml
+++ b/changelog/@unreleased/pr-2230.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Propagate additional safety information in the `SafeLoggingPropagation` check and automated fixes:
+    1. Method return statements are analyzed to determine safety of unmarked methods
+    2. Types are annotated based on the safety of their `toString` method, which is a reasonable heuristic for value types that may be logged.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2230


### PR DESCRIPTION
==COMMIT_MSG==
Propagate additional safety information in the `SafeLoggingPropagation` check and automated fixes:
1. Method return statements are analyzed to determine safety of unmarked methods
2. Types are annotated based on the safety of their `toString` method, which is a reasonable heuristic for value types that may be logged.
==COMMIT_MSG==

These two checks work together nicely when types define a `toString`: the inputs to the toString (assuming string concatenation, we haven't implemented anything special for StringBuilder accumulation) are combined into an annotation on the toString method, which is applied at the type level in the next run.

## Possible downsides?
This may result in a lot of annotations.
Our automation can restrict safety, but i never eases safety -- we can mark a method `@Unsafe` or `@DoNotLog`, but never `@Safe`.