### PR TITLE
Support subclass safety overrides

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreASTHelpers.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/MoreASTHelpers.java
@@ -22,6 +22,8 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.CatchTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.Tree;
 import com.sun.source.tree.TryTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
@@ -32,7 +34,7 @@ import javax.annotation.Nullable;
 
 /** Utility functionality that does not exist in {@link com.google.errorprone.util.ASTHelpers}. */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
-final class MoreASTHelpers {
+public final class MoreASTHelpers {
 
     /** Removes any type that is a subtype of another type in the set. */
     @SuppressWarnings("ReferenceEquality")
@@ -113,6 +115,12 @@ final class MoreASTHelpers {
             return ImmutableList.copyOf(unionType.getAlternativeTypes());
         }
         return ImmutableList.of(type);
+    }
+
+    public static Type getResultType(Tree tree) {
+        return tree instanceof ExpressionTree
+                ? ASTHelpers.getResultType((ExpressionTree) tree)
+                : ASTHelpers.getType(tree);
     }
 
     private MoreASTHelpers() {}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -183,7 +183,7 @@ public final class SafeLoggingPropagation extends BugChecker
 
     private Description matchRecord(ClassTree classTree, ClassSymbol classSymbol, VisitorState state) {
         Safety existingClassSafety = SafetyAnnotations.getSafety(classTree, state);
-        Safety safety = getTypeSafetyFromAncestors(classTree, state);
+        Safety safety = SafetyAnnotations.getTypeSafetyFromAncestors(classTree, state);
         for (VarSymbol recordComponent : getRecordComponents(classSymbol)) {
             Safety symbolSafety = SafetyAnnotations.getSafety(recordComponent, state);
             Safety typeSymSafety = SafetyAnnotations.getSafety(recordComponent.type.tsym, state);
@@ -203,7 +203,7 @@ public final class SafeLoggingPropagation extends BugChecker
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private Description matchImmutables(ClassTree classTree, ClassSymbol classSymbol, VisitorState state) {
         Safety existingClassSafety = SafetyAnnotations.getSafety(classTree, state);
-        Safety safety = getTypeSafetyFromAncestors(classTree, state);
+        Safety safety = SafetyAnnotations.getTypeSafetyFromAncestors(classTree, state);
         boolean hasKnownGetter = false;
         boolean isJson = hasJacksonAnnotation(classSymbol, state);
         for (Tree member : classTree.getMembers()) {
@@ -249,14 +249,6 @@ public final class SafeLoggingPropagation extends BugChecker
         Safety existingClassSafety = SafetyAnnotations.getSafety(classTree, state);
         Safety symbolSafety = SafetyAnnotations.getSafety(toStringSymbol, state);
         return handleSafety(classTree, classTree.getModifiers(), state, existingClassSafety, symbolSafety);
-    }
-
-    private static Safety getTypeSafetyFromAncestors(ClassTree classTree, VisitorState state) {
-        Safety safety = SafetyAnnotations.getSafety(classTree.getExtendsClause(), state);
-        for (Tree implemented : classTree.getImplementsClause()) {
-            safety = safety.leastUpperBound(SafetyAnnotations.getSafety(implemented, state));
-        }
-        return safety;
     }
 
     private Description handleSafety(

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Multimap;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Attribute;
@@ -122,6 +123,14 @@ public final class SafetyAnnotations {
             return getSafetyInternal(type, state, null);
         }
         return Safety.UNKNOWN;
+    }
+
+    public static Safety getTypeSafetyFromAncestors(ClassTree classTree, VisitorState state) {
+        Safety safety = SafetyAnnotations.getSafety(classTree.getExtendsClause(), state);
+        for (Tree implemented : classTree.getImplementsClause()) {
+            safety = safety.leastUpperBound(SafetyAnnotations.getSafety(implemented, state));
+        }
+        return safety;
     }
 
     public static Safety getDirectSafety(@Nullable Symbol symbol, VisitorState state) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1745,8 +1745,7 @@ class IllegalSafeLoggingArgumentTest {
                         "  @DoNotLog class DoNotLogClass {}",
                         "  @Safe interface SafeClass {}",
                         "  @Unsafe interface UnsafeClass {}",
-                        "  @Safe interface SafeSubclass extends UnsafeClass {}",
-                        "  void f(Object object, UnsafeClass unsafeObject) {",
+                        "  void f(Object object, UnsafeClass unsafeObject, @Unsafe Object unsafeAnnotatedObject) {",
                         "    fun(object);",
                         "    fun((SafeClass) object);",
                         "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
@@ -1755,9 +1754,22 @@ class IllegalSafeLoggingArgumentTest {
                         "    fun((DoNotLogClass) object);",
                         "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
                         "    fun((SafeClass) unsafeObject);",
-                        "    fun((SafeSubclass) unsafeObject);",
+                        "    fun((SafeClass) unsafeAnnotatedObject);",
                         "  }",
                         "  private static void fun(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testSubclassWithLenientSafety() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  @Unsafe interface UnsafeClass {}",
+                        "  // BUG: Diagnostic contains: Dangerous type: annotated 'SAFE' but ancestors declare 'SAFE'.",
+                        "  @Safe interface SafeSubclass extends UnsafeClass {}",
                         "}")
                 .doTest();
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1736,6 +1736,32 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testCastSafety() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  @DoNotLog class DoNotLogClass {}",
+                        "  @Safe interface SafeClass {}",
+                        "  @Unsafe interface UnsafeClass {}",
+                        "  @Safe interface SafeSubclass extends UnsafeClass {}",
+                        "  void f(Object object, UnsafeClass unsafeObject) {",
+                        "    fun(object);",
+                        "    fun((SafeClass) object);",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun((UnsafeClass) object);",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG'",
+                        "    fun((DoNotLogClass) object);",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    fun((SafeClass) unsafeObject);",
+                        "    fun((SafeSubclass) unsafeObject);",
+                        "  }",
+                        "  private static void fun(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/changelog/@unreleased/pr-2289.v2.yml
+++ b/changelog/@unreleased/pr-2289.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Trust type safety on cast results, based on validation that occurred
+    when the type was created.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2289


### PR DESCRIPTION
## Before this PR
Casting from an unsafe-annotated interface to a safe-annotated interface produced `UNSAFE` data.

## After this PR
==COMMIT_MSG==
Trust type safety on cast results, based on validation that occurred when the type was created. 
==COMMIT_MSG==

## Possible downsides?
The behavior this allows breaks several of our assumptions, and may cause issues elsewhere.

However there are cases where this is reasonable that don't break any assumptions, for instance:

```java
void arbitraryObjectConsumer(@Unsafe Object input) {
    if (input instanceof SafeType) {
        // this is absolutely safe, the inputs to `arbitraryObjectConsumer` are just known
        // to allow unsafe values, they aren't required to be unsafe. All values of a safe type
        // MUST be safe.
        SafeType safe = (SafeType) input;
    }
}