### PR TITLE
Fix ConcurrentModificationExceptions thrown from BaselineNullAway

### DIFF
--- a/changelog/@unreleased/pr-2427.v2.yml
+++ b/changelog/@unreleased/pr-2427.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix ConcurrentModificationExceptions thrown from BaselineNullAway
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2427

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -134,7 +134,7 @@ public final class BaselineNullAway implements Plugin<Project> {
 
     private static boolean anyProjectUsesJava15(Project proj) {
         return proj.getAllprojects().stream()
-                .anyMatch(project -> project.getTasks().withType(JavaCompile.class).stream()
+                .anyMatch(project -> ImmutableList.copyOf(project.getTasks().withType(JavaCompile.class)).stream()
                         .anyMatch(comp -> {
                             JavaVersion javaVersion = JavaVersion.toVersion(comp.getTargetCompatibility());
                             return javaVersion == JavaVersion.VERSION_15;


### PR DESCRIPTION
Addresses https://github.com/palantir/gradle-baseline/issues/2413

## Before this PR
`java.util.ConcurrentModificationException` thrown from this plugin:

```
Caused by: java.util.ConcurrentModificationException
        at org.gradle.api.internal.collections.FilteredCollection$FilteringIterator.findNext(FilteredCollection.java:121)
        at org.gradle.api.internal.collections.FilteredCollection$FilteringIterator.next(FilteredCollection.java:140)
        at org.gradle.api.internal.DefaultDomainObjectCollection$IteratorImpl.next(DefaultDomainObjectCollection.java:485)
        at com.palantir.baseline.plugins.BaselineNullAway.lambda$anyProjectUsesJava15$4(BaselineNullAway.java:138)
        at com.palantir.baseline.plugins.BaselineNullAway.anyProjectUsesJava15(BaselineNullAway.java:137)
        at com.palantir.baseline.plugins.BaselineNullAway$5.lambda$execute$0(BaselineNullAway.java:128)
```

## After this PR
==COMMIT_MSG==
Fix ConcurrentModificationExceptions thrown from BaselineNullAway
==COMMIT_MSG==

## Possible downsides?
I think this exception indicates that the project's task list is being modified/resolved at the same time as we iterate over it in this class. 

By making a copy before iterating, I think we'll reduce the CMEs being thrown, but not actually fix the underlying issue of concurrent changes happening.  I'm not super familiar with Gradle internals, but think we may instead need to do something where BaselineNullAway runs in a `doLast` so it doesn't interfere with project resolution.

This fix was confirmed on an internal failing repro, but we don't have a test case for it as part of this PR.

~~By using the TaskCollection's `.anyMatch()` directly, we hope that it is a bit smarter about modification during iteration versus converting to a Stream and using `Stream#anyMatch()`.~~