### PR TITLE
Make baseline-exact-dependencies compatible with configure-on-demand

### DIFF
--- a/changelog/@unreleased/pr-2363.v2.yml
+++ b/changelog/@unreleased/pr-2363.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Make the `checkUnusedDependencies` tasks added by `baseline-exact-dependencies`
+    compatible with Gradle's configure-on-demand feature.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2363

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -181,7 +181,11 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         explicitCompile
                 .getIncoming()
                 .beforeResolve(ir -> Preconditions.checkState(
-                        projectsEvaluated.get(), "Tried to resolve %s too early.", explicitCompile));
+                        projectsEvaluated.get()
+                                || (project.getGradle().getStartParameter().isConfigureOnDemand()
+                                        && project.getState().getExecuted()),
+                        "Tried to resolve %s too early.",
+                        explicitCompile));
 
         TaskProvider<CheckUnusedDependenciesTask> sourceSetUnusedDependencies = project.getTasks()
                 .register(


### PR DESCRIPTION
## Before this PR
With configure-on-demand enabled, these configurations get resolved
before projectsEvaluated triggers are run. (I haven't dug in fully,
but I think this is happening during task graph expansion.)

Make this check more lenient if configure-on-demand is enabled.

## After this PR
==COMMIT_MSG==
Make the `checkUnusedDependencies` tasks added by `baseline-exact-dependencies` compatible with Gradle's configure-on-demand feature.
==COMMIT_MSG==

## Possible downsides?
Unlikely