### PR TITLE
Don't opt in to CheckOptionalEmptiness

### DIFF
--- a/changelog/@unreleased/pr-2396.v2.yml
+++ b/changelog/@unreleased/pr-2396.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`com.palantir.baseline-null-away` no longer enables the `CheckOptionalEmptiness`
+    checker by default.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2396

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -70,7 +70,6 @@ public final class BaselineNullAway implements Plugin<Project> {
             @Override
             public void execute(ErrorProneOptions options) {
                 options.option("NullAway:AnnotatedPackages", String.join(",", DEFAULT_ANNOTATED_PACKAGES));
-                options.option("NullAway:CheckOptionalEmptiness", "true");
             }
         });
     }


### PR DESCRIPTION
## Before this PR

When compiling with java 17 and NullAway 0.10.1 internally (https://internal-github/adjudication-service/pull/4216) I have been getting a NPE from inside NullAway, which looks _super weird_ to me because it implies that Java's `Element.getKind()` method returned null (but I literally can't see what subtype would return null)

```
error: An unhandled exception was thrown by the Error Prone static analysis plugin.
                .map(Map.Entry::getKey)
                     ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.15.0
     BugPattern: NullAway
     Stack Trace:
     java.lang.NullPointerException: Cannot invoke "javax.lang.model.element.ElementKind.equals(Object)" because the return value of "javax.lang.model.element.Element.getKind()" is null
  	at com.uber.nullaway.handlers.StreamNullabilityPropagator.onMatchMethodReference(StreamNullabilityPropagator.java:351)
  	at com.uber.nullaway.handlers.CompositeHandler.onMatchMethodReference(CompositeHandler.java:103)
  	at com.uber.nullaway.NullAway.matchMemberReference(NullAway.java:854)
  	at com.google.errorprone.scanner.ErrorProneScanner.processMatchers(ErrorProneScanner.java:449)
  	at com.google.errorprone.scanner.ErrorProneScanner.visitMemberReference(ErrorProneScanner.java:715)
```

## After this PR
==COMMIT_MSG==
`com.palantir.baseline-null-away` no longer enables the `CheckOptionalEmptiness` checker by default. 
==COMMIT_MSG==

You can still enable this if you want to with something like

```gradle
    plugins.withId('com.palantir.baseline-error-prone', {
        tasks.withType(JavaCompile) {
            options.errorprone.errorproneArgs.add '-XepOpt:NullAway:CheckOptionalEmptiness=true'
        }
    })
```

## Possible downsides?
- folks who were enjoying the reassurance of this strict optional checking now have a bit of static analysis taken away :(

