### PR TITLE
Disable CanIgnoreReturnValueSuggester

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -170,6 +170,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         errorProneOptions.disable(
                 "AutoCloseableMustBeClosed",
                 "CatchSpecificity",
+                "CanIgnoreReturnValueSuggester",
                 "InlineMeSuggester",
                 "PreferImmutableStreamExCollections",
                 "UnusedVariable",


### PR DESCRIPTION
This was added in https://github.com/palantir/gradle-baseline/pull/2352 and is blocking baseline upgrades in most of our repos.

We did a similar thing for `InlineMeSuggester` in https://github.com/palantir/gradle-baseline/pull/1775.