### PR TITLE
Disable NullAway for Test Source

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -188,6 +188,9 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // Relax some checks for test code
         if (errorProneOptions.getCompilingTestOnlyCode().get()) {
             errorProneOptions.disable("UnnecessaryLambda");
+            // NullAway has some poor interactions with mockito and
+            // tests generally do some odd accesses for brevity
+            errorProneOptions.disable("NullAway");
         }
 
         if (javaCompile.getName().equals(compileRefaster.getName())) {


### PR DESCRIPTION
## Before this PR
`NullAway` was interacting poorly with mockito and other testing patterns

## After this PR
`NullAway` should no longer fail on tests

## Possible downsides?
Difficult to enable if you care about that thing

