### PR TITLE
Promote ReturnsNullCollection and ReturnMissingNullable to error

### DIFF
--- a/changelog/@unreleased/pr-2307.v2.yml
+++ b/changelog/@unreleased/pr-2307.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Promote ReturnsNullCollection and ReturnMissingNullable to error
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2307

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -183,7 +183,9 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "JavaDurationGetSecondsGetNano",
                 "URLEqualsHashCode",
                 "BoxedPrimitiveEquality",
-                "ReferenceEquality");
+                "ReferenceEquality",
+                "ReturnMissingNullable",
+                "ReturnsNullCollection");
         // Relax some checks for test code
         if (errorProneOptions.getCompilingTestOnlyCode().get()) {
             errorProneOptions.disable("UnnecessaryLambda");


### PR DESCRIPTION
## Before this PR
We would not alter on null return values from methods. We generally though never return null values and it should be considered an error if one does so. Errorprone has checks for those but they're just suggestions

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Promote ReturnsNullCollection and ReturnMissingNullable to error
==COMMIT_MSG==

## Possible downsides?
The recommended resolution is to add Nullable while we would want the author to never return null

