### PR TITLE
Increase javac heap to 2g by default (up from 512m)

### DIFF
--- a/changelog/@unreleased/pr-2482.v2.yml
+++ b/changelog/@unreleased/pr-2482.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Increase javac heap to 2g by default (up from 512m). Existing overrides
+    are not impacted.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2482

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/Baseline.java
@@ -58,6 +58,7 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply(BaselineTesting.class);
             proj.getPluginManager().apply(BaselineTestHeap.class);
             proj.getPluginManager().apply(BaselineJavaCompilerDiagnostics.class);
+            proj.getPluginManager().apply(BaselineJavaCompilerHeap.class);
             proj.getPluginManager().apply(BaselineJavaParameters.class);
             proj.getPluginManager().apply(BaselineImmutables.class);
             proj.getPluginManager().apply(BaselineModuleJvmArgs.class);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaCompilerHeap.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineJavaCompilerHeap.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.compile.ForkOptions;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+/**
+ * Increases the default {@link JavaCompile} task heap from {@code 512m} to {@code 2g}.
+ */
+public final class BaselineJavaCompilerHeap implements Plugin<Project> {
+
+    private static final String JAVAC_HEAP = "2g";
+
+    @Override
+    public void apply(Project proj) {
+        proj.afterEvaluate(
+                project -> project.getTasks().withType(JavaCompile.class).configureEach(javaCompileTask -> {
+                    ForkOptions options = javaCompileTask.getOptions().getForkOptions();
+                    if (options.getMemoryMaximumSize() == null) {
+                        options.setMemoryMaximumSize(JAVAC_HEAP);
+                    }
+                }));
+    }
+}

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaCompilerHeapTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaCompilerHeapTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline
+
+import com.palantir.baseline.plugins.BaselineJavaCompilerHeap
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class BaselineJavaCompilerHeapTest extends Specification {
+
+    def testDefault() {
+        when:
+        def project = ProjectBuilder.builder().build()
+        project.buildscript {
+            repositories {
+                mavenCentral()
+            }
+        }
+        project.plugins.apply 'java'
+        project.plugins.apply BaselineJavaCompilerHeap
+        project.evaluate()
+
+        then:
+        JavaCompile compileTask = project.tasks.getByName('compileJava').asType(JavaCompile.class)
+        compileTask.options.forkOptions.memoryMaximumSize == "2g"
+    }
+
+    def testOverridden() {
+        when:
+        def project = ProjectBuilder.builder().build()
+        project.buildscript {
+            repositories {
+                mavenCentral()
+            }
+        }
+        project.plugins.apply 'java'
+        project.tasks.compileJava {
+            options.forkOptions.memoryMaximumSize = "768m"
+        }
+        project.plugins.apply BaselineJavaCompilerHeap
+        project.evaluate()
+
+        then:
+        JavaCompile compileTask = project.tasks.getByName('compileJava').asType(JavaCompile.class)
+        compileTask.options.forkOptions.memoryMaximumSize == "768m"
+    }
+}


### PR DESCRIPTION
==COMMIT_MSG==
Increase javac heap to 2g by default (up from 512m). Existing overrides are not impacted.
==COMMIT_MSG==

