### PR TITLE
Exclude javadoc @link from linelength

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -43,7 +43,7 @@
     </module>
     <module name="LineLength"> <!-- Java Style Guide: No line-wrapping -->
         <property name="max" value="120"/>
-        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\* \{@link"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -43,7 +43,7 @@
     </module>
     <module name="LineLength"> <!-- Java Style Guide: No line-wrapping -->
         <property name="max" value="120"/>
-        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\* \{@link"/>
     </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->

--- a/changelog/@unreleased/pr-2414.v2.yml
+++ b/changelog/@unreleased/pr-2414.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: exempt @link javadoc comment from LineLength check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2414

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -49,7 +49,7 @@
     </module>
     <module name="LineLength"> <!-- Java Style Guide: No line-wrapping -->
         <property name="max" value="120"/>
-        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\* \{@link"/>
     </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -49,7 +49,7 @@
     </module>
     <module name="LineLength"> <!-- Java Style Guide: No line-wrapping -->
         <property name="max" value="120"/>
-        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\* \{@link"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\{@link"/>
     </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->


### PR DESCRIPTION
`@link` in javadoc should not break into multiple lines

## Before this PR
Using `@link` with a long reference would trigger LineLength violation.

## After this PR
`@link` javadoc comment lines are exempted from LineLength check

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

