### PR TITLE
gradle task configuration avoidance

### DIFF
--- a/changelog/@unreleased/pr-2299.v2.yml
+++ b/changelog/@unreleased/pr-2299.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Avoid creating and configuring gradle tasks
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2299

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
@@ -127,14 +127,18 @@ class BaselineEclipse extends AbstractBaselinePlugin {
                 }
 
                 // Run eclipseTemplate when eclipse task is run
-                project.tasks.eclipse.dependsOn(eclipseTemplate)
+                project.tasks.named("eclipse").configure {
+                    dependsOn(eclipseTemplate)
+                }
 
                 // Override default Eclipse JRE.
-                project.tasks.eclipseClasspath.doFirst {
-                    String eclipseClassPath = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-" + project.sourceCompatibility;
-                    project.eclipse.classpath {
-                        containers.clear()
-                        containers.add(eclipseClassPath)
+                project.tasks.named("eclipseClasspath").configure {
+                    doFirst {
+                        String eclipseClassPath = "org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-" + project.sourceCompatibility;
+                        project.eclipse.classpath {
+                            containers.clear()
+                            containers.add(eclipseClassPath)
+                        }
                     }
                 }
             }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -85,7 +85,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             }
         }
 
-        project.getTasks().findByName("idea").doLast(cleanup)
+        project.getTasks().named("idea").configure(idea -> idea.doLast(cleanup))
     }
 
     void applyToRootProject(Project rootProject) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
@@ -34,19 +34,21 @@ public final class BaselineImmutables implements Plugin<Project> {
             project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
                 project.getTasks()
                         .named(sourceSet.getCompileJavaTaskName(), JavaCompile.class)
-                        .get()
-                        .getOptions()
-                        .getCompilerArgumentProviders()
-                        // Use an anonymous class because tasks with lambda inputs cannot be cached
-                        .add(new CommandLineArgumentProvider() {
-                            @Override
-                            public Iterable<String> asArguments() {
-                                if (hasImmutablesProcessor(project, sourceSet)) {
-                                    return Collections.singletonList("-Aimmutables.gradle.incremental");
-                                }
+                        .configure(javaCompileTask -> {
+                            javaCompileTask
+                                    .getOptions()
+                                    .getCompilerArgumentProviders()
+                                    // Use an anonymous class because tasks with lambda inputs cannot be cached
+                                    .add(new CommandLineArgumentProvider() {
+                                        @Override
+                                        public Iterable<String> asArguments() {
+                                            if (hasImmutablesProcessor(project, sourceSet)) {
+                                                return Collections.singletonList("-Aimmutables.gradle.incremental");
+                                            }
 
-                                return Collections.emptyList();
-                            }
+                                            return Collections.emptyList();
+                                        }
+                                    });
                         });
             });
         });

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -71,15 +72,15 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             configureExecutionTasks(project, javaToolchains.forVersion(extension.runtime()));
 
             // Validation
-            project.getTasks()
+            TaskProvider<CheckJavaVersionsTask> checkJavaVersions = project.getTasks()
                     .register("checkJavaVersions", CheckJavaVersionsTask.class, new Action<CheckJavaVersionsTask>() {
                         @Override
                         public void execute(CheckJavaVersionsTask task) {
                             task.getTargetVersion().set(extension.target());
                             task.getRuntimeVersion().set(extension.runtime());
-                            project.getTasks().getByName("check").dependsOn(task);
                         }
                     });
+            project.getTasks().named("check").configure(check -> check.dependsOn(checkJavaVersions));
         });
     }
 


### PR DESCRIPTION
also fix an issue in BaselineJavaVersion

## Before this PR
We are unnecessarily creating and configuring tasks during gradle configuration. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more details.

## After this PR
==COMMIT_MSG==
Avoid creating and configuring gradle tasks
==COMMIT_MSG==

## Possible downsides?
None.
