### PR TITLE
ensure tasks that use moduleJvmArgs have task inputs set correctly

### DIFF
--- a/changelog/@unreleased/pr-2477.v2.yml
+++ b/changelog/@unreleased/pr-2477.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: add input properties for each task that uses moduleJvmArgs so that
+    when the extension value changes, the task will no longer be up-to-date.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2477

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -272,12 +272,9 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
     }
 
     private static void setTaskInputsFromExtension(Task task, BaselineModuleJvmArgsExtension extension) {
-        task.getInputs()
-                .property("baseline-module-jvm-args-extension-exports", extension.exports());
-        task.getInputs()
-                .property("baseline-module-jvm-args-extension-opens", extension.opens());
-        task.getInputs()
-                .property("baseline-module-jvm-args-extension-enablePreview", extension.getEnablePreview());
+        task.getInputs().property("baseline-module-jvm-args-extension-exports", extension.exports());
+        task.getInputs().property("baseline-module-jvm-args-extension-opens", extension.opens());
+        task.getInputs().property("baseline-module-jvm-args-extension-enablePreview", extension.getEnablePreview());
     }
 
     private static void addManifestAttribute(

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -111,6 +111,8 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
                                     return arguments;
                                 }
                             });
+
+                    setTaskInputsFromExtension(javaCompile, extension);
                 });
 
                 TaskProvider<Task> javadocTaskProvider = null;
@@ -175,6 +177,8 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
                                 }
                             }
                         });
+
+                        setTaskInputsFromExtension(javadocTask, extension);
                     });
                 }
             });
@@ -198,6 +202,8 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
                             return arguments;
                         }
                     });
+
+                    setTaskInputsFromExtension(test, extension);
                 }
             });
 
@@ -220,6 +226,8 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
                             return arguments;
                         }
                     });
+
+                    setTaskInputsFromExtension(javaExec, extension);
                 }
             });
 
@@ -256,9 +264,20 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
                             });
                         }
                     });
+
+                    setTaskInputsFromExtension(jar, extension);
                 }
             });
         });
+    }
+
+    private static void setTaskInputsFromExtension(Task task, BaselineModuleJvmArgsExtension extension) {
+        task.getInputs()
+                .property("baseline-module-jvm-args-extension-exports", extension.exports());
+        task.getInputs()
+                .property("baseline-module-jvm-args-extension-opens", extension.opens());
+        task.getInputs()
+                .property("baseline-module-jvm-args-extension-enablePreview", extension.getEnablePreview());
     }
 
     private static void addManifestAttribute(


### PR DESCRIPTION
The BaselineModuleJvmArgs plugin configures several tasks from the 'java' plugin to use values from the 'moduleJvmArgs' extension (e.g. to update compiler arguments, output values to the jar manifest, etc.). However, when the value on the extension changes, those tasks are not re-run.

To fix that, add input properties for each task that uses moduleJvmArgs so that when the extension value changes, the task will no longer be up-to-date.

Fixes #2476

## Before this PR
The BaselineModuleJvmArgs plugin configures several tasks from the 'java' plugin to use values from the 'moduleJvmArgs' extension (e.g. to update compiler arguments, output values to the jar manifest, etc.). However, when the value on the extension changes, those tasks are not re-run.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
add input properties for each task that uses moduleJvmArgs so that when the extension value changes, the task will no longer be up-to-date.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

