### PR TITLE
Disable `JavaxInjectOnAbstractMethod` for Gradle plugins

### DIFF
--- a/changelog/@unreleased/pr-2460.v2.yml
+++ b/changelog/@unreleased/pr-2460.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Suppress the `JavaxInjectOnAbstractMethod` check for projects that
+    apply `java-gradle-plugin`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2460

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -147,6 +147,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                         errorProneOptions.check("PreferSafeLogger", CheckSeverity.OFF);
                         errorProneOptions.check("PreferSafeLoggingPreconditions", CheckSeverity.OFF);
                         errorProneOptions.check("PreconditionsConstantMessage", CheckSeverity.OFF);
+                        errorProneOptions.check("JavaxInjectOnAbstractMethod", CheckSeverity.OFF);
                     }));
         });
     }


### PR DESCRIPTION
## Before this PR
Gradle uses the pattern of putting `@Inject` on abstract methods a lot - it's how [it's whole service injection for Managed Properties](https://docs.gradle.org/current/userguide/custom_gradle_types.html#property_injection) works. Every time you want to use one of these injected types, you need to suppress the `JavaxInjectOnAbstractMethod` errorprone check:

```java
@SuppressWarnings("JavaxInjectOnAbstractMethod")
@Inject
public abstract ExecOperations getExecOperations();
```

## After this PR
==COMMIT_MSG==
Suppress the `JavaxInjectOnAbstractMethod` check for projects that apply `java-gradle-plugin`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

