### PR TITLE
task configuration avoidance

### DIFF
--- a/changelog/@unreleased/pr-2290.v2.yml
+++ b/changelog/@unreleased/pr-2290.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid configuring many gradle tasks
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2290

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java
@@ -51,11 +51,10 @@ public final class BaselineCheckstyle extends AbstractBaselinePlugin {
             // Java 8+ new doclint compiler feature redundant.
             if (javaConvention.getSourceCompatibility().isJava8Compatible()) {
                 project.getTasks()
-                        .withType(
-                                Javadoc.class,
-                                javadoc -> javadoc.options(
-                                        javadocOptions -> ((StandardJavadocDocletOptions) javadocOptions)
-                                                .addStringOption("Xdoclint:none", "-quiet")));
+                        .withType(Javadoc.class)
+                        .configureEach(javadoc ->
+                                javadoc.options(javadocOptions -> ((StandardJavadocDocletOptions) javadocOptions)
+                                        .addStringOption("Xdoclint:none", "-quiet")));
             }
         });
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
@@ -65,10 +65,11 @@ public final class BaselineCircleCi implements Plugin<Project> {
             throw new RuntimeException("failed to create CIRCLE_ARTIFACTS directory", e);
         }
 
-        project.getRootProject().allprojects(proj -> proj.getTasks().withType(Test.class, test -> {
-            test.getReports().getHtml().getRequired().set(true);
-            test.getReports().getHtml().getOutputLocation().set(junitPath(circleArtifactsDir, test.getPath()));
-        }));
+        project.getRootProject()
+                .allprojects(proj -> proj.getTasks().withType(Test.class).configureEach(test -> {
+                    test.getReports().getHtml().getRequired().set(true);
+                    test.getReports().getHtml().getOutputLocation().set(junitPath(circleArtifactsDir, test.getPath()));
+                }));
     }
 
     private void configurePluginsForReports(Project project) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineClassUniquenessPlugin.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineClassUniquenessPlugin.java
@@ -44,7 +44,7 @@ public class BaselineClassUniquenessPlugin extends AbstractBaselinePlugin {
                     task.usesService(jarClassHasher);
                 });
         project.getPlugins().apply(LifecycleBasePlugin.class);
-        project.getTasks().getByName(LifecycleBasePlugin.CHECK_TASK_NAME).dependsOn(checkClassUniqueness);
+        project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(checkClassUniqueness));
 
         project.getPlugins().withId("java", plugin -> {
             checkClassUniqueness.configure(t -> {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEnablePreviewFlag.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEnablePreviewFlag.java
@@ -51,14 +51,14 @@ public final class BaselineEnablePreviewFlag implements Plugin<Project> {
         project.getExtensions().getExtraProperties().set("enablePreview", enablePreview);
 
         project.getPlugins().withId("java", _unused -> {
-            project.getTasks().withType(JavaCompile.class, t -> {
+            project.getTasks().withType(JavaCompile.class).configureEach(t -> {
                 List<CommandLineArgumentProvider> args = t.getOptions().getCompilerArgumentProviders();
                 args.add(new MaybeEnablePreview(enablePreview)); // mutation is gross, but it's the gradle convention
             });
-            project.getTasks().withType(Test.class, t -> {
+            project.getTasks().withType(Test.class).configureEach(t -> {
                 t.getJvmArgumentProviders().add(new MaybeEnablePreview(enablePreview));
             });
-            project.getTasks().withType(JavaExec.class, t -> {
+            project.getTasks().withType(JavaExec.class).configureEach(t -> {
                 t.getJvmArgumentProviders().add(new MaybeEnablePreview(enablePreview));
             });
 
@@ -68,7 +68,7 @@ public final class BaselineEnablePreviewFlag implements Plugin<Project> {
                     JavaVersion sourceCompat = project.getConvention()
                             .getPlugin(JavaPluginConvention.class)
                             .getSourceCompatibility();
-                    project.getTasks().withType(Javadoc.class, t -> {
+                    project.getTasks().withType(Javadoc.class).configureEach(t -> {
                         CoreJavadocOptions options = (CoreJavadocOptions) t.getOptions();
 
                         // Yes truly javadoc wants a single leading dash, other javac wants a double leading dash.

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineFormat.java
@@ -204,12 +204,15 @@ class BaselineFormat extends AbstractBaselinePlugin {
         });
 
         project.afterEvaluate(p -> {
-            Task spotlessJava = project.getTasks().getByName("spotlessJava");
             if (eclipseFormattingEnabled(project) && !Files.exists(eclipseXml)) {
-                spotlessJava.dependsOn(":baselineUpdateConfig");
+                TaskProvider<Task> spotlessJava = project.getTasks().named("spotlessJava");
+                spotlessJava.configure(t -> t.dependsOn(":baselineUpdateConfig"));
             }
 
-            project.getTasks().withType(JavaCompile.class).configureEach(spotlessJava::mustRunAfter);
+            project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> {
+                Task spotlessJava = project.getTasks().getByName("spotlessJava");
+                spotlessJava.mustRunAfter(javaCompile);
+            });
         });
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -34,12 +34,14 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.UnknownTaskException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
@@ -75,96 +77,106 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
             // https://github.com/gradle/gradle/issues/18824
             // However, we set sourceCompatibility in BaselineJavaVersion to opt out of the '--release' flag.
             project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
-                JavaCompile javaCompile = project.getTasks()
-                        .named(sourceSet.getCompileJavaTaskName(), JavaCompile.class)
-                        .get();
-                javaCompile
-                        .getOptions()
-                        .getCompilerArgumentProviders()
-                        // Use an anonymous class because tasks with lambda inputs cannot be cached
-                        .add(new CommandLineArgumentProvider() {
+                TaskProvider<JavaCompile> javaCompileProvider =
+                        project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
+                javaCompileProvider.configure(javaCompile -> {
+                    javaCompile
+                            .getOptions()
+                            .getCompilerArgumentProviders()
+                            // Use an anonymous class because tasks with lambda inputs cannot be cached
+                            .add(new CommandLineArgumentProvider() {
+                                @Override
+                                public Iterable<String> asArguments() {
+                                    // The '--release' flag is set when BaselineJavaVersion is not used.
+                                    if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
+                                        project.getLogger()
+                                                .debug(
+                                                        "BaselineModuleJvmArgs not applying args to compilation task "
+                                                                + "{} on {} due to lack of BaselineJavaVersion",
+                                                        javaCompile.getName(),
+                                                        project);
+                                        return ImmutableList.of();
+                                    }
+                                    ImmutableList<String> arguments =
+                                            collectCompilationArgs(project, extension, sourceSet);
+                                    project.getLogger()
+                                            .debug(
+                                                    "BaselineModuleJvmArgs compiling {} on {} with exports: {}",
+                                                    javaCompile.getName(),
+                                                    project,
+                                                    arguments);
+                                    return arguments;
+                                }
+                            });
+                });
+
+                TaskProvider<Task> javadocTaskProvider = null;
+                try {
+                    javadocTaskProvider = project.getTasks().named(sourceSet.getJavadocTaskName());
+                } catch (UnknownTaskException e) {
+                    // skip
+                }
+                if (javadocTaskProvider != null) {
+                    javadocTaskProvider.configure(javadocTask -> {
+                        javadocTask.doFirst(new Action<Task>() {
                             @Override
-                            public Iterable<String> asArguments() {
+                            public void execute(Task task) {
                                 // The '--release' flag is set when BaselineJavaVersion is not used.
                                 if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
                                     project.getLogger()
                                             .debug(
                                                     "BaselineModuleJvmArgs not applying args to compilation task "
                                                             + "{} on {} due to lack of BaselineJavaVersion",
-                                                    javaCompile.getName(),
+                                                    task.getName(),
                                                     project);
-                                    return ImmutableList.of();
+                                    return;
                                 }
-                                ImmutableList<String> arguments = collectCompilationArgs(project, extension, sourceSet);
-                                project.getLogger()
-                                        .debug(
-                                                "BaselineModuleJvmArgs compiling {} on {} with exports: {}",
-                                                javaCompile.getName(),
-                                                project,
-                                                arguments);
-                                return arguments;
+
+                                Javadoc javadoc = (Javadoc) task;
+
+                                MinimalJavadocOptions options = javadoc.getOptions();
+                                if (options instanceof CoreJavadocOptions) {
+                                    CoreJavadocOptions coreOptions = (CoreJavadocOptions) options;
+                                    ImmutableList<JarManifestModuleInfo> info =
+                                            collectClasspathInfo(project, sourceSet);
+                                    List<String> exportValues = Stream.concat(
+                                                    // Compilation only supports exports, so we union with opens.
+                                                    Stream.concat(
+                                                            extension.exports().get().stream(),
+                                                            extension.opens().get().stream()),
+                                                    info.stream()
+                                                            .flatMap(item -> Stream.concat(
+                                                                    item.exports().stream(), item.opens().stream())))
+                                            .distinct()
+                                            .sorted()
+                                            .map(item -> item + "=ALL-UNNAMED")
+                                            .collect(ImmutableList.toImmutableList());
+                                    project.getLogger()
+                                            .debug(
+                                                    "BaselineModuleJvmArgs building {} on {} " + "with exports: {}",
+                                                    javadoc.getName(),
+                                                    project,
+                                                    exportValues);
+                                    if (!exportValues.isEmpty()) {
+                                        coreOptions
+                                                // options are automatically prefixed with '-' internally
+                                                .addMultilineStringsOption("-add-exports")
+                                                .setValue(exportValues);
+                                    }
+                                } else {
+                                    project.getLogger()
+                                            .error(
+                                                    "MinimalJavadocOptions implementation was "
+                                                            + "not CoreJavadocOptions, rather '{}'",
+                                                    options.getClass().getName());
+                                }
                             }
                         });
-
-                Task maybeJavadocTask = project.getTasks().findByName(sourceSet.getJavadocTaskName());
-                if (maybeJavadocTask instanceof Javadoc) {
-                    maybeJavadocTask.doFirst(new Action<Task>() {
-                        @Override
-                        public void execute(Task task) {
-                            // The '--release' flag is set when BaselineJavaVersion is not used.
-                            if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
-                                project.getLogger()
-                                        .debug(
-                                                "BaselineModuleJvmArgs not applying args to compilation task "
-                                                        + "{} on {} due to lack of BaselineJavaVersion",
-                                                task.getName(),
-                                                project);
-                                return;
-                            }
-
-                            Javadoc javadoc = (Javadoc) task;
-
-                            MinimalJavadocOptions options = javadoc.getOptions();
-                            if (options instanceof CoreJavadocOptions) {
-                                CoreJavadocOptions coreOptions = (CoreJavadocOptions) options;
-                                ImmutableList<JarManifestModuleInfo> info = collectClasspathInfo(project, sourceSet);
-                                List<String> exportValues = Stream.concat(
-                                                // Compilation only supports exports, so we union with opens.
-                                                Stream.concat(
-                                                        extension.exports().get().stream(),
-                                                        extension.opens().get().stream()),
-                                                info.stream()
-                                                        .flatMap(item -> Stream.concat(
-                                                                item.exports().stream(), item.opens().stream())))
-                                        .distinct()
-                                        .sorted()
-                                        .map(item -> item + "=ALL-UNNAMED")
-                                        .collect(ImmutableList.toImmutableList());
-                                project.getLogger()
-                                        .debug(
-                                                "BaselineModuleJvmArgs building {} on {} " + "with exports: {}",
-                                                javadoc.getName(),
-                                                project,
-                                                exportValues);
-                                if (!exportValues.isEmpty()) {
-                                    coreOptions
-                                            // options are automatically prefixed with '-' internally
-                                            .addMultilineStringsOption("-add-exports")
-                                            .setValue(exportValues);
-                                }
-                            } else {
-                                project.getLogger()
-                                        .error(
-                                                "MinimalJavadocOptions implementation was "
-                                                        + "not CoreJavadocOptions, rather '{}'",
-                                                options.getClass().getName());
-                            }
-                        }
                     });
                 }
             });
 
-            project.getTasks().withType(Test.class, new Action<Test>() {
+            project.getTasks().withType(Test.class).configureEach(new Action<Test>() {
 
                 @Override
                 public void execute(Test test) {
@@ -186,7 +198,7 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
                 }
             });
 
-            project.getTasks().withType(JavaExec.class, new Action<JavaExec>() {
+            project.getTasks().withType(JavaExec.class).configureEach(new Action<JavaExec>() {
 
                 @Override
                 public void execute(JavaExec javaExec) {
@@ -208,7 +220,7 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
                 }
             });
 
-            project.getTasks().withType(Jar.class, new Action<Jar>() {
+            project.getTasks().withType(Jar.class).configureEach(new Action<Jar>() {
                 @Override
                 public void execute(Jar jar) {
                     jar.doFirst(new Action<Task>() {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -87,7 +87,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             Project project,
             Provider<JavaLanguageVersion> targetVersionProvider,
             Provider<BaselineJavaToolchain> javaToolchain) {
-        project.getTasks().withType(JavaCompile.class, new Action<JavaCompile>() {
+        project.getTasks().withType(JavaCompile.class).configureEach(new Action<JavaCompile>() {
             @Override
             public void execute(JavaCompile javaCompile) {
                 javaCompile.getJavaCompiler().set(javaToolchain.flatMap(BaselineJavaToolchain::javaCompiler));
@@ -103,14 +103,14 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             }
         });
 
-        project.getTasks().withType(Javadoc.class, new Action<Javadoc>() {
+        project.getTasks().withType(Javadoc.class).configureEach(new Action<Javadoc>() {
             @Override
             public void execute(Javadoc javadoc) {
                 javadoc.getJavadocTool().set(javaToolchain.flatMap(BaselineJavaToolchain::javadocTool));
             }
         });
 
-        project.getTasks().withType(GroovyCompile.class, new Action<GroovyCompile>() {
+        project.getTasks().withType(GroovyCompile.class).configureEach(new Action<GroovyCompile>() {
             @Override
             public void execute(GroovyCompile groovyCompile) {
                 groovyCompile.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
@@ -126,7 +126,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             }
         });
 
-        project.getTasks().withType(ScalaCompile.class, new Action<ScalaCompile>() {
+        project.getTasks().withType(ScalaCompile.class).configureEach(new Action<ScalaCompile>() {
             @Override
             public void execute(ScalaCompile scalaCompile) {
                 scalaCompile.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
@@ -142,7 +142,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             }
         });
 
-        project.getTasks().withType(ScalaDoc.class, new Action<ScalaDoc>() {
+        project.getTasks().withType(ScalaDoc.class).configureEach(new Action<ScalaDoc>() {
             @Override
             public void execute(ScalaDoc scalaDoc) {
                 scalaDoc.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
@@ -151,14 +151,14 @@ public final class BaselineJavaVersion implements Plugin<Project> {
     }
 
     private static void configureExecutionTasks(Project project, Provider<BaselineJavaToolchain> javaToolchain) {
-        project.getTasks().withType(JavaExec.class, new Action<JavaExec>() {
+        project.getTasks().withType(JavaExec.class).configureEach(new Action<JavaExec>() {
             @Override
             public void execute(JavaExec javaExec) {
                 javaExec.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
             }
         });
 
-        project.getTasks().withType(Test.class, new Action<Test>() {
+        project.getTasks().withType(Test.class).configureEach(new Action<Test>() {
             @Override
             public void execute(Test test) {
                 test.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsPlugin.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsPlugin.java
@@ -35,7 +35,7 @@ public final class JunitReportsPlugin implements Plugin<Project> {
         JunitReportsExtension rootExt = project.getRootProject().getExtensions().getByType(JunitReportsExtension.class);
         JunitTaskResultExtension ext = JunitTaskResultExtension.register(project);
 
-        project.getTasks().withType(Test.class, test -> {
+        project.getTasks().withType(Test.class).configureEach(test -> {
             test.getReports().getJunitXml().getRequired().set(true);
             test.getReports()
                     .getJunitXml()
@@ -43,12 +43,12 @@ public final class JunitReportsPlugin implements Plugin<Project> {
                     .fileProvider(junitPath(rootExt.getReportsDirectory(), test.getPath()));
         });
 
-        project.getTasks().withType(Checkstyle.class, checkstyle -> {
+        project.getTasks().withType(Checkstyle.class).configureEach(checkstyle -> {
             ext.registerTask(
                     checkstyle.getName(), XmlReportFailuresSupplier.create(checkstyle, new CheckstyleReportHandler()));
         });
 
-        project.getTasks().withType(JavaCompile.class, javac -> {
+        project.getTasks().withType(JavaCompile.class).configureEach(javac -> {
             ext.registerTask(javac.getName(), JavacFailuresSupplier.create(javac));
         });
 

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsPlugin.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsPlugin.java
@@ -43,12 +43,12 @@ public final class JunitReportsPlugin implements Plugin<Project> {
                     .fileProvider(junitPath(rootExt.getReportsDirectory(), test.getPath()));
         });
 
-        project.getTasks().withType(Checkstyle.class).configureEach(checkstyle -> {
+        project.getTasks().withType(Checkstyle.class, checkstyle -> {
             ext.registerTask(
                     checkstyle.getName(), XmlReportFailuresSupplier.create(checkstyle, new CheckstyleReportHandler()));
         });
 
-        project.getTasks().withType(JavaCompile.class).configureEach(javac -> {
+        project.getTasks().withType(JavaCompile.class, javac -> {
             ext.registerTask(javac.getName(), JavacFailuresSupplier.create(javac));
         });
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Many tasks are configured unnecessarily.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid configuring many gradle tasks
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None.
