### PR TITLE
Update minimum required Gradle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See also the [Baseline Java Style Guide and Best Practices](./docs).
 
 
 ## Usage
-The baseline set of plugins requires at least Gradle 6.1.
+The baseline set of plugins requires at least Gradle 7.5.
 
 It is recommended to add `apply plugin: 'com.palantir.baseline'` to your root project's build.gradle.  Individual plugins will be automatically applied to appropriate subprojects.
 


### PR DESCRIPTION
See https://github.com/palantir/gradle-baseline/pull/2351#issuecomment-1211113305

Not sure if we'd rather bump the version of revert the change. We likely have quite a few internal repos that are not yet on Gradle 7.5.