### PR TITLE
Error-prone is enabled in idea for uniformity with CLI compilation

### DIFF
--- a/changelog/@unreleased/pr-2405.v2.yml
+++ b/changelog/@unreleased/pr-2405.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Error-prone is enabled in idea for uniformity with CLI compilation
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2405

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -22,7 +22,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MoreCollectors;
-import com.palantir.baseline.IntellijSupport;
 import com.palantir.baseline.extensions.BaselineErrorProneExtension;
 import com.palantir.baseline.tasks.CompileRefasterTask;
 import java.io.File;
@@ -349,7 +348,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
     private static boolean isDisabled(Project project) {
         Object disable = project.findProperty(DISABLE_PROPERTY);
         if (disable == null) {
-            return IntellijSupport.isRunningInIntellij();
+            return false;
         } else {
             return !disable.equals("false");
         }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -112,7 +112,7 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         file('src/main/java/test/Test.java') << invalidJavaFile
 
         then:
-        BuildResult result = with('compileJava', '-Didea.active=true').build()
+        BuildResult result = with('compileJava', '-Didea.active=true').buildAndFail()
         result.task(":compileJava").outcome == TaskOutcome.FAILED
         result.output.contains("[ArrayEquals] Reference equality used to compare arrays")
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -106,14 +106,16 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         result.task(":compileJava").outcome == TaskOutcome.SUCCESS
     }
 
-    def 'error-prone is disabled in IntelliJ'() {
+    def 'error-prone is not disabled in IntelliJ'() {
         when:
         buildFile << standardBuildFile
         file('src/main/java/test/Test.java') << invalidJavaFile
 
         then:
         BuildResult result = with('compileJava', '-Didea.active=true').build()
-        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        result.task(":compileJava").outcome == TaskOutcome.FAILED
+        result.output.contains("[ArrayEquals] Reference equality used to compare arrays")
+
     }
 
     def 'error-prone can be enabled using property'() {


### PR DESCRIPTION
error-prone requires several javac options to access compiler innards, which have the side-effect of enabling immutables to function correctly. Given this spooky interaction and our migration toward jdk17 source, it's best to provide uniform behavior.

==COMMIT_MSG==
Error-prone is enabled in idea for uniformity with CLI compilation
==COMMIT_MSG==
