### PR TITLE
Exclude Spark UnusedStubClass from class uniqueness

### DIFF
--- a/changelog/@unreleased/pr-2390.v2.yml
+++ b/changelog/@unreleased/pr-2390.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Exclude Spark UnusedStubClass from class uniqueness
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2390

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/JarClassHasher.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/JarClassHasher.java
@@ -74,9 +74,7 @@ public abstract class JarClassHasher implements BuildService<BuildServiceParamet
                         continue;
                     }
 
-                    if (entry.getName().contains("module-info.class")) {
-                        // Java 9 allows jars to have a module-info.class file in the root,
-                        // we shouldn't complain about these.
+                    if (isExcluded(entry.getName())) {
                         continue;
                     }
 
@@ -115,5 +113,14 @@ public abstract class JarClassHasher implements BuildService<BuildServiceParamet
         // Try to free up memory when this is no longer needed
         cache.invalidateAll();
         cache.cleanUp();
+    }
+
+    /**
+     * Java 9 allows jars to have a module-info.class, we shouldn't complain about these.
+     * Spark contains an 'UnusedStubClass' which generates many false positives, we shouldn't complain about this,
+     * either.
+     */
+    private static boolean isExcluded(String path) {
+        return path.endsWith("module-info.class") || path.equals("org/apache/spark/unused/UnusedStubClass.class");
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
@@ -104,6 +104,21 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
         with('checkClassUniqueness', '-s').build()
     }
 
+    def 'ignores duplicates based on module-info and UnusedStubClass'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << """
+        dependencies {
+            // depends on spark-network-common, which also contains UnusedStubClass. Also depends on versions of Jackson
+            // that use module-info.java.
+            api 'org.apache.spark:spark-network-shuffle_2.13:3.3.0'
+        }
+        """.stripIndent()
+
+        then:
+        with('checkClassUniqueness', '-s').build()
+    }
+
     def 'task should be up-to-date when classpath is unchanged'() {
         when:
         buildFile << standardBuildFile


### PR DESCRIPTION
Spark UnusedStubClass exists for mechanical reasons and is as described, never used. With this PR it is skipped, like module-infos.

Potential badness: It's possible that this change would block excavators on certain projects by changing the set of duplicated classes. I think it's likely that this would simply require approval from a human, depending on how the excavator was written.