### PR TITLE
Nullaway is not enabled in test sources

### DIFF
--- a/changelog/@unreleased/pr-2402.v2.yml
+++ b/changelog/@unreleased/pr-2402.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Nullaway is not enabled in test sources
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2402

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -188,9 +188,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // Relax some checks for test code
         if (errorProneOptions.getCompilingTestOnlyCode().get()) {
             errorProneOptions.disable("UnnecessaryLambda");
-            // NullAway has some poor interactions with mockito and
-            // tests generally do some odd accesses for brevity
-            errorProneOptions.disable("NullAway");
         }
 
         if (javaCompile.getName().equals(compileRefaster.getName())) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -70,6 +70,12 @@ public final class BaselineNullAway implements Plugin<Project> {
             @Override
             public void execute(ErrorProneOptions options) {
                 options.option("NullAway:AnnotatedPackages", String.join(",", DEFAULT_ANNOTATED_PACKAGES));
+                // Relax some checks for test code
+                if (options.getCompilingTestOnlyCode().get()) {
+                    // NullAway has some poor interactions with mockito and
+                    // tests generally do some odd accesses for brevity
+                    options.disable("NullAway");
+                }
             }
         });
     }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineNullAwayIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineNullAwayIntegrationTest.groovy
@@ -78,6 +78,15 @@ class BaselineNullAwayIntegrationTest extends IntegrationSpec {
         result.standardError.contains("[NullAway] dereferenced expression throwable.getMessage() is @Nullable")
     }
 
+    def 'Test tasks are not impacted by null-away'() {
+        when:
+        buildFile << standardBuildFile
+        writeJavaSourceFile(invalidJavaFile, "src/test/java")
+
+        then:
+        runTasksSuccessfully('compileTestJava')
+    }
+
     def 'compileJava succeeds when null-away finds no errors'() {
         when:
         buildFile << standardBuildFile


### PR DESCRIPTION
This fixes a bug in the previous implementation which attempted to opt out of nullaway in projects that didn't use the plugin.

==COMMIT_MSG==
Nullaway is not enabled in test sources
==COMMIT_MSG==

