### PR TITLE
Workaround to IDEA-301084

### DIFF
--- a/changelog/@unreleased/pr-2368.v2.yml
+++ b/changelog/@unreleased/pr-2368.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Workaround to IDEA-301084
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2368

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -96,10 +97,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             @Override
             public void execute(JavaCompile javaCompileTask) {
                 javaCompileTask.getJavaCompiler().set(javaToolchain.flatMap(BaselineJavaToolchain::javaCompiler));
-                javaCompileTask
-                        .getOptions()
-                        .getCompilerArgumentProviders()
-                        .add(new EnablePreviewArgumentProvider(target));
+                enablePreviewOnCompileTask(target, javaCompileTask.getOptions());
 
                 // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
                 javaCompileTask.doFirst(new Action<Task>() {
@@ -264,6 +262,16 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                                 + "exceed the requested runtime Java version (%s)",
                         target, runtime));
             }
+        }
+    }
+
+    /**
+     * <a href="https://github.com/JetBrains/intellij-community/pull/2135">Further details available here.</a>
+     */
+    private static void enablePreviewOnCompileTask(
+            Provider<ChosenJavaVersion> provider, CompileOptions compileOptions) {
+        if (provider.get().enablePreview()) {
+            compileOptions.getCompilerArgs().add(EnablePreviewArgumentProvider.FLAG);
         }
     }
 


### PR DESCRIPTION
See https://github.com/JetBrains/intellij-community/pull/2135 for
more details. Even if JetBrains takes this PR, it'll be months
before it's common that our devs have a fixed version (it's common
for devs to be a version or two behind) so it seems sensible to
just workaround in baseline for hte next year or two.