### PR TITLE
Revert "Enable switchBlockAsSingleDecisionPoint (#2383)"

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -420,9 +420,7 @@
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
-        <module name="CyclomaticComplexity"> <!-- Java Coding Guidelines: Reduce Cyclomatic Complexity -->
-            <property name="switchBlockAsSingleDecisionPoint">true</property>
-        </module>
+        <module name="CyclomaticComplexity"/> <!-- Java Coding Guidelines: Reduce Cyclomatic Complexity -->
         <module name="DesignForExtension"> <!-- Java Coding Guidelines: Design for extension -->
             <property name="ignoredAnnotations" value="ParameterizedTest, Test, Before, BeforeEach, After, AfterEach, BeforeClass, BeforeAll, AfterClass, AfterAll"/>
         </module>


### PR DESCRIPTION
This reverts commit e132e2ddb3b50fd35c29190f7766780455f70cb4.

==COMMIT_MSG==
Revert "Enable switchBlockAsSingleDecisionPoint (#2383)" due to configuration parsing failures.
==COMMIT_MSG==
