### PR TITLE
fix #2328 Handle safety flow through instanceof pattern matching

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -3,6 +3,11 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 apply plugin: 'java-library'
 apply plugin: 'com.palantir.external-publish-jar'
 
+javaVersions {
+    libraryTarget = 11
+    runtime = 17
+}
+
 dependencies {
     implementation 'com.google.errorprone:error_prone_core'
     // Ensure a new enough version of dataflow-errorprone is available

--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -3,8 +3,8 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 apply plugin: 'java-library'
 apply plugin: 'com.palantir.external-publish-jar'
 
-javaVersions {
-    libraryTarget = 11
+javaVersion {
+    target = 11
     runtime = 17
 }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -211,7 +211,7 @@ class SafeLoggingPropagationTest {
 
     @Test
     void testRecordWithUnsafeTypes() {
-        fix("--release", "15", "--enable-preview")
+        fix("--release", "17")
                 .addInputLines(
                         "Test.java",
                         "import com.palantir.tokens.auth.*;",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -314,10 +314,10 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
-    @DisabledForJreRange(max = JRE.JAVA_13)
+    @DisabledForJreRange(max = JRE.JAVA_16)
     public void testRecord() {
         compilationHelper = CompilationTestHelper.newInstance(StrictUnusedVariable.class, getClass())
-                .setArgs("--enable-preview", "--release", "15");
+                .setArgs("--release", "17");
 
         compilationHelper
                 .addSourceLines("Test.java", "class Test {", "  record Foo(int bar) {}", "}")

--- a/baseline-refaster-rules/build.gradle
+++ b/baseline-refaster-rules/build.gradle
@@ -34,4 +34,5 @@ moduleJvmArgs {
             'jdk.compiler/com.sun.tools.javac.tree',
             'jdk.compiler/com.sun.tools.javac.util'
     ]
+    opens = ['jdk.compiler/com.sun.tools.javac.comp']
 }

--- a/changelog/@unreleased/pr-2331.v2.yml
+++ b/changelog/@unreleased/pr-2331.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle safety flow through instanceof pattern matching
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2331


### PR DESCRIPTION
==COMMIT_MSG==
Handle safety flow through instanceof pattern matching
==COMMIT_MSG==
