### PR TITLE
baseline-immutables handles annotationProcessor configuration extendsFrom

### DIFF
--- a/changelog/@unreleased/pr-2465.v2.yml
+++ b/changelog/@unreleased/pr-2465.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Ensure that `baseline-immutables` configures immutables to work incrementally
+    when the immutables `annotationProcessor` dependency is not a direct dependency
+    (ie it is brought in transitively or by an `extendsFrom`).
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2465

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
@@ -21,7 +21,9 @@ import java.util.Collections;
 import java.util.Objects;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -74,12 +76,22 @@ public final class BaselineImmutables implements Plugin<Project> {
         return project
                 .getConfigurations()
                 .getByName(sourceSet.getAnnotationProcessorConfigurationName())
-                .getDependencies()
+                .getIncoming()
+                .getResolutionResult()
+                .getAllComponents()
                 .stream()
                 .anyMatch(BaselineImmutables::isImmutablesValue);
     }
 
-    private static boolean isImmutablesValue(Dependency dep) {
-        return Objects.equals(dep.getGroup(), "org.immutables") && Objects.equals(dep.getName(), "value");
+    private static boolean isImmutablesValue(ResolvedComponentResult component) {
+        ComponentIdentifier id = component.getId();
+
+        if (!(id instanceof ModuleComponentIdentifier)) {
+            return false;
+        }
+
+        ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) id;
+
+        return Objects.equals(moduleId.getGroup(), "org.immutables") && Objects.equals(moduleId.getModule(), "value");
     }
 }


### PR DESCRIPTION
## Before this PR
Internally, someone had written the code:

```gradle
configurations {
    testAnnotationProcessor.extendsFrom annotationProcessor
    testCompileOnly.extendsFrom compileOnly
} 
```

in their repo. They then only put the immutables processor in `annotationProcessor`, but not `testAnnotationProcessor`:

```gradle
dependencies {
    annotationProcess 'org.immutables:value'
}
````

The plugin currently only checks dependencies declared directly in the configuration. This means the `test` source set had immutables, but was not configuring it to be incremental, meaning that the iteration loop for tests was a 2 min full compile.

Additionally, the current plugin does not handle the case where immutables would be brought in transitively.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensure that `baseline-immutables` configures immutables to work incrementally when the immutables `annotationProcessor` dependency is not a direct dependency (ie it is brought in transitively or by an `extendsFrom`).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

