### PR TITLE
baseline-immutables adds required exports to the java compiler

### DIFF
--- a/changelog/@unreleased/pr-2406.v2.yml
+++ b/changelog/@unreleased/pr-2406.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: baseline-immutables adds required exports to the java compiler for
+    compatibility with jdk-17+
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2406


### PR DESCRIPTION
See https://github.com/immutables/immutables/issues/1379 for more information

==COMMIT_MSG==
baseline-immutables adds required exports to the java compiler
==COMMIT_MSG==
