### PR TITLE
Fix class hierarchy safe-logging error message agreement

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -354,8 +354,7 @@ public final class IllegalSafeLoggingArgument extends BugChecker
         }
         return buildDescription(tree)
                 .setMessage(String.format(
-                        "Dangerous type: annotated '%s' but ancestors declare '%s'.",
-                        directSafety, SafetyAnnotations.getSafety(tree, state)))
+                        "Dangerous type: annotated '%s' but ancestors declare '%s'.", directSafety, ancestorSafety))
                 .build();
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1768,7 +1768,8 @@ class IllegalSafeLoggingArgumentTest {
                         "import com.palantir.logsafe.*;",
                         "class Test {",
                         "  @Unsafe interface UnsafeClass {}",
-                        "  // BUG: Diagnostic contains: Dangerous type: annotated 'SAFE' but ancestors declare 'SAFE'.",
+                        "  // BUG: Diagnostic contains: "
+                                + "Dangerous type: annotated 'SAFE' but ancestors declare 'UNSAFE'.",
                         "  @Safe interface SafeSubclass extends UnsafeClass {}",
                         "}")
                 .doTest();

--- a/changelog/@unreleased/pr-2295.v2.yml
+++ b/changelog/@unreleased/pr-2295.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix class hierarchy safe-logging error message agreement
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2295


### PR DESCRIPTION
Previously the safety referenced in the message did not agree
with the failure.

==COMMIT_MSG==
Fix class hierarchy safe-logging error message agreement
==COMMIT_MSG==

