### PR TITLE
Don't apply JUnit reports plugin by default

### DIFF
--- a/changelog/@unreleased/pr-2355.v2.yml
+++ b/changelog/@unreleased/pr-2355.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The JUnits reports plugin is no longer applied by default. Test reports
+    now use the standard output locations from Gradle conventions.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2355

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
@@ -19,8 +19,6 @@ package com.palantir.baseline.plugins;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.palantir.gradle.junit.JunitReportsExtension;
-import com.palantir.gradle.junit.JunitReportsPlugin;
-import com.palantir.gradle.junit.JunitReportsRootPlugin;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -40,9 +38,6 @@ public final class BaselineCircleCi implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPluginManager().apply(JunitReportsRootPlugin.class);
-        project.getPluginManager().apply(JunitReportsPlugin.class);
-
         configurePluginsForReports(project);
         configurePluginsForArtifacts(project);
 
@@ -84,9 +79,20 @@ public final class BaselineCircleCi implements Plugin<Project> {
             throw new RuntimeException("failed to create CIRCLE_TEST_REPORTS directory", e);
         }
 
-        project.getExtensions().configure(JunitReportsExtension.class, junitReports -> junitReports
-                .getReportsDirectory()
-                .set(new File(circleReportsDir)));
+        project.getRootProject()
+                .allprojects(proj -> proj.getTasks().withType(Test.class).configureEach(test -> {
+                    test.getReports().getJunitXml().getRequired().set(true);
+                    test.getReports()
+                            .getJunitXml()
+                            .getOutputLocation()
+                            .set(junitPath(circleReportsDir, test.getPath()));
+                }));
+
+        project.getPluginManager().withPlugin("com.palantir.junit-reports", unused -> {
+            project.getExtensions().configure(JunitReportsExtension.class, junitReports -> junitReports
+                    .getReportsDirectory()
+                    .set(new File(circleReportsDir)));
+        });
     }
 
     private static File junitPath(String basePath, String testPath) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineCircleCiJavaIntegrationTests.java
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineCircleCiJavaIntegrationTests.java
@@ -54,34 +54,6 @@ public class BaselineCircleCiJavaIntegrationTests {
     }
 
     @Test
-    public void javacIntegrationTest() throws IOException {
-        copyTestFile("non-compiling-class", projectDir, "src/main/java/com/example/MyClass.java");
-
-        BuildResult result = GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(projectDir.getRoot())
-                .withArguments("--stacktrace", "compileJava")
-                .buildAndFail();
-        assertThat(result.getOutput())
-                .contains("Compilation failed")
-                .contains("error: incompatible types")
-                .contains("private final int a")
-                .contains("error: cannot assign a value to final variable b")
-                .contains("b = 2")
-                .contains("uses unchecked or unsafe operations");
-
-        File report = new File(reportsDir, "/foobar-compileJava.xml");
-        assertThat(report).exists();
-        String reportXml = Files.asCharSource(report, StandardCharsets.UTF_8).read();
-        assertThat(reportXml)
-                .contains("incompatible types")
-                .contains("private final int a")
-                .contains("cannot assign a value to final variable b")
-                .contains("b = 2")
-                .doesNotContain("uses unchecked or unsafe operations");
-    }
-
-    @Test
     public void junitIntegrationTest() throws IOException {
         copyTestFile("tested-class", projectDir, "src/main/java/com/example/MyClass.java");
         copyTestFile("tested-class-tests", projectDir, "src/test/java/com/example/MyClassTests.java");
@@ -121,57 +93,6 @@ public class BaselineCircleCiJavaIntegrationTests {
                 .contains("tests=\"2\"")
                 .contains("failures=\"1\"")
                 .contains("org.junit.ComparisonFailure");
-    }
-
-    @Test
-    public void checkstyleIntegrationTest() throws IOException {
-        copyTestFile("checkstyle-violating-class", projectDir, "src/main/java/com/example/MyClass.java");
-
-        BuildResult result = GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(projectDir.getRoot())
-                .withArguments("--stacktrace", "checkstyleMain")
-                .buildAndFail();
-        assertThat(result.getOutput()).contains("Checkstyle rule violations were found");
-
-        File report = new File(reportsDir, "foobar-checkstyleMain.xml");
-        assertThat(report).exists();
-        String reportXml = Files.asCharSource(report, StandardCharsets.UTF_8).read();
-        assertThat(reportXml).contains("Name 'a_constant' must match pattern");
-    }
-
-    @Test
-    public void buildStepFailureIntegrationTest() throws IOException {
-        BuildResult result = GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(projectDir.getRoot())
-                .withArguments("--stacktrace", "failingTask")
-                .buildAndFail();
-        assertThat(result.getOutput()).contains("This task will always fail");
-
-        File report = new File(reportsDir, "gradle/build.xml");
-        assertThat(report).exists();
-        String reportXml = Files.asCharSource(report, StandardCharsets.UTF_8).read();
-        assertThat(reportXml).contains("message=\"RuntimeException: This task will always fail\"");
-    }
-
-    @Test
-    public void findsUniqueBuildStepsReportFileName() throws IOException {
-        assertThat(new File(reportsDir, "gradle").mkdirs()).isTrue();
-        assertThat(new File(reportsDir, "gradle/build.xml").createNewFile()).isTrue();
-        assertThat(new File(reportsDir, "gradle/build2.xml").createNewFile()).isTrue();
-
-        BuildResult result = GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(projectDir.getRoot())
-                .withArguments("--stacktrace", "failingTask")
-                .buildAndFail();
-        assertThat(result.getOutput()).contains("This task will always fail");
-
-        File report = new File(reportsDir, "gradle/build3.xml");
-        assertThat(report).exists();
-        String reportXml = Files.asCharSource(report, StandardCharsets.UTF_8).read();
-        assertThat(reportXml).contains("message=\"RuntimeException: This task will always fail\"");
     }
 
     @Test

--- a/gradle-junit-reports/src/main/resources/META-INF/gradle-plugins/com.palantir.junit-reports.properties
+++ b/gradle-junit-reports/src/main/resources/META-INF/gradle-plugins/com.palantir.junit-reports.properties
@@ -1,1 +1,1 @@
-implementation-class=com.palantir.gradle.junit.JunitReportsPlugin
+implementation-class=com.palantir.gradle.junit.JunitReportsRootPlugin


### PR DESCRIPTION
The JUnit reports plugin has a couple of problems.

## It creates test reports for Gradle tasks

This is very strange. Test reports are intended to be for tests, not for arbitrary tasks. This is confusing in other services that integrate with Gradle test reports (like CircleCI) because it appears that tests have failed when they haven't.

In addition, this causing confusing output when tests are sharded across multiple CI nodes. For true test failures, the failure is only reported once (by the node that ran the test). But Gradle task failures are reported by every node. This leads to confusing output as shown in the screenshot below. We have 5 CI nodes and these errors are reported 5 times (the screenshot just shows 2).

<img src="https://user-images.githubusercontent.com/5273164/183766639-1f1b67ce-937f-4126-96da-8716da348018.png" width="400">

This also creates a ton of garbage output locally. The `build.xml` files are never deleted and this plugin just happily keeps adding 1 until it finds a file name that doesn't exist. Here's an example from one of my local projects:

![Screen Shot 2022-08-09 at 2 53 50 PM](https://user-images.githubusercontent.com/5273164/183768831-ee035054-abf2-4dde-9fac-a94b07a5dce1.png)

## It stores test reports in a non-standard place

By default Gradle puts test reports in the following places:
- JUnit XML test reports in `{projectDir}/build/test-results/test`
- HTML test reports in `{projectDir}/build/reports/tests/test`

But the test reporting plugin moves the JUnit XML test reports to the root project in a custom directory:
- **JUnit XML test reports in `{rootProjectDir}/build/junit-reports/junit/{projectName}/test`**
- HTML test reports in `{projectDir}/build/reports/tests/test`

There's no good reason to do this. It just makes it hard for devs to understand how our infrastructure works. This is especially confusing because documentation for other tools often references the standard behavior. For example, in the [CircleCI docs](https://circleci.com/docs/collect-test-data#gradle-junit-test-results).

---

I don't anticipate this being a disruptive change for a couple reasons:
- Our standard CircleCI configs look for files using the regex `.*/build/.*TEST.*xml`, which will find JUnit XML test reports even in the standard output location.
- No one appears to be using custom report. Searching internally for the `junitReports` or `junitTaskResults` Gradle extension config, I find just a single use.

I'm strongly inclined to just remove this JUnit reporting plugin altogether. It appears to be wildly over-engineered to support arbitrary/custom reports, unnecessarily messes with standard Gradle conventions, and is confusingly called "junit reports" even though these reports are definitely not related to JUnit.

