### PR TITLE
Fix safety evaluation requiring lhs assignment to be safe unnecessarily

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
@@ -184,6 +184,10 @@ public final class SafetyAnnotations {
                 }
                 Safety safety = Safety.SAFE;
                 List<Type> typeArguments = asSubtype.getTypeArguments();
+                if (typeArguments.isEmpty()) {
+                    // Type information is not available, not enough data to make a decision
+                    return null;
+                }
                 for (Type typeArgument : typeArguments) {
                     Safety safetyBasedOnType = SafetyAnnotations.getSafetyInternal(typeArgument, state, deJaVuToPass);
                     Safety safetyBasedOnSymbol = SafetyAnnotations.getSafety(typeArgument.tsym, state);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1096,6 +1096,26 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testThrowableFieldAssignment() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.*;",
+                        "class Test<OutputT> {",
+                        "  private volatile Set<Throwable> fieldValue = null;",
+                        "  static final class Other {",
+                        "  void f(Test obj, Set<Throwable> newValue) {",
+                        "    synchronized (obj) {",
+                        "      if (obj.fieldValue != newValue)",
+                        "      obj.fieldValue = newValue;",
+                        "    }",
+                        "  }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void disagreeingSafetyAnnotations() {
         helper().addSourceLines(
                         "Test.java",

--- a/changelog/@unreleased/pr-2242.v2.yml
+++ b/changelog/@unreleased/pr-2242.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix safety evaluation requiring lhs of an assignment to be safe unnecessarily
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2242


### PR DESCRIPTION
The type parameter passthrough code would evaluate to SAFE rather
as opposed to UNKNOWN when type parameters were unknown/erased.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix safety evaluation requiring lhs of an assignment to be safe unnecessarily
==COMMIT_MSG==
