### PR TITLE
Update error-prone configuration for gradle 7 up-to-date correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,11 @@ Error-prone rules can be suppressed on a per-line or per-block basis just like C
 Rules can be suppressed at the project level, or have their severity modified, by adding the following to the project's `build.gradle`:
 
 ```gradle
-tasks.withType(JavaCompile).configureEach {
-    options.errorprone.disable 'Slf4jLogsafeArgs'
-}
+tasks.withType(JavaCompile).configureEach(new Action<Task>() {
+    public void execute(Task task) {
+        task.options.errorprone.disable 'Slf4jLogsafeArgs'
+    }
+})
 ```
 
 More information on error-prone severity handling can be found at [errorprone.info/docs/flags](http://errorprone.info/docs/flags).


### PR DESCRIPTION
## Before this PR
The suggested error-prone configuration syntax results in tasks never being up-to-date in gradle 7+

## After this PR
Swapping from lambda notation to an explicit interface implementation causes these tasks to be correctly considered up-to-date, following the instructions from https://docs.gradle.org/current/userguide/validation_problems.html#implementation_unknown

==COMMIT_MSG==

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

