### PR TITLE
Ignore fields annotated with `@Mock`

### DIFF
--- a/changelog/@unreleased/pr-2399.v2.yml
+++ b/changelog/@unreleased/pr-2399.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Ignore fields annotated with `@Mock`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2399

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -70,6 +70,7 @@ public final class BaselineNullAway implements Plugin<Project> {
             @Override
             public void execute(ErrorProneOptions options) {
                 options.option("NullAway:AnnotatedPackages", String.join(",", DEFAULT_ANNOTATED_PACKAGES));
+                options.option("NullAway:ExcludedFieldAnnotations", "org.mockito.Mock");
             }
         });
     }


### PR DESCRIPTION
## Before this PR
```java
@Mock
private Object foo;
```

would yield a false positive. See https://github.com/uber/NullAway/issues/280 for more context on the problem and the fix.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ignore fields annotated with `@Mock`
==COMMIT_MSG==
