### PR TITLE
Fix typo in "Prefer acyclic dependency graphs" section of Java coding principles

### DIFF
--- a/docs/best-practices/java-coding-guidelines/readme.md
+++ b/docs/best-practices/java-coding-guidelines/readme.md
@@ -1760,7 +1760,7 @@ public FooResource(String name) {
 }
 ```
 
-Acyclic dependency graphs are hard to understand, hard to setup for tests and mocks, and introduce subtle code ordering
+Circular dependency graphs are hard to understand, hard to setup for tests and mocks, and introduce subtle code ordering
 constraints. For example, switching the order of the constructor statements introduces a bug where the resource name is
 always "FooResource on port 0" since `Server#port` hasn't been initialized when the resource calls `Server#port()`:
 


### PR DESCRIPTION
## Before this PR
The guide said that acyclic dependency graphs are hard to understand.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Change "Acyclic dependency graphs are hard to understand" to "Circular dependency graphs are hard to understand"
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

