### PR TITLE
Immutables redactions may be unsafe (previously forced do-not-log)

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -567,6 +567,36 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
+    void testRedactedMayBeUnsafe() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @Unsafe",
+                        "  @JsonValue",
+                        "  @Value.Redacted",
+                        "  String token();",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.fasterxml.jackson.annotation.*;",
+                        "import org.immutables.value.Value;",
+                        "@Unsafe",
+                        "@Value.Immutable",
+                        "interface Test {",
+                        "  @Unsafe",
+                        "  @JsonValue",
+                        "  @Value.Redacted",
+                        "  String token();",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testRedactedIsDoNotLog_jsonSerializable() {
         fix().addInputLines(
                         "Test.java",

--- a/changelog/@unreleased/pr-2277.v2.yml
+++ b/changelog/@unreleased/pr-2277.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Immutables redactions may be unsafe (previously forced do-not-log)
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2277


### PR DESCRIPTION
We still assume do-not-log by default, however type and annotation
information may be used to suggest unsafe.

this addresses an edge case that I've seen come up from time to time.

==COMMIT_MSG==
Immutables redactions may be unsafe (previously forced do-not-log)
==COMMIT_MSG==

