### PR TITLE
Fix BaselineJavaVersion checkstyle configuration on gradle < 7.5

### DIFF
--- a/changelog/@unreleased/pr-2360.v2.yml
+++ b/changelog/@unreleased/pr-2360.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix BaselineJavaVersion checkstyle configuration on gradle < 7.5
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2360

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.external.javadoc.CoreJavadocOptions;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.util.GradleVersion;
 
 public final class BaselineJavaVersion implements Plugin<Project> {
 
@@ -132,12 +133,15 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             }
         });
 
-        project.getTasks().withType(Checkstyle.class).configureEach(new Action<Checkstyle>() {
-            @Override
-            public void execute(Checkstyle checkstyle) {
-                checkstyle.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
-            }
-        });
+        // checkstyle.getJavaLauncher() was added in Gradle 7.5
+        if (GradleVersion.current().compareTo(GradleVersion.version("7.5")) >= 0) {
+            project.getTasks().withType(Checkstyle.class).configureEach(new Action<Checkstyle>() {
+                @Override
+                public void execute(Checkstyle checkstyle) {
+                    checkstyle.getJavaLauncher().set(javaToolchain.flatMap(BaselineJavaToolchain::javaLauncher));
+                }
+            });
+        }
 
         project.getTasks().withType(GroovyCompile.class).configureEach(new Action<GroovyCompile>() {
             @Override


### PR DESCRIPTION
==COMMIT_MSG==
Fix BaselineJavaVersion checkstyle configuration on gradle < 7.5
==COMMIT_MSG==

