### PR TITLE
Safety propagation ignores immutables helpers

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -78,6 +78,7 @@ public final class SafeLoggingPropagation extends BugChecker
             Matchers.hasModifier(Modifier.ABSTRACT),
             Matchers.symbolHasAnnotation("org.immutables.value.Value.Default"),
             Matchers.symbolHasAnnotation("org.immutables.value.Value.Derived"),
+            Matchers.symbolHasAnnotation("org.immutables.value.Value.Lazy"),
             Matchers.allOf(Matchers.hasModifier(Modifier.DEFAULT), Matchers.enclosingClass((Matcher<ClassTree>)
                     (classTree, state) -> {
                         ClassSymbol classSymbol = ASTHelpers.getSymbol(classTree);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -44,6 +44,7 @@ import com.sun.source.util.TreePath;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
@@ -70,10 +71,8 @@ public final class SafeLoggingPropagation extends BugChecker
             Matchers.isSameType(SafetyAnnotations.DO_NOT_LOG));
 
     private static final Matcher<MethodTree> METHOD_RETURNS_VOID = Matchers.methodReturns(Matchers.isVoidType());
-    private static final Matcher<MethodTree> NON_PRIVATE_NON_STATIC_NON_CTOR = Matchers.not(Matchers.anyOf(
-            Matchers.hasModifier(Modifier.PRIVATE),
-            Matchers.hasModifier(Modifier.STATIC),
-            Matchers.methodIsConstructor()));
+    private static final Matcher<MethodTree> NON_PRIVATE_NON_STATIC_NON_CTOR =
+            Matchers.not(Matchers.anyOf(Matchers.hasModifier(Modifier.STATIC), Matchers.methodIsConstructor()));
 
     private static final Matcher<MethodTree> IS_IMMUTABLES_FIELD = Matchers.anyOf(
             Matchers.hasModifier(Modifier.ABSTRACT),
@@ -83,7 +82,8 @@ public final class SafeLoggingPropagation extends BugChecker
                     (classTree, state) -> {
                         ClassSymbol classSymbol = ASTHelpers.getSymbol(classTree);
                         return classSymbol != null && immutablesDefaultAsDefault(classSymbol, state);
-                    })));
+                    })),
+            (methodTree, state) -> hasJacksonAnnotation(ASTHelpers.getSymbol(methodTree), state));
     private static final Matcher<MethodTree> GETTER_METHOD_MATCHER = Matchers.allOf(
             NON_PRIVATE_NON_STATIC_NON_CTOR,
             Matchers.not(METHOD_RETURNS_VOID),
@@ -96,6 +96,9 @@ public final class SafeLoggingPropagation extends BugChecker
     private static final com.google.errorprone.suppliers.Supplier<Name> IMMUTABLES_STYLE =
             VisitorState.memoize(state -> state.getName("org.immutables.value.Value.Style"));
 
+    private static final com.google.errorprone.suppliers.Supplier<Name> JACKSON_ANNOTATION =
+            VisitorState.memoize(state -> state.getName("com.fasterxml.jackson.annotation.JacksonAnnotation"));
+
     @Override
     public Description matchClass(ClassTree classTree, VisitorState state) {
         ClassSymbol classSymbol = ASTHelpers.getSymbol(classTree);
@@ -107,6 +110,27 @@ public final class SafeLoggingPropagation extends BugChecker
         } else {
             return matchClassOrInterface(classTree, classSymbol, state);
         }
+    }
+
+    /** Matches any jackson annotation based on the meta-annotation {@code @JacksonAnnotation}. */
+    private static boolean hasJacksonAnnotation(Symbol typeSymbol, VisitorState state) {
+        return hasJacksonAnnotation(typeSymbol, state, 1)
+                && !ASTHelpers.hasAnnotation(typeSymbol, "com.fasterxml.jackson.annotation.JsonIgnore", state);
+    }
+
+    private static boolean hasJacksonAnnotation(Symbol typeSymbol, VisitorState state, int nestedDepth) {
+        if (typeSymbol != null) {
+            Name jacksonAnnotationName = JACKSON_ANNOTATION.get(state);
+            for (Attribute.Compound metadata : typeSymbol.getRawAttributes()) {
+                if (jacksonAnnotationName.equals(metadata.type.tsym.getQualifiedName())) {
+                    return true;
+                }
+                if (nestedDepth > 0 && hasJacksonAnnotation(metadata.type.tsym, state, nestedDepth - 1)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static boolean immutablesDefaultAsDefault(TypeSymbol typeSymbol, VisitorState state) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -71,7 +71,7 @@ public final class SafeLoggingPropagation extends BugChecker
             Matchers.isSameType(SafetyAnnotations.DO_NOT_LOG));
 
     private static final Matcher<MethodTree> METHOD_RETURNS_VOID = Matchers.methodReturns(Matchers.isVoidType());
-    private static final Matcher<MethodTree> NON_PRIVATE_NON_STATIC_NON_CTOR =
+    private static final Matcher<MethodTree> NON_STATIC_NON_CTOR =
             Matchers.not(Matchers.anyOf(Matchers.hasModifier(Modifier.STATIC), Matchers.methodIsConstructor()));
 
     private static final Matcher<MethodTree> IS_IMMUTABLES_FIELD = Matchers.anyOf(
@@ -86,7 +86,7 @@ public final class SafeLoggingPropagation extends BugChecker
                     })),
             (methodTree, state) -> hasJacksonAnnotation(ASTHelpers.getSymbol(methodTree), state));
     private static final Matcher<MethodTree> GETTER_METHOD_MATCHER = Matchers.allOf(
-            NON_PRIVATE_NON_STATIC_NON_CTOR,
+            NON_STATIC_NON_CTOR,
             Matchers.not(METHOD_RETURNS_VOID),
             Matchers.methodHasNoParameters(),
             IS_IMMUTABLES_FIELD);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -27,6 +27,7 @@ import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.MoreAnnotations;
 import com.palantir.baseline.errorprone.safety.Safety;
 import com.palantir.baseline.errorprone.safety.SafetyAnalysis;
 import com.palantir.baseline.errorprone.safety.SafetyAnnotations;
@@ -41,9 +42,11 @@ import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.util.Name;
 import java.util.List;
@@ -67,13 +70,31 @@ public final class SafeLoggingPropagation extends BugChecker
             Matchers.isSameType(SafetyAnnotations.DO_NOT_LOG));
 
     private static final Matcher<MethodTree> METHOD_RETURNS_VOID = Matchers.methodReturns(Matchers.isVoidType());
-    private static final Matcher<MethodTree> NON_STATIC_NON_CTOR =
-            Matchers.not(Matchers.anyOf(Matchers.hasModifier(Modifier.STATIC), Matchers.methodIsConstructor()));
-    private static final Matcher<MethodTree> GETTER_METHOD_MATCHER =
-            Matchers.allOf(NON_STATIC_NON_CTOR, Matchers.not(METHOD_RETURNS_VOID), Matchers.methodHasNoParameters());
+    private static final Matcher<MethodTree> NON_PRIVATE_NON_STATIC_NON_CTOR = Matchers.not(Matchers.anyOf(
+            Matchers.hasModifier(Modifier.PRIVATE),
+            Matchers.hasModifier(Modifier.STATIC),
+            Matchers.methodIsConstructor()));
+
+    private static final Matcher<MethodTree> IS_IMMUTABLES_FIELD = Matchers.anyOf(
+            Matchers.hasModifier(Modifier.ABSTRACT),
+            Matchers.symbolHasAnnotation("org.immutables.value.Value.Default"),
+            Matchers.symbolHasAnnotation("org.immutables.value.Value.Derived"),
+            Matchers.allOf(Matchers.hasModifier(Modifier.DEFAULT), Matchers.enclosingClass((Matcher<ClassTree>)
+                    (classTree, state) -> {
+                        ClassSymbol classSymbol = ASTHelpers.getSymbol(classTree);
+                        return classSymbol != null && immutablesDefaultAsDefault(classSymbol, state);
+                    })));
+    private static final Matcher<MethodTree> GETTER_METHOD_MATCHER = Matchers.allOf(
+            NON_PRIVATE_NON_STATIC_NON_CTOR,
+            Matchers.not(METHOD_RETURNS_VOID),
+            Matchers.methodHasNoParameters(),
+            IS_IMMUTABLES_FIELD);
 
     private static final com.google.errorprone.suppliers.Supplier<Name> TO_STRING_NAME =
             VisitorState.memoize(state -> state.getName("toString"));
+
+    private static final com.google.errorprone.suppliers.Supplier<Name> IMMUTABLES_STYLE =
+            VisitorState.memoize(state -> state.getName("org.immutables.value.Value.Style"));
 
     @Override
     public Description matchClass(ClassTree classTree, VisitorState state) {
@@ -86,6 +107,29 @@ public final class SafeLoggingPropagation extends BugChecker
         } else {
             return matchClassOrInterface(classTree, classSymbol, state);
         }
+    }
+
+    private static boolean immutablesDefaultAsDefault(TypeSymbol typeSymbol, VisitorState state) {
+        return immutablesDefaultAsDefault(typeSymbol, state, 1);
+    }
+
+    private static boolean immutablesDefaultAsDefault(TypeSymbol typeSymbol, VisitorState state, int nestedDepth) {
+        Name styleName = IMMUTABLES_STYLE.get(state);
+        for (Attribute.Compound metadata : typeSymbol.getRawAttributes()) {
+            if (styleName.equals(metadata.type.tsym.getQualifiedName())) {
+                return immutablesDefaultAsDefault(metadata);
+            }
+            if (nestedDepth > 0 && immutablesDefaultAsDefault(metadata.type.tsym, state, nestedDepth - 1)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean immutablesDefaultAsDefault(Attribute.Compound styleAnnotation) {
+        return MoreAnnotations.getValue(styleAnnotation, "defaultAsDefault")
+                .map(attr -> (boolean) attr.getValue())
+                .orElse(false);
     }
 
     private static boolean isRecord(ClassSymbol classSymbol) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -272,21 +272,6 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
-    void ignoresDefaultMethod() {
-        fix().addInputLines(
-                        "Test.java",
-                        "import com.palantir.logsafe.*;",
-                        "import org.immutables.value.Value;",
-                        "@Value.Immutable",
-                        "interface Test {",
-                        "  @DoNotLog",
-                        "  default String token() { return \"\"; }",
-                        "}")
-                .expectUnchanged()
-                .doTest();
-    }
-
-    @Test
     void includesDefaultMethodWhenDefaultAsDefault() {
         fix().addInputLines(
                         "Test.java",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -496,7 +496,7 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
-    void testIgnoresJsonIgnoreHelperMethod() throws Exception {
+    void testIgnoresJsonIgnoreHelperMethod() {
         fix().addInputLines(
                         "Test.java",
                         "import com.palantir.logsafe.*;",
@@ -509,6 +509,36 @@ class SafeLoggingPropagationTest {
                         "  default String token() { return \"\"; }",
                         "}")
                 .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    void testIncludesJsonIgnored() {
+        // JsonIgnored methods are included in safety because they're
+        // still included in the toString value.
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @DoNotLog",
+                        "  @JsonIgnore",
+                        "  String token();",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@DoNotLog",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @DoNotLog",
+                        "  @JsonIgnore",
+                        "  String token();",
+                        "}")
                 .doTest();
     }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -429,6 +429,62 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
+    void testIncludesJacksonAnnotatedHelperMethods_iface() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @DoNotLog",
+                        "  @JsonProperty",
+                        "  default String token() { return \"\"; }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@DoNotLog",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @DoNotLog",
+                        "  @JsonProperty",
+                        "  default String token() { return \"\"; }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testIncludesJacksonAnnotatedHelperMethods_abstract() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@Value.Immutable",
+                        "abstract class Test {",
+                        "  @DoNotLog",
+                        "  @JsonProperty",
+                        "  String token() { return \"\"; }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@DoNotLog",
+                        "@Value.Immutable",
+                        "abstract class Test {",
+                        "  @DoNotLog",
+                        "  @JsonProperty",
+                        "  String token() { return \"\"; }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testIgnoresVoidMethods() {
         fix().addInputLines(
                         "Test.java",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -511,6 +511,23 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
+    void testIgnoresJsonIgnoreHelperMethod() throws Exception {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @DoNotLog",
+                        "  @JsonIgnore",
+                        "  default String token() { return \"\"; }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
     void testIgnoresVoidMethods() {
         fix().addInputLines(
                         "Test.java",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -16,7 +16,6 @@
 
 package com.palantir.baseline.errorprone;
 
-import org.immutables.value.Value;
 import org.junit.jupiter.api.Test;
 
 class SafeLoggingPropagationTest {
@@ -397,46 +396,6 @@ class SafeLoggingPropagationTest {
                         "  default String token() { return \"\"; }",
                         "}")
                 .doTest();
-    }
-
-    @Value.Immutable
-    @Value.Style(defaultAsDefault = true)
-    interface Foo {
-        String message();
-
-        @Value.Derived
-        default String other() {
-            return "derived";
-        }
-
-        //        @Value.Default
-        default String def() {
-            return "default";
-        }
-
-        default String bare() {
-            return "bare";
-        }
-    }
-
-    @Value.Immutable
-    @Value.Style(defaultAsDefault = true)
-    abstract static class Bar {
-        abstract String message();
-
-        @Value.Derived
-        String other() {
-            return "derived";
-        }
-
-        @Value.Default
-        String def() {
-            return "default";
-        }
-
-        String bare() {
-            return "bare";
-        }
     }
 
     @Test

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -399,6 +399,32 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
+    void includesDefaultMethodWhenLazy() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import org.immutables.value.Value;",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @DoNotLog",
+                        "  @Value.Lazy",
+                        "  default String token() { return \"\"; }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import org.immutables.value.Value;",
+                        "@DoNotLog",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @DoNotLog",
+                        "  @Value.Lazy",
+                        "  default String token() { return \"\"; }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testIgnoresHelperMethods_iface() {
         fix().addInputLines(
                         "Test.java",

--- a/changelog/@unreleased/pr-2237.v2.yml
+++ b/changelog/@unreleased/pr-2237.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Safety propagation ignores utility methods on immutables definitions
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2237


### PR DESCRIPTION
For example:
```
@Value.Immutable
interface Context {
  AuthService authService();

  // not a field, only a utility method
  default BearerToken token() {
    return authService().currentToken();
  }
}
```

==COMMIT_MSG==
Safety propagation ignores utility methods on immutables definitions
==COMMIT_MSG==
