### PR TITLE
Fix #2243: VarUsage failures reference a real tree

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/VarUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/VarUsage.java
@@ -64,7 +64,7 @@ public final class VarUsage extends BugChecker implements BugChecker.VariableTre
                     && token.hasName()
                     && token.name().contentEquals("var")) {
                 SuggestedFix.Builder fix = SuggestedFix.builder();
-                return buildDescription(typeTree)
+                return buildDescription(tree)
                         .addFix(fix.replace(
                                         token.pos(),
                                         token.endPos(),

--- a/changelog/@unreleased/pr-2244.v2.yml
+++ b/changelog/@unreleased/pr-2244.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: VarUsage failures reference a real tree
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2244


### PR DESCRIPTION
The `var` type tree is ambiguous and may not have a source
location, leading to confusing errors.

==COMMIT_MSG==
VarUsage failures reference a real tree
==COMMIT_MSG==
