### PR TITLE
Set the java launcher for Checkstyle tasks, too

### DIFF
--- a/changelog/@unreleased/pr-2351.v2.yml
+++ b/changelog/@unreleased/pr-2351.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Set the java launcher for Checkstyle tasks, too
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2351

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -132,6 +132,13 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             }
         });
 
+        project.getTasks().withType(Checkstyle.class).configureEach(new Action<Checkstyle>() {
+            @Override
+            public void execute(Checkstyle checkstyle) {
+                checkstyle.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
+            }
+        });
+
         project.getTasks().withType(GroovyCompile.class).configureEach(new Action<GroovyCompile>() {
             @Override
             public void execute(GroovyCompile groovyCompileTask) {
@@ -178,13 +185,6 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             @Override
             public void execute(ScalaDoc scalaDoc) {
                 scalaDoc.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
-            }
-        });
-
-        project.getTasks().withType(Checkstyle.class).configureEach(new Action<Checkstyle>() {
-            @Override
-            public void execute(Checkstyle checkstyle) {
-                checkstyle.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
             }
         });
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -25,6 +25,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.CacheableTask;
@@ -196,6 +197,13 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             public void execute(Test test) {
                 test.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
                 test.getJvmArgumentProviders().add(new EnablePreviewArgumentProvider(runtime));
+            }
+        });
+
+        project.getTasks().withType(Checkstyle.class).configureEach(new Action<Checkstyle>() {
+            @Override
+            public void execute(Checkstyle checkstyle) {
+                checkstyle.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
             }
         });
     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -180,6 +180,13 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                 scalaDoc.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
             }
         });
+
+        project.getTasks().withType(Checkstyle.class).configureEach(new Action<Checkstyle>() {
+            @Override
+            public void execute(Checkstyle checkstyle) {
+                checkstyle.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
+            }
+        });
     }
 
     private static void configureExecutionTasks(
@@ -197,13 +204,6 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             public void execute(Test test) {
                 test.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
                 test.getJvmArgumentProviders().add(new EnablePreviewArgumentProvider(runtime));
-            }
-        });
-
-        project.getTasks().withType(Checkstyle.class).configureEach(new Action<Checkstyle>() {
-            @Override
-            public void execute(Checkstyle checkstyle) {
-                checkstyle.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
             }
         });
     }


### PR DESCRIPTION
The gradle-jdks plugin aims to download JDKs from a source and use them
at runtime. In theory, this means that in order to develop using such a
library, one only needs a JDK installed that can run Gradle (there are
some limitations but this is the theory).

Inside the Checkstyle task is a Java launcher property. When this is
resolved, it will query the Java version service, which will query
the configured JDKs. This means that the baseline-java-versions
configured JDK is not used, and if the gradle-jdks approach is used, the
Checkstyle task will fail.

I _think_ that this change is enough to correctly override the Java
launcher used.

Fixes https://github.com/palantir/gradle-jdks/issues/93