### PR TITLE
Fix javadoc when enable preview flag is added

### DIFF
--- a/changelog/@unreleased/pr-2338.v2.yml
+++ b/changelog/@unreleased/pr-2338.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: javadoc tasks are now properly configured when `--enable-preview` is
+    used
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2338

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -114,7 +114,6 @@ public final class BaselineJavaVersion implements Plugin<Project> {
         project.getTasks().withType(Javadoc.class).configureEach(new Action<Javadoc>() {
             @Override
             public void execute(Javadoc javadocTask) {
-
                 javadocTask.getJavadocTool().set(javaToolchain.flatMap(BaselineJavaToolchain::javadocTool));
 
                 // javadocTask doesn't allow us to add a CommandLineArgumentProvider, so we do it just in time
@@ -125,7 +124,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                         if (target.get().enablePreview()) {
                             // yes, javadoc truly takes a single-dash where everyone else takes a double dash
                             options.addBooleanOption("-enable-preview", true);
-                            // options.setSource(target.get().javaLanguageVersion().toString());
+                            options.setSource(target.get().javaLanguageVersion().toString());
                         }
                     }
                 });

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -114,6 +114,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
         project.getTasks().withType(Javadoc.class).configureEach(new Action<Javadoc>() {
             @Override
             public void execute(Javadoc javadocTask) {
+
                 javadocTask.getJavadocTool().set(javaToolchain.flatMap(BaselineJavaToolchain::javadocTool));
 
                 // javadocTask doesn't allow us to add a CommandLineArgumentProvider, so we do it just in time
@@ -124,6 +125,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                         if (target.get().enablePreview()) {
                             // yes, javadoc truly takes a single-dash where everyone else takes a double dash
                             options.addBooleanOption("-enable-preview", true);
+                            // options.setSource(target.get().javaLanguageVersion().toString());
                         }
                     }
                 });

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -147,6 +147,20 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, ENABLE_PREVIEW_BYTECODE)
     }
 
+    def 'java 17 preview javadoc works'() {
+        when:
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 11
+            distributionTarget = '17_PREVIEW'
+        }
+        '''.stripIndent(true)
+        file('src/main/java/Main.java') << java17PreviewCode
+
+        then:
+        runTasksSuccessfully('javadoc', '-i')
+    }
+
     def 'library target is used when no artifacts are published but project is overridden as a library'() {
         when:
         buildFile << '''


### PR DESCRIPTION
## Before this PR

We'd successfully add the `-enable-preview` flag to the `javadoc` task, but since we don't have the `-source` or `--release` flags, it fails with the following:

```
> Task :witchcraft-example-api:witchcraft-example-api-undertow:javadoc FAILED
error: --enable-preview must be used with either -source or --release
1 error
```

We did not have an automated test that actually invokes `javadoc`, hence why this bug slipped in.

## After this PR
==COMMIT_MSG==
javadoc tasks are now properly configured when `--enable-preview` is used
==COMMIT_MSG==

We now have a failing test that runs javadoc, and the last commit fixes it!

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

