### PR TITLE
Revert "Disable NullAway for Test Source"

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -188,9 +188,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // Relax some checks for test code
         if (errorProneOptions.getCompilingTestOnlyCode().get()) {
             errorProneOptions.disable("UnnecessaryLambda");
-            // NullAway has some poor interactions with mockito and
-            // tests generally do some odd accesses for brevity
-            errorProneOptions.disable("NullAway");
         }
 
         if (javaCompile.getName().equals(compileRefaster.getName())) {


### PR DESCRIPTION
Turns out that this breaks if you do not have the NullAway plugin installed. Will move this to that plugin instead.

Reverts palantir/gradle-baseline#2397