### PR TITLE
Fix BaselineModuleJvmArgs with enable-preview functionality

### DIFF
--- a/changelog/@unreleased/pr-2336.v2.yml
+++ b/changelog/@unreleased/pr-2336.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix the `BaselineModuleJvmArgs` plugin to once again work as intended
+    in multi-project builds
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2336

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.baseline.extensions.BaselineModuleJvmArgsExtension;
 import com.palantir.baseline.plugins.javaversions.BaselineJavaVersion;
-import com.palantir.baseline.plugins.javaversions.BaselineJavaVersionsExtension;
+import com.palantir.baseline.plugins.javaversions.BaselineJavaVersionExtension;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -225,8 +225,8 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
 
             // Derive this plugin's `enablePreview` property from BaselineJavaVersion's extension
             project.getPlugins().withType(BaselineJavaVersion.class, _unused -> {
-                BaselineJavaVersionsExtension javaVersionsExtension =
-                        project.getExtensions().getByType(BaselineJavaVersionsExtension.class);
+                BaselineJavaVersionExtension javaVersionsExtension =
+                        project.getExtensions().getByType(BaselineJavaVersionExtension.class);
                 extension.setEnablePreview(javaVersionsExtension.runtime().map(chosenJavaVersion -> {
                     return chosenJavaVersion.enablePreview()
                             ? Optional.of(chosenJavaVersion.javaLanguageVersion())


### PR DESCRIPTION
## Before this PR

I just tried to apply baseline 4.149.0 to template-witchcraft to try out my newly merged `--enable-preview` stuff from https://github.com/palantir/gradle-baseline/pull/2322, but found a BUG:

```
./gradlew tasks         

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* Where:
Build file '/Volumes/git/template-witchcraft/build.gradle' line: 62

* What went wrong:
A problem occurred evaluating root project 'witchcraft-example-root'.
> Failed to apply plugin class 'com.palantir.baseline.plugins.javaversions.BaselineJavaVersion'.
   > Extension of type 'BaselineJavaVersionsExtension' does not exist. Currently registered extension types: [ExtraPropertiesExtension, JunitTaskResultExtension, ReportingExtension, CheckstyleExtension, IdeaModel, BasePluginExtension, DefaultArtifactPublicationSet, SpotlessExtension, VersionsLockExtension, SourceSetContainer, JavaPluginExtension, JavaToolchainService, TestingExtension, EclipseModel, BaselineErrorProneExtension, BaselineModuleJvmArgsExtension, BaselineJavaVersionExtension]
```

Turns out the tests I added were all _single project tests_ and this obscured a mistake whereby multi-project builds would fail.

## After this PR
==COMMIT_MSG==
Fix the `BaselineModuleJvmArgs` plugin to once again work as intended in multi-project builds
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

