### PR TITLE
[draft] PreferUnionSwitch

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferUnionSwitch.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferUnionSwitch.java
@@ -17,17 +17,22 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
-import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 import java.util.List;
 
 /**
@@ -66,13 +71,83 @@ public final class PreferUnionSwitch extends BugChecker implements MethodInvocat
         if (arguments.size() != 1) {
             return Description.NO_MATCH;
         }
-        // ExpressionTree onlyArgument = Iterables.getOnlyElement(arguments);
+        ExpressionTree onlyArgument = Iterables.getOnlyElement(arguments);
+        if (!(onlyArgument instanceof MethodInvocationTree)) {
+            return Description.NO_MATCH;
+        }
+        MethodInvocationTree visitorBuilder = (MethodInvocationTree) onlyArgument;
+
+        String[] parts = state.getSourceForNode(visitorBuilder).split("\\.");
+        if (parts.length == 0) {
+            return Description.NO_MATCH;
+        }
+        String unionName = parts[0];
+
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        StringBuilder replacementBuilder = new StringBuilder();
 
         String methodInvocation = state.getSourceForNode(tree.getMethodSelect());
         String receiverOnly = methodInvocation.replaceAll("\\.accept", "");
+        replacementBuilder.append(String.format("switch (%s) {", receiverOnly));
+
+        if (!iterateChain(state, replacementBuilder, unionName, visitorBuilder)) {
+            return Description.NO_MATCH;
+        }
+
+        replacementBuilder.append("}");
+        fix.replace(tree, replacementBuilder.toString());
 
         return buildDescription(tree)
-                .addFix(SuggestedFixes.replaceIncludingComments(state.getPath(), receiverOnly, state))
+                .setMessage("Prefer Java 17 switch")
+                .addFix(fix.build())
                 .build();
+    }
+
+    private static boolean iterateChain(
+            VisitorState state, StringBuilder replacementBuilder, String unionName, MethodInvocationTree tree) {
+        if (!(tree.getMethodSelect() instanceof MemberSelectTree)) {
+            return false;
+        }
+        MemberSelectTree memberSelect = (MemberSelectTree) tree.getMethodSelect();
+        if (memberSelect.getIdentifier().toString().equals("builder")) {
+            return true;
+        }
+        if (memberSelect.getExpression() instanceof MethodInvocationTree) {
+            if (!iterateChain(
+                    state, replacementBuilder, unionName, (MethodInvocationTree) memberSelect.getExpression())) {
+                return false;
+            }
+        }
+        if (!memberSelect.getIdentifier().toString().equals("build")) {
+            if (tree.getArguments().size() == 1) {
+                ExpressionTree argument = Iterables.getOnlyElement(tree.getArguments());
+
+                if (argument instanceof LambdaExpressionTree) {
+                    LambdaExpressionTree lambda = (LambdaExpressionTree) argument;
+
+                    if (lambda.getParameters().size() == 1) {
+                        VariableTree variable = Iterables.getOnlyElement(lambda.getParameters());
+                        Tree statement = lambda.getBody();
+
+                        replacementBuilder.append(String.format(
+                                "case %s.%s %s -> %s;",
+                                unionName,
+                                uppercase(memberSelect.getIdentifier().toString()),
+                                state.getSourceForNode(variable),
+                                state.getSourceForNode(statement)));
+                    } else {
+                        return false;
+                    }
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String uppercase(String name) {
+        String cleanName = name.endsWith("_") ? name.substring(0, name.length() - 1) : name;
+        return cleanName.substring(0, 1).toUpperCase() + cleanName.substring(1);
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferUnionSwitch.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferUnionSwitch.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.List;
+
+/**
+ * TODOs:
+ * - don't rewrite _all_ visitors, only those that are a sealed interface
+ * - visitor builders
+ * - anonymously defined visitor classes
+ *
+ * Things we probably can't solve:
+ * - if people have extended
+ * - functions returning visitors (e.g. all the utilities in Apollo) <- could lint against this?
+ */
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.WARNING,
+        summary = "Prefer switch expressions instead of manually constructed visitors for Conjure unions")
+public final class PreferUnionSwitch extends BugChecker implements MethodInvocationTreeMatcher {
+    private static final Matcher<ExpressionTree> ACCEPT_METHOD_MATCHER = Matchers.instanceMethod()
+            // only care about unions with the new 'sealed interface codegen'
+            .onClass((type, _state) -> {
+                // TODO(dfox): do we need to filter down to conjure-generated unions?
+                return type.isInterface();
+            })
+            // .anyClass()
+            .named("accept");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!ACCEPT_METHOD_MATCHER.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        List<? extends ExpressionTree> arguments = tree.getArguments();
+        if (arguments.size() != 1) {
+            return Description.NO_MATCH;
+        }
+        // ExpressionTree onlyArgument = Iterables.getOnlyElement(arguments);
+
+        String methodInvocation = state.getSourceForNode(tree.getMethodSelect());
+        String receiverOnly = methodInvocation.replaceAll("\\.accept", "");
+
+        return buildDescription(tree)
+                .addFix(SuggestedFixes.replaceIncludingComments(state.getPath(), receiverOnly, state))
+                .build();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferUnionSwitchTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferUnionSwitchTest.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.jupiter.api.Test;
+
+/** {@link com.palantir.baseline.errorprone.SampleConjureUnion}. */
+class PreferUnionSwitchTest {
+
+    /**
+     * Cases to test:
+     * - staged builders
+     * - non staged builders
+     * - visitor defined using anonymous class
+     * - throwOnUnknown
+     * - one line expressions (not involving the variable)
+     * - one line expressions (involving the variable)
+     * - multiline expressions including return keyword (replace with yield)
+     */
+
+    @Test
+    public void auto_fix_straightforward_lambdas() {
+        RefactoringValidator.of(PreferUnionSwitch.class, getClass())
+                .addInputLines(
+                        "Test.java",
+                        "import com.palantir.baseline.errorprone.SampleConjureUnion;",
+                        "class Test {",
+                        "public static boolean isAssetInfo(SampleConjureUnion myUnion) {",
+                        "    return myUnion.accept(SampleConjureUnion.Visitor.<Boolean>builder()",
+                        "            .bar(bar -> false)",
+                        "            .baz(baz -> false)",
+                        "            .foo(foo -> true)",
+                        "            .unknown(unknown -> false)",
+                        "            .build());",
+                        "}",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.baseline.errorprone.SampleConjureUnion;",
+                        "class Test {",
+                        "public static boolean isAssetInfo(SampleConjureUnion myUnion) {",
+                        "    return switch (myUnion) {",
+                        "        case SampleConjureUnion.Bar bar -> false;",
+                        "        case SampleConjureUnion.Baz baz -> false;",
+                        "        case SampleConjureUnion.Foo foo -> true;",
+                        "        case SampleConjureUnion.Unknown unknown -> false;",
+                        "    };",
+                        "}",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    // class Sample {
+    //     public static boolean isAssetInfo(SampleConjureUnion myUnion) {
+    //         return switch (myUnion) {
+    //             case SampleConjureUnion.Bar bar -> false;
+    //             case SampleConjureUnion.Baz baz -> false;
+    //             case SampleConjureUnion.Foo foo -> true;
+    //             case SampleConjureUnion.Unknown unknown -> false;
+    //         };
+    //     }
+    // }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferUnionSwitchTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferUnionSwitchTest.java
@@ -32,20 +32,19 @@ class PreferUnionSwitchTest {
      * - one line expressions (involving the variable)
      * - multiline expressions including return keyword (replace with yield)
      */
-
     @Test
     public void auto_fix_straightforward_lambdas() {
-        RefactoringValidator.of(PreferUnionSwitch.class, getClass())
+        RefactoringValidator.of(PreferUnionSwitch.class, getClass(), "--enable-preview", "--release=17")
                 .addInputLines(
                         "Test.java",
                         "import com.palantir.baseline.errorprone.SampleConjureUnion;",
                         "class Test {",
                         "public static boolean isAssetInfo(SampleConjureUnion myUnion) {",
                         "    return myUnion.accept(SampleConjureUnion.Visitor.<Boolean>builder()",
-                        "            .bar(bar -> false)",
-                        "            .baz(baz -> false)",
-                        "            .foo(foo -> true)",
-                        "            .unknown(unknown -> false)",
+                        "            .bar(_bar -> false)",
+                        "            .baz(_baz -> false)",
+                        "            .foo(_foo -> true)",
+                        "            .unknown(_unknown -> false)",
                         "            .build());",
                         "}",
                         "}")
@@ -55,10 +54,10 @@ class PreferUnionSwitchTest {
                         "class Test {",
                         "public static boolean isAssetInfo(SampleConjureUnion myUnion) {",
                         "    return switch (myUnion) {",
-                        "        case SampleConjureUnion.Bar bar -> false;",
-                        "        case SampleConjureUnion.Baz baz -> false;",
-                        "        case SampleConjureUnion.Foo foo -> true;",
-                        "        case SampleConjureUnion.Unknown unknown -> false;",
+                        "        case SampleConjureUnion.Bar _bar -> false;",
+                        "        case SampleConjureUnion.Baz _baz -> false;",
+                        "        case SampleConjureUnion.Foo _foo -> true;",
+                        "        case SampleConjureUnion.Unknown _unknown -> false;",
                         "    };",
                         "}",
                         "}")

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SampleConjureUnion.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SampleConjureUnion.java
@@ -1,0 +1,392 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.palantir.baseline.errorprone.SampleConjureUnion.Bar;
+import com.palantir.baseline.errorprone.SampleConjureUnion.Baz;
+import com.palantir.baseline.errorprone.SampleConjureUnion.Foo;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.palantir.conjure.java.types.UnionGenerator")
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "type",
+        visible = true,
+        defaultImpl = SampleConjureUnion.Unknown.class)
+@JsonSubTypes({@JsonSubTypes.Type(Foo.class), @JsonSubTypes.Type(Bar.class), @JsonSubTypes.Type(Baz.class)})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public sealed interface SampleConjureUnion {
+    static SampleConjureUnion foo(String value) {
+        return new Foo(value);
+    }
+
+    /**
+     * @deprecated Int is deprecated.
+     */
+    @Deprecated
+    static SampleConjureUnion bar(int value) {
+        return new Bar(value);
+    }
+
+    /**
+     * 64-bit integer.
+     * @deprecated Prefer <code>foo</code>.
+     */
+    @Deprecated
+    static SampleConjureUnion baz(long value) {
+        return new Baz(value);
+    }
+
+    static SampleConjureUnion unknown(@Safe String type, Object value) {
+        switch (Preconditions.checkNotNull(type, "Type is required")) {
+            case "foo":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: foo");
+            case "bar":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: bar");
+            case "baz":
+                throw new SafeIllegalArgumentException(
+                        "Unknown type cannot be created as the provided type is known: baz");
+            default:
+                return new Unknown(type, Collections.singletonMap(type, value));
+        }
+    }
+
+    default Known throwOnUnknown() {
+        if (this instanceof Unknown) {
+            throw new SafeIllegalArgumentException(
+                    "Unknown variant of the 'Union' union", SafeArg.of("type", ((Unknown) this).getType()));
+        } else {
+            return (Known) this;
+        }
+    }
+
+    <T> T accept(Visitor<T> visitor);
+
+    sealed interface Known permits Foo, Bar, Baz {}
+
+    @JsonTypeName("foo")
+    record Foo(String value) implements SampleConjureUnion, Known {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public Foo(@JsonSetter("foo") @Nonnull String value) {
+            Preconditions.checkNotNull(value, "foo cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "foo";
+        }
+
+        @JsonProperty("foo")
+        private String getValue() {
+            return value;
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitFoo(value);
+        }
+
+        @Override
+        public String toString() {
+            return "Foo{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("bar")
+    record Bar(int value) implements SampleConjureUnion, Known {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public Bar(@JsonSetter("bar") @Nonnull int value) {
+            Preconditions.checkNotNull(value, "bar cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "bar";
+        }
+
+        @JsonProperty("bar")
+        private int getValue() {
+            return value;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBar(value);
+        }
+
+        @Override
+        public String toString() {
+            return "Bar{value: " + value + '}';
+        }
+    }
+
+    @JsonTypeName("baz")
+    record Baz(long value) implements SampleConjureUnion, Known {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public Baz(@JsonSetter("baz") @Nonnull long value) {
+            Preconditions.checkNotNull(value, "baz cannot be null");
+            this.value = value;
+        }
+
+        @JsonProperty(value = "type", index = 0)
+        private String getType() {
+            return "baz";
+        }
+
+        @JsonProperty("baz")
+        private long getValue() {
+            return value;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitBaz(value);
+        }
+
+        @Override
+        public String toString() {
+            return "Baz{value: " + value + '}';
+        }
+    }
+
+    final class Unknown implements SampleConjureUnion {
+        private final String type;
+
+        private final Map<String, Object> value;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        private Unknown(@JsonProperty("type") String type) {
+            this(type, new HashMap<String, Object>());
+        }
+
+        private Unknown(@Nonnull String type, @Nonnull Map<String, Object> value) {
+            Preconditions.checkNotNull(type, "type cannot be null");
+            Preconditions.checkNotNull(value, "value cannot be null");
+            this.type = type;
+            this.value = value;
+        }
+
+        @JsonProperty
+        private String getType() {
+            return type;
+        }
+
+        @JsonAnyGetter
+        private Map<String, Object> getValue() {
+            return value;
+        }
+
+        @JsonAnySetter
+        private void put(String key, Object val) {
+            value.put(key, val);
+        }
+
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return visitor.visitUnknown(type, value.get(type));
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || (other instanceof Unknown && equalTo((Unknown) other));
+        }
+
+        private boolean equalTo(Unknown other) {
+            return this.type.equals(other.type) && this.value.equals(other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 1;
+            hash = 31 * hash + this.type.hashCode();
+            hash = 31 * hash + this.value.hashCode();
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return "Unknown{type: " + type + ", value: " + value + '}';
+        }
+    }
+
+    interface Visitor<T> {
+        T visitFoo(String value);
+
+        /**
+         * @deprecated Int is deprecated.
+         */
+        @Deprecated
+        T visitBar(int value);
+
+        /**
+         * 64-bit integer.
+         * @deprecated Prefer <code>foo</code>.
+         */
+        @Deprecated
+        T visitBaz(long value);
+
+        T visitUnknown(@Safe String unknownType, Object unknownValue);
+
+        /**
+         * @Deprecated - prefer Java 17 pattern matching switch expressions.
+         */
+        @Deprecated
+        static <T> BarStageVisitorBuilder<T> builder() {
+            return new VisitorBuilder<T>();
+        }
+    }
+
+    final class VisitorBuilder<T>
+            implements BarStageVisitorBuilder<T>,
+            BazStageVisitorBuilder<T>,
+            FooStageVisitorBuilder<T>,
+            UnknownStageVisitorBuilder<T>,
+            Completed_StageVisitorBuilder<T> {
+        private IntFunction<T> barVisitor;
+
+        private Function<Long, T> bazVisitor;
+
+        private Function<String, T> fooVisitor;
+
+        private BiFunction<@Safe String, Object, T> unknownVisitor;
+
+        @Override
+        public BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor) {
+            Preconditions.checkNotNull(barVisitor, "barVisitor cannot be null");
+            this.barVisitor = barVisitor;
+            return this;
+        }
+
+        @Override
+        public FooStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor) {
+            Preconditions.checkNotNull(bazVisitor, "bazVisitor cannot be null");
+            this.bazVisitor = bazVisitor;
+            return this;
+        }
+
+        @Override
+        public UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor) {
+            Preconditions.checkNotNull(fooVisitor, "fooVisitor cannot be null");
+            this.fooVisitor = fooVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = unknownVisitor;
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor) {
+            Preconditions.checkNotNull(unknownVisitor, "unknownVisitor cannot be null");
+            this.unknownVisitor = (unknownType, _unknownValue) -> unknownVisitor.apply(unknownType);
+            return this;
+        }
+
+        @Override
+        public Completed_StageVisitorBuilder<T> throwOnUnknown() {
+            this.unknownVisitor = (unknownType, _unknownValue) -> {
+                throw new SafeIllegalArgumentException(
+                        "Unknown variant of the 'SampleConjureUnion' union", SafeArg.of("unknownType", unknownType));
+            };
+            return this;
+        }
+
+        @Override
+        public Visitor<T> build() {
+            final IntFunction<T> barVisitor = this.barVisitor;
+            final Function<Long, T> bazVisitor = this.bazVisitor;
+            final Function<String, T> fooVisitor = this.fooVisitor;
+            final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
+            return new Visitor<T>() {
+                @Override
+                public T visitBar(int value) {
+                    return barVisitor.apply(value);
+                }
+
+                @Override
+                public T visitBaz(long value) {
+                    return bazVisitor.apply(value);
+                }
+
+                @Override
+                public T visitFoo(String value) {
+                    return fooVisitor.apply(value);
+                }
+
+                @Override
+                public T visitUnknown(String unknownType, Object unknownValue) {
+                    return unknownVisitor.apply(unknownType, unknownValue);
+                }
+            };
+        }
+    }
+
+    interface BarStageVisitorBuilder<T> {
+        BazStageVisitorBuilder<T> bar(@Nonnull IntFunction<T> barVisitor);
+    }
+
+    interface BazStageVisitorBuilder<T> {
+        FooStageVisitorBuilder<T> baz(@Nonnull Function<Long, T> bazVisitor);
+    }
+
+    interface FooStageVisitorBuilder<T> {
+        UnknownStageVisitorBuilder<T> foo(@Nonnull Function<String, T> fooVisitor);
+    }
+
+    interface UnknownStageVisitorBuilder<T> {
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull BiFunction<@Safe String, Object, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> unknown(@Nonnull Function<@Safe String, T> unknownVisitor);
+
+        Completed_StageVisitorBuilder<T> throwOnUnknown();
+    }
+
+    interface Completed_StageVisitorBuilder<T> {
+        Visitor<T> build();
+    }
+}
+

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SampleConjureUnion.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SampleConjureUnion.java
@@ -16,15 +16,7 @@
 
 package com.palantir.baseline.errorprone;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.*;
 import com.palantir.baseline.errorprone.SampleConjureUnion.Bar;
 import com.palantir.baseline.errorprone.SampleConjureUnion.Baz;
 import com.palantir.baseline.errorprone.SampleConjureUnion.Foo;
@@ -32,14 +24,15 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
-import javax.annotation.Generated;
-import javax.annotation.Nonnull;
 
 @Generated("com.palantir.conjure.java.types.UnionGenerator")
 @JsonTypeInfo(
@@ -208,7 +201,7 @@ public sealed interface SampleConjureUnion {
         }
 
         @JsonProperty
-        private String getType() {
+        public String getType() {
             return type;
         }
 
@@ -279,10 +272,10 @@ public sealed interface SampleConjureUnion {
 
     final class VisitorBuilder<T>
             implements BarStageVisitorBuilder<T>,
-            BazStageVisitorBuilder<T>,
-            FooStageVisitorBuilder<T>,
-            UnknownStageVisitorBuilder<T>,
-            Completed_StageVisitorBuilder<T> {
+                    BazStageVisitorBuilder<T>,
+                    FooStageVisitorBuilder<T>,
+                    UnknownStageVisitorBuilder<T>,
+                    Completed_StageVisitorBuilder<T> {
         private IntFunction<T> barVisitor;
 
         private Function<Long, T> bazVisitor;
@@ -389,4 +382,3 @@ public sealed interface SampleConjureUnion {
         Visitor<T> build();
     }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,6 @@ allprojects {
 }
 
 javaVersions {
-    libraryTarget = 11
-    runtime = 15
+    libraryTarget = 17
+    runtime = 17
 }


### PR DESCRIPTION
## Before this PR

As per the #hackweek-2022-sealed-unions channel, I'm trying to replace conjure visitors with Java 17 pattern-matching-switch expressions.

I've got the codegen up at https://github.com/palantir/conjure-java/pull/1838, but I want to automate the toil of replacing these visitors with switch expressions everywhere.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

