### PR TITLE
Automatically fix upstream `NarrowCalculation`

### DIFF
--- a/changelog/@unreleased/pr-2240.v2.yml
+++ b/changelog/@unreleased/pr-2240.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Automatically fix upstream `NarrowCalculation`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2240

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -87,6 +87,7 @@ public class BaselineErrorProneExtension {
             "LoopOverCharArray",
             "MissingBraces",
             "MissingOverride",
+            "NarrowCalculation",
             "ObjectsHashCodePrimitive",
             "PreferJavaTimeOverload",
             "ProtectedMembersInFinalClass",


### PR DESCRIPTION
See https://errorprone.info/bugpattern/NarrowCalculation

I've manually run the following on several projects and haven't
had to modify the result manually:
```
./gradlew classes testClasses -PerrorProneApply=NarrowCalculation
```
It should be provided as a default suggestion.

==COMMIT_MSG==
Automatically fix upstream `NarrowCalculation`
==COMMIT_MSG==
