### PR TITLE
Safety analysis detects annotations on superclasses and their interfaces

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
@@ -105,7 +105,7 @@ public final class SafetyAnnotations {
             }
             if (symbol instanceof ClassSymbol) {
                 ClassSymbol classSymbol = (ClassSymbol) symbol;
-                Safety safety = Safety.UNKNOWN;
+                Safety safety = getSafety(classSymbol.getSuperclass().tsym, state);
                 for (Type type : classSymbol.getInterfaces()) {
                     safety = Safety.mergeAssumingUnknownIsSame(safety, getSafety(type.tsym, state));
                 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1676,6 +1676,48 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testSuperClassInterfaceAnnotated() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  @Unsafe",
+                        "  interface Iface {",
+                        "  }",
+                        "  static class Sup implements Iface {}",
+                        "  static class Sub extends Sup {}",
+                        "  void f(Sub value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(value);",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testMultipleInterfacesDifferentSafety() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  @Unsafe interface UnsafeIface {}",
+                        "  @Safe interface SafeIface {}",
+                        "  @DoNotLog interface DnlIface {}",
+                        "  static class One implements SafeIface, UnsafeIface {}",
+                        "  static class Two implements SafeIface, DnlIface, UnsafeIface {}",
+                        "  void f(One one, Two two) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun(one);",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG'",
+                        "    fun(two);",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1718,6 +1718,24 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testSuperclassLessStrictThanInterfaces() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  @DoNotLog interface DnlIface {}",
+                        "  @Safe static class Sup {}",
+                        "  static class Impl extends Sup implements DnlIface {}",
+                        "  void f(Impl value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG'",
+                        "    fun(value);",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/changelog/@unreleased/pr-2271.v2.yml
+++ b/changelog/@unreleased/pr-2271.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Safety analysis detects annotations on superclasses and their interfaces
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2271


### PR DESCRIPTION
Previously it would detect direct interfaces and supertypes, but
not interfaces on supertypes.

## After this PR
==COMMIT_MSG==
Safety analysis detects annotations on superclasses and their interfaces
==COMMIT_MSG==

## Possible downsides?
More work at build time!
