### PR TITLE
Apply more task config laziness to gradle-junit-reports

### DIFF
--- a/changelog/@unreleased/pr-2364.v2.yml
+++ b/changelog/@unreleased/pr-2364.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make task initialization lazier in the `junit-reports` plugin.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2364

--- a/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsPlugin.java
+++ b/gradle-junit-reports/src/main/java/com/palantir/gradle/junit/JunitReportsPlugin.java
@@ -43,12 +43,12 @@ public final class JunitReportsPlugin implements Plugin<Project> {
                     .fileProvider(junitPath(rootExt.getReportsDirectory(), test.getPath()));
         });
 
-        project.getTasks().withType(Checkstyle.class, checkstyle -> {
+        project.getTasks().withType(Checkstyle.class).configureEach(checkstyle -> {
             ext.registerTask(
                     checkstyle.getName(), XmlReportFailuresSupplier.create(checkstyle, new CheckstyleReportHandler()));
         });
 
-        project.getTasks().withType(JavaCompile.class, javac -> {
+        project.getTasks().withType(JavaCompile.class).configureEach(javac -> {
             ext.registerTask(javac.getName(), JavacFailuresSupplier.create(javac));
         });
 


### PR DESCRIPTION
## Before this PR
Applying the junit-reports plugin always causes JavaCompile and Checkstyle tasks to get instantiated.

## After this PR
==COMMIT_MSG==
Make task initialization lazier in the `junit-reports` plugin.
==COMMIT_MSG==

## Possible downsides?
None

