### PR TITLE
Fix intellij gradle integration copyright configuration

### DIFF
--- a/changelog/@unreleased/pr-2234.v2.yml
+++ b/changelog/@unreleased/pr-2234.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix intellij gradle integration copyright configuration
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2234

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -319,7 +319,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
     }
 
     private static void createOrUpdateCopyrightFile(Node node, File file, String fileName) {
-        def copyrightText = XmlUtil.escapeControlCharacters(XmlUtil.escapeXml(file.text.trim()))
+        def copyrightText = file.text.trim()
         // Ensure that subsequent runs don't produce duplicate entries
         Node copyrightNode = GroovyXmlUtils.matchOrCreateChild(node, "copyright")
         Node noticeNode = GroovyXmlUtils.matchOrCreateChild(copyrightNode, "option", ["name": "notice"])

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -116,6 +116,8 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
 
         def apacheCopyright = new File(copyrightDir, "001_apache-2.0.xml").text
         apacheCopyright.contains('<option name="myName" value="001_apache-2.0.txt"/>')
+        // Ensure correct xml encoding (not double-encoded)
+        apacheCopyright.contains('Apache License, Version 2.0 (the &quot;License&quot;)')
 
         def palantirCopyright = new File(copyrightDir, "999_palantir.xml").text
         palantirCopyright.contains('<option name="myName" value="999_palantir.txt"/>')


### PR DESCRIPTION
previously the value was double-escaped, resulting in a
single-line garbled copyright on new files.

==COMMIT_MSG==
Fix intellij gradle integration copyright configuration
==COMMIT_MSG==

