### PR TITLE
Remove CyclomaticComplexity checks

### DIFF
--- a/changelog/@unreleased/pr-2365.v2.yml
+++ b/changelog/@unreleased/pr-2365.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `CyclomaticComplexity` checkstyle check is no longer enabled by
+    default.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2365

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -420,7 +420,6 @@
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
-        <module name="CyclomaticComplexity"/> <!-- Java Coding Guidelines: Reduce Cyclomatic Complexity -->
         <module name="DesignForExtension"> <!-- Java Coding Guidelines: Design for extension -->
             <property name="ignoredAnnotations" value="ParameterizedTest, Test, Before, BeforeEach, After, AfterEach, BeforeClass, BeforeAll, AfterClass, AfterAll"/>
         </module>


### PR DESCRIPTION
This check is almost always a false positive that is blindly suppressed.

Here are some common examples of code that adheres to good design patterns and is conceptually simple, but has high cyclomatic complexity. I routinely find code like this that triggers the `CyclomaticComplexity` check.
- A method with many if-return blocks

    ```java
    String foo = getFoo();
    if (foo == nul) {
        return foo;
    }
    
    Bar bar = getBar(foo);
    if (bar == null) {
        return;
    }
    
    ...
    ```

- Switch statements with many cases, especially if those cases contains additional branches

    ```java
    return switch (foo) {
        case CASE_1 -> checkArgument(bar == 1 && baz == 2, ...);
        case CASE_2 -> checkArgument(bar == 3 && baz == 4, ...);
        ...
    }
    ```