### PR TITLE
Don't count identifier expressions as variable usages in `StrictUnusedVariable` check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -91,6 +91,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.VariableTree;
@@ -1054,7 +1055,9 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
         @Override
         public Void visitMemberSelect(MemberSelectTree memberSelectTree, Void unused) {
-            usageSites.put(getSymbol(memberSelectTree), getCurrentPath());
+            if (!memberSelectTree.getExpression().getKind().equals(Kind.IDENTIFIER)) {
+                usageSites.put(getSymbol(memberSelectTree), getCurrentPath());
+            }
             return super.visitMemberSelect(memberSelectTree, null);
         }
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -81,7 +81,7 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
-    public void handles_classes_constructorFields() {
+    public void handles_classes_ignoresIdentifierExpressions() {
         compilationHelper
                 .addSourceLines(
                         "Test.java",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -81,6 +81,20 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
+    public void handles_classes_constructorFields() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "  private final String _field;",
+                        "  public Test(String value) {",
+                        "    this._field = value;",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void handles_enums() {
         compilationHelper
                 .addSourceLines(

--- a/changelog/@unreleased/pr-2304.v2.yml
+++ b/changelog/@unreleased/pr-2304.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Don't count identifier expressions as variable usages in `StrictUnusedVariable`
+    check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2304


### PR DESCRIPTION
## Before this PR
If you have a class like this
```
public class Test {
    private final String myField;

    public Test(String myField) {
        this.myField = myField;
    }
}
```
then the `StrictUsedVariable` check fails with
```
error: [StrictUnusedVariable] The field 'myField' is never read. Intentional occurrences are acknowledged by renaming the unused variable with a leading underscore. '_myField', for example.
    private final String myField;
                         ^
```

But if I apply the suggested fix
```
public class Test {
    private final String _myField;

    public Test(String myField) {
        this._myField = myField;
    }
}
```
I also get a `StrictUnusedVariable` error
```
error: [StrictUnusedVariable] The field '_myField' is read but has 'StrictUnusedVariable' suppressed because of its name.
    private final String _myField;
                         ^
```

See https://github.com/palantir/gradle-baseline/pull/2304/commits/a1b70a50a849b374bf590009c112265e09fb2525 https://app.circleci.com/pipelines/github/palantir/gradle-baseline/4165/workflows/756c72ee-8297-4da5-837a-40a3b010ad09/jobs/34598 for example of failing test before change.

## After this PR
==COMMIT_MSG==
Don't count identifier expressions as variable usages in `StrictUnusedVariable` check
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

