### PR TITLE
Fix bug

### DIFF
--- a/changelog/@unreleased/pr-2379.v2.yml
+++ b/changelog/@unreleased/pr-2379.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix interface visibility bug
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2379

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionsExtension.java
@@ -123,7 +123,7 @@ public class BaselineJavaVersionsExtension implements BaselineJavaVersionsExtens
                 .map(javaInstallationMetadata -> ref -> ref.set(javaInstallationMetadata)));
     }
 
-    interface LazyJdks {
+    public interface LazyJdks {
         Optional<JavaInstallationMetadata> jdkFor(JavaLanguageVersion javaLanguageVersion, Project project);
     }
 }


### PR DESCRIPTION
## Before this PR
#2376 introduced `LazyJdks` package private interface that was not visible and triggered the following exception:

`failed to access class com.palantir.baseline.plugins.javaversions.BaselineJavaVersionsExtension$LazyJdks from class com.palantir.gradle.jdks.JdksPlugin (com.palantir.baseline.plugins.javaversions.BaselineJavaVersionsExtension$LazyJdks and com.palantir.gradle.jdks.JdksPlugin are in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @57e989a9)`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
An interface was accidentally made package-private.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

