### PR TITLE
Bring IntelliJ in sync with ErrorProne on bad inner static class names

### DIFF
--- a/changelog/@unreleased/pr-2447.v2.yml
+++ b/changelog/@unreleased/pr-2447.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Bring IntelliJ in sync with ErrorProne on bad inner static class names
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2447

--- a/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
+++ b/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
@@ -44,8 +44,10 @@
               <package name="" withSubpackages="true" static="false" />
             </value>
           </option>
+          <!-- Should be a superset of https://github.com/google/error-prone/blob/c481b3f9c2da112db36ccfcbf64e755261a127ab/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java#L63 -->
           <DO_NOT_IMPORT_INNER>
             <CLASS name="Builder" />
+            <CLASS name="BuilderFactory" />
             <CLASS name="Callback" />
             <CLASS name="Class" />
             <CLASS name="Entry" />
@@ -54,6 +56,7 @@
             <CLASS name="Type" />
             <CLASS name="Key" />
             <CLASS name="Id" />
+            <CLASS name="Identifier" />
             <CLASS name="Provider" />
           </DO_NOT_IMPORT_INNER>
         </GroovyCodeStyleSettings>


### PR DESCRIPTION
By re-syncing DO_NOT_IMPORT_INNER IntelliJ config from ErrorProne BadImport.BAD_NESTED_CLASSES

## Before this PR
IntelliJ settings for inner static class names to not import were out of sync with ErrorProne's BadImport check.  This causes IntelliJ to produce/allow code that ErrorProne would then fail on.

## After this PR
==COMMIT_MSG==

==COMMIT_MSG==

This is an extension of https://github.com/palantir/gradle-baseline/pull/1617, which initially populated the list.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

