### PR TITLE
lazily configure NullAway dependencies

### DIFF
--- a/changelog/@unreleased/pr-2393.v2.yml
+++ b/changelog/@unreleased/pr-2393.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: lazily configure NullAway dependencies to successfully apply NullAway
+    without ordering issues
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2393

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -22,9 +22,11 @@ import net.ltgt.gradle.errorprone.ErrorProneOptions;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.compile.JavaCompile;
 
 public final class BaselineNullAway implements Plugin<Project> {
@@ -50,7 +52,20 @@ public final class BaselineNullAway implements Plugin<Project> {
                             + "beware this compromises build reproducibility");
                     return "latest.release";
                 });
-        project.getDependencies().add("errorprone", "com.palantir.baseline:baseline-null-away:" + version);
+        project.getConfigurations()
+                .matching(new Spec<Configuration>() {
+                    @Override
+                    public boolean isSatisfiedBy(Configuration config) {
+                        return "errorprone".equals(config.getName());
+                    }
+                })
+                .configureEach(new Action<Configuration>() {
+                    @Override
+                    public void execute(Configuration _files) {
+                        project.getDependencies()
+                                .add("errorprone", "com.palantir.baseline:baseline-null-away:" + version);
+                    }
+                });
         configureErrorProneOptions(project, new Action<ErrorProneOptions>() {
             @Override
             public void execute(ErrorProneOptions options) {
@@ -60,11 +75,18 @@ public final class BaselineNullAway implements Plugin<Project> {
         });
     }
 
-    private static void configureErrorProneOptions(Project project, Action<ErrorProneOptions> action) {
-        project.getTasks().withType(JavaCompile.class).configureEach(new Action<JavaCompile>() {
+    private static void configureErrorProneOptions(Project proj, Action<ErrorProneOptions> action) {
+        proj.afterEvaluate(new Action<Project>() {
             @Override
-            public void execute(JavaCompile javaCompile) {
-                ((ExtensionAware) javaCompile.getOptions()).getExtensions().configure(ErrorProneOptions.class, action);
+            public void execute(Project project) {
+                project.getTasks().withType(JavaCompile.class).configureEach(new Action<JavaCompile>() {
+                    @Override
+                    public void execute(JavaCompile javaCompile) {
+                        ((ExtensionAware) javaCompile.getOptions())
+                                .getExtensions()
+                                .configure(ErrorProneOptions.class, action);
+                    }
+                });
             }
         });
     }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineNullAwayIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineNullAwayIntegrationTest.groovy
@@ -16,20 +16,16 @@
 
 package com.palantir.baseline
 
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
 
-import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.Unroll
-
-class BaselineNullAwayIntegrationTest extends AbstractPluginTest {
+class BaselineNullAwayIntegrationTest extends IntegrationSpec {
 
     def standardBuildFile = '''
-        plugins {
-            id 'java'
-            id 'com.palantir.baseline-error-prone'
-            id 'com.palantir.baseline-null-away'
-            id 'com.palantir.baseline-java-versions'
-        }
+        apply plugin: 'com.palantir.baseline-java-versions'
+        apply plugin: 'com.palantir.baseline-null-away'
+        apply plugin: 'com.palantir.baseline-error-prone'
+        apply plugin: 'java'
         repositories {
             mavenLocal()
             mavenCentral()
@@ -37,8 +33,15 @@ class BaselineNullAwayIntegrationTest extends AbstractPluginTest {
         javaVersions {
             libraryTarget = 17
         }
-        tasks.withType(JavaCompile).configureEach {
-            options.compilerArgs += ['-Werror']
+        allprojects {
+            afterEvaluate {
+                plugins.withId('net.ltgt.errorprone', {
+                    tasks.withType(JavaCompile).configureEach({
+                      options.errorprone.excludedPaths = null
+                      options.compilerArgs += ['-Werror']
+                    })
+                })
+            }
         }
     '''.stripIndent()
 
@@ -62,47 +65,43 @@ class BaselineNullAwayIntegrationTest extends AbstractPluginTest {
         buildFile << standardBuildFile
 
         then:
-        with('compileJava', '--info').build()
+        runTasksSuccessfully('compileJava', '--info')
     }
 
     def 'compileJava fails when null-away finds errors'() {
         when:
         buildFile << standardBuildFile
-        file('src/main/java/com/palantir/test/Test.java') << invalidJavaFile
+        writeJavaSourceFile(invalidJavaFile)
 
         then:
-        BuildResult result = with('compileJava').buildAndFail()
-        result.task(":compileJava").outcome == TaskOutcome.FAILED
-        result.output.contains("[NullAway] dereferenced expression throwable.getMessage() is @Nullable")
+        ExecutionResult result = runTasksWithFailure('compileJava')
+        result.standardError.contains("[NullAway] dereferenced expression throwable.getMessage() is @Nullable")
     }
 
     def 'compileJava succeeds when null-away finds no errors'() {
         when:
         buildFile << standardBuildFile
-        file('src/main/java/com/palantir/test/Test.java') << validJavaFile
+        writeJavaSourceFile(validJavaFile)
 
         then:
-        BuildResult result = with('compileJava').build()
-        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        runTasksSuccessfully('compileJava')
     }
 
     def 'compileJava succeeds when null-away finds no errors on jdk15'() {
         when:
         buildFile << standardBuildFile.replace('libraryTarget = 17', 'libraryTarget = 15')
-        file('src/main/java/com/palantir/test/Test.java') << validJavaFile
+        writeJavaSourceFile(validJavaFile)
 
         then:
-        BuildResult result = with('compileJava').build()
-        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        runTasksSuccessfully('compileJava')
     }
 
     def 'compileJava succeeds when null-away finds no errors on jdk11'() {
         when:
         buildFile << standardBuildFile.replace('libraryTarget = 17', 'libraryTarget = 11')
-        file('src/main/java/com/palantir/test/Test.java') << validJavaFile
+        writeJavaSourceFile(validJavaFile)
 
         then:
-        BuildResult result = with('compileJava').build()
-        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        runTasksSuccessfully('compileJava')
     }
 }


### PR DESCRIPTION
## Before this PR
Plugin failed to apply in some cases

## After this PR
==COMMIT_MSG==
lazily configure NullAway dependencies to successfully apply NullAway without ordering issues
==COMMIT_MSG==

## Possible downsides?
~~Unable to repro the failure which prompted this~~ Solved
