### PR TITLE
Allow projects which don't use jdk-15 to resolve latest nullaway

### DIFF
--- a/changelog/@unreleased/pr-2400.v2.yml
+++ b/changelog/@unreleased/pr-2400.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow projects which don't use jdk-15 to resolve latest nullaway
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2400

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -16,10 +16,13 @@
 
 package com.palantir.baseline.plugins;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.palantir.baseline.plugins.javaversions.BaselineJavaVersions;
 import java.util.Optional;
 import net.ltgt.gradle.errorprone.ErrorProneOptions;
 import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -73,6 +76,7 @@ public final class BaselineNullAway implements Plugin<Project> {
                 options.option("NullAway:CheckOptionalEmptiness", "true");
             }
         });
+        newerNullAwayInNonJdk15Projects(project);
     }
 
     private static void configureErrorProneOptions(Project proj, Action<ErrorProneOptions> action) {
@@ -89,5 +93,48 @@ public final class BaselineNullAway implements Plugin<Project> {
                 });
             }
         });
+    }
+
+    // Workaround for nullaway bugs in the last release to support jdk-15. Projects that don't use jdk-15
+    // resolve a newer nullaway version with bug-fixes. This may be deleted after we've rolled everything
+    // off jdk-15 MTS.
+    private static void newerNullAwayInNonJdk15Projects(Project project) {
+        project.getRootProject().getPlugins().hasPlugin(BaselineJavaVersions.class);
+
+        project.getConfigurations()
+                .matching(new Spec<Configuration>() {
+                    @Override
+                    public boolean isSatisfiedBy(Configuration config) {
+                        return "errorprone".equals(config.getName());
+                    }
+                })
+                .configureEach(new Action<Configuration>() {
+                    @Override
+                    public void execute(Configuration _files) {
+                        project.getDependencies().addProvider("errorprone", project.provider(() -> {
+                            if (anyProjectUsesJava15(project)) {
+                                // Cannot upgrade dependencies in this case because newer nullaway/checkerframework
+                                // are not compatible with java 15, but fully support jdk11 and jdk17.
+                                return ImmutableList.of();
+                            }
+                            return ImmutableList.of(
+                                    "com.uber.nullaway:nullaway:0.10.1",
+                                    // align 'org.checkerframework' dependency versions on
+                                    // the current latest version.
+                                    "org.checkerframework:dataflow-errorprone:3.25.0",
+                                    "org.checkerframework:dataflow-nullaway:3.25.0",
+                                    "org.checkerframework:checker-qual:3.25.0");
+                        }));
+                    }
+                });
+    }
+
+    private static boolean anyProjectUsesJava15(Project proj) {
+        return proj.getAllprojects().stream()
+                .anyMatch(project -> project.getTasks().withType(JavaCompile.class).stream()
+                        .anyMatch(comp -> {
+                            JavaVersion javaVersion = JavaVersion.toVersion(comp.getTargetCompatibility());
+                            return javaVersion == JavaVersion.VERSION_15;
+                        }));
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -119,12 +119,9 @@ public final class BaselineNullAway implements Plugin<Project> {
                     public void execute(Configuration _files) {
                         for (String dep : NON_15_DEPS) {
                             project.getDependencies().addProvider("errorprone", project.provider(() -> {
-                                if (anyProjectUsesJava15(project)) {
-                                    // Cannot upgrade dependencies in this case because newer nullaway/checkerframework
-                                    // are not compatible with java 15, but fully support jdk11 and jdk17.
-                                    return null;
-                                }
-                                return dep;
+                                // Cannot upgrade dependencies in this case because newer nullaway/checkerframework
+                                // are not compatible with java 15, but fully support jdk11 and jdk17.
+                                return anyProjectUsesJava15(project) ? null : dep;
                             }));
                         }
                     }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -18,7 +18,6 @@ package com.palantir.baseline.plugins;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.palantir.baseline.plugins.javaversions.BaselineJavaVersions;
 import java.util.Optional;
 import net.ltgt.gradle.errorprone.ErrorProneOptions;
 import org.gradle.api.Action;

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -107,8 +107,6 @@ public final class BaselineNullAway implements Plugin<Project> {
     // resolve a newer nullaway version with bug-fixes. This may be deleted after we've rolled everything
     // off jdk-15 MTS.
     private static void newerNullAwayInNonJdk15Projects(Project project) {
-        project.getRootProject().getPlugins().hasPlugin(BaselineJavaVersions.class);
-
         project.getConfigurations()
                 .matching(new Spec<Configuration>() {
                     @Override

--- a/versions.props
+++ b/versions.props
@@ -1,13 +1,10 @@
 com.fasterxml.jackson.core:jackson-databind = 2.13.3
 com.google.auto.service:auto-service = 1.0.1
-com.google.errorprone:error_prone_* = 2.15.0
 com.google.guava:guava = 31.1-jre
 com.palantir.safe-logging:* = 3.0.0
-com.uber.nullaway:nullaway = 0.9.9
 commons-lang:commons-lang = 2.6
 org.apache.maven.shared:maven-dependency-analyzer = 1.12.0
 org.apache.maven:maven-core = 3.8.5
-org.checkerframework:* = 3.23.0
 org.inferred:freebuilder = 1.14.6
 org.jooq:jooq = 3.17.2
 org.slf4j:* = 1.7.36
@@ -45,4 +42,9 @@ org.codehaus.groovy:* = 3.0.10
 com.palantir.javaformat:gradle-palantir-java-format = 1.1.0
 # Newer spotless versions have issues resolving dependencies at configuration time
 com.diffplug.spotless:spotless-plugin-gradle = 6.6.0
+# Newer releases of checkerframework do not support jdk15. These dependencies may
+# be moved back to hte upgradable block once we've removed uses of jdk-15 MTS
+com.google.errorprone:error_prone_* = 2.15.0
+com.uber.nullaway:nullaway = 0.9.9
+org.checkerframework:* = 3.23.0
 # dependency-upgrader:ON


### PR DESCRIPTION
## Before this PR
Crashes due to bugs resolved in newer nullaway releases

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow projects which don't use jdk-15 to resolve latest nullaway
==COMMIT_MSG==

## Possible downsides?
Bit of a hack, but likely better than alternatives?
