### PR TITLE
Implement safety tracking through StringBuilder/StringBuffer

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1443,6 +1443,50 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testStringBuilder() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  void f(@Safe String safe, @Unsafe String unsafe) {",
+                        "    fun(new StringBuilder(safe));",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(new StringBuilder(unsafe));",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(new StringBuilder(safe).append(unsafe).toString());",
+                        "    StringBuilder sb = new StringBuilder().append(safe);",
+                        "    sb.append(safe).append(unsafe);",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(sb.append(safe).toString());",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testStringBuffer() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  void f(@Safe String safe, @Unsafe String unsafe) {",
+                        "    fun(new StringBuffer(safe));",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(new StringBuffer(unsafe));",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(new StringBuffer(safe).append(unsafe).toString());",
+                        "    StringBuffer sb = new StringBuffer().append(safe);",
+                        "    sb.append(safe).append(unsafe);",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(sb.append(safe).toString());",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/changelog/@unreleased/pr-2245.v2.yml
+++ b/changelog/@unreleased/pr-2245.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement safety tracking through StringBuilder/StringBuffer
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2245


### PR DESCRIPTION
This adds support for both fluent and non-fluent cases, where
the latter operates as a compound assignment, updating the
receiver variable/field if present.

==COMMIT_MSG==
Implement safety tracking through StringBuilder/StringBuffer
==COMMIT_MSG==


This is particularly helpful for non-immutables codebases where we propagate type-level safety from `toString` implementations which are written using StringBuilders.