### PR TITLE
Stream.collect safety no longer incorrectly includes map collectors

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1625,6 +1625,37 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testTransformingStreamCollectors() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.*;",
+                        "import java.util.function.*;",
+                        "import java.util.stream.*;",
+                        "import com.google.common.collect.*;",
+                        "class Test {",
+                        "  @DoNotLog",
+                        "  interface TopLevel {",
+                        "     @Safe String name();",
+                        "     @Safe String value();",
+                        "     @DoNotLog String token();",
+                        "  }",
+                        "  void f(@Unsafe Stream<TopLevel> stream) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG'",
+                        "    fun(stream.collect(Collectors.toList()));",
+                        "    fun(stream.collect(Collectors.counting()));",
+                        "    fun(stream.collect(Collectors.toMap(TopLevel::name, TopLevel::value)));",
+                        "    fun(stream.collect(Collectors.toConcurrentMap(TopLevel::name, TopLevel::value)));",
+                        "    fun(stream.collect(Collectors.toUnmodifiableMap(TopLevel::name, TopLevel::value)));",
+                        "    fun(stream.collect(ImmutableMap.toImmutableMap(TopLevel::name, TopLevel::value)));",
+                        "    fun(stream.collect(ImmutableBiMap.toImmutableBiMap(TopLevel::name, TopLevel::value)));",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/changelog/@unreleased/pr-2264.v2.yml
+++ b/changelog/@unreleased/pr-2264.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Stream.collect safety no longer incorrectly includes map collectors
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2264


### PR DESCRIPTION
Map collectors, unlike most others, doesn't collect the data from
the stream into an element, rather acts in two steps: A `stream.map`
for each key and value function, as well as a collect of the merged
results. Thus, we cannot make assumptions about the output safety
based on the inputs. In the future, this will be handled using
the same functionality as `stream.map(func)`.

==COMMIT_MSG==
Stream.collect safety no longer incorrectly includes map collectors
==COMMIT_MSG==

## Possible downsides?
Sometimes the map collector result may be unsafe (e.g. Function.identity and similar), however in many cases we can get safety based on type information in the result. Best to produce high confidence results, as opposed to allowing developers to assume some are noise.
