### PR TITLE
Add log-safety test cases for records

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1592,6 +1592,39 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testRecordConstruction() {
+        helper().setArgs("--release", "15", "--enable-preview")
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  record MyRecord(@Safe String value) {}",
+                        "  void f(@Unsafe String value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    new MyRecord(value);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testRecordComponentUsage() {
+        helper().setArgs("--release", "15", "--enable-preview")
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  record MyRecord(@Unsafe String value) {}",
+                        "  void f(MyRecord rec) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(rec.value());",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }


### PR DESCRIPTION
==COMMIT_MSG==
Add log-safety test cases for records
==COMMIT_MSG==

No implementation change, just ensuring that they work (via existing mechanisms!) and continue to do so.

At the moment we leverage the `SafeLoggingPropagation` check to ensure the combination of record components is added to the record itself, rather than computing the combination ourselves. This requires more pieces to work together, however if we computed record safety at build time, we would potentially have to walk large, complex type hierarchies, which requires far more compute.