### PR TITLE
Safety analysis checks superinterfaces (in addition to superclasses)

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
@@ -24,6 +24,7 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
@@ -101,6 +102,14 @@ public final class SafetyAnnotations {
             if (symbol instanceof VarSymbol) {
                 VarSymbol varSymbol = (VarSymbol) symbol;
                 return getSuperMethodParameterSafety(varSymbol, state);
+            }
+            if (symbol instanceof ClassSymbol) {
+                ClassSymbol classSymbol = (ClassSymbol) symbol;
+                Safety safety = Safety.UNKNOWN;
+                for (Type type : classSymbol.getInterfaces()) {
+                    safety = Safety.mergeAssumingUnknownIsSame(safety, getSafety(type.tsym, state));
+                }
+                return safety;
             }
         }
         return Safety.UNKNOWN;

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1656,6 +1656,26 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testResultOfInvocationSuperInterfaceAnnotated() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.function.*;",
+                        "class Test {",
+                        "  @Unsafe",
+                        "  interface Iface {",
+                        "  }",
+                        "  static final class Impl implements Iface {}",
+                        "  void f(Supplier<Impl> supplier) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(supplier.get());",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/changelog/@unreleased/pr-2267.v2.yml
+++ b/changelog/@unreleased/pr-2267.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Safety analysis checks superinterfaces (in addition to superclasses)
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2267


### PR DESCRIPTION
Inherited annotations apply to subclasses, however we must also
check interfaces.

==COMMIT_MSG==
Safety analysis checks superinterfaces (in addition to superclasses)
==COMMIT_MSG==

Possible downside: deep type hierarchies may be more expensive to validate than before.

