### PR TITLE
add JooqBatchWithoutBindArgs check

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `FilterOutputStreamSlowMultibyteWrite`: Subclasses of FilterOutputStream should provide a more efficient implementation of `write(byte[], int, int)` to avoid slow writes.
 - `BugCheckerAutoService`: Concrete BugChecker implementations should be annotated `@AutoService(BugChecker.class)` for auto registration with error-prone.
 - `DangerousCollapseKeysUsage`: Disallow usage of `EntryStream#collapseKeys()`.
+- `JooqBatchWithoutBindArgs`: Disallow jOOQ batch methods that execute queries without bind args.
 
 ### Programmatic Application
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `FilterOutputStreamSlowMultibyteWrite`: Subclasses of FilterOutputStream should provide a more efficient implementation of `write(byte[], int, int)` to avoid slow writes.
 - `BugCheckerAutoService`: Concrete BugChecker implementations should be annotated `@AutoService(BugChecker.class)` for auto registration with error-prone.
 - `DangerousCollapseKeysUsage`: Disallow usage of `EntryStream#collapseKeys()`.
-- `JooqBatchWithoutBindArgs`: Disallow jOOQ batch methods that execute queries without bind args.
+- `JooqBatchWithoutBindArgs`: jOOQ batch methods that execute without bind args can cause performance problems.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/JooqBatchWithoutBindArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/JooqBatchWithoutBindArgs.java
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.BugPattern.StandardTags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Type;
+import java.util.Collection;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.ERROR,
+        tags = StandardTags.PERFORMANCE,
+        summary = "Disallow jOOQ batch methods that execute queries without bind args.")
+public final class JooqBatchWithoutBindArgs extends BugChecker implements MethodInvocationTreeMatcher {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String DSL_CONTEXT = "org.jooq.DSLContext";
+    private static final String BATCH = "batch";
+    private static final String ERROR_MESSAGE =
+            "Jooq batch methods that execute queries without bind args cause performance problems.";
+
+    private static final Supplier<Type> QUERY_TYPE =
+            VisitorState.memoize(state -> state.getTypeFromString("org.jooq.Query"));
+
+    private static final Matcher<ExpressionTree> BATCH_WITHOUT_BINDS_MATCHER = Matchers.anyOf(
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(DSL_CONTEXT)
+                    .named(BATCH)
+                    .withParameters("org.jooq.Queries"),
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(DSL_CONTEXT)
+                    .named(BATCH)
+                    .withParameters(Collection.class.getName()),
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(DSL_CONTEXT)
+                    .named(BATCH)
+                    .withParametersOfType(ImmutableList.of(Suppliers.arrayOf(Suppliers.STRING_TYPE))),
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(DSL_CONTEXT)
+                    .named(BATCH)
+                    .withParametersOfType(ImmutableList.of(Suppliers.arrayOf(QUERY_TYPE))));
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (BATCH_WITHOUT_BINDS_MATCHER.matches(tree, state)) {
+            return buildDescription(tree).setMessage(ERROR_MESSAGE).build();
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JooqBatchWithoutBindArgsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JooqBatchWithoutBindArgsTest.java
@@ -51,7 +51,7 @@ public final class JooqBatchWithoutBindArgsTest {
                         "  static final Queries QUERIES = DSL.queries(QUERY_LIST);",
                         "",
                         "  void f(DSLContext ctx, Table<? extends Record> table, Field<Integer> intField) {",
-                        fail ? "    // BUG: Diagnostic contains: Jooq batch methods that execute queries without" : "",
+                        fail ? "    // BUG: Diagnostic contains: jOOQ batch methods that execute without bind" : "",
                         "    ctx.batch(" + batchArgs + ").execute();",
                         "  }",
                         "}")

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JooqBatchWithoutBindArgsTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/JooqBatchWithoutBindArgsTest.java
@@ -1,0 +1,108 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * See {@code org.jooq.DSLContext#batch} docs to see which ones use bind args.
+ */
+public final class JooqBatchWithoutBindArgsTest {
+
+    private void testFail(String batchArgs) {
+        test(batchArgs, true);
+    }
+
+    private void testPass(String batchArgs) {
+        test(batchArgs, false);
+    }
+
+    private void test(String batchArgs, boolean fail) {
+        CompilationTestHelper.newInstance(JooqBatchWithoutBindArgs.class, getClass())
+                .addSourceLines(
+                        "Test.java",
+                        "import org.jooq.DSLContext;",
+                        "import org.jooq.Queries;",
+                        "import org.jooq.Query;",
+                        "import org.jooq.Table;",
+                        "import org.jooq.Record;",
+                        "import org.jooq.Field;",
+                        "import org.jooq.impl.DSL;",
+                        "import java.util.ArrayList;",
+                        "",
+                        "class Test {",
+                        "",
+                        "  static final ArrayList<Query> QUERY_LIST = new ArrayList<>();",
+                        "  static final Queries QUERIES = DSL.queries(QUERY_LIST);",
+                        "",
+                        "  void f(DSLContext ctx, Table<? extends Record> table, Field<Integer> intField) {",
+                        fail ? "    // BUG: Diagnostic contains: Jooq batch methods that execute queries without" : "",
+                        "    ctx.batch(" + batchArgs + ").execute();",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testPassSingleQueryString() {
+        // batch(String)
+        testPass("\"DELETE FROM table WHERE id = ?\"");
+    }
+
+    @Test
+    public void testFailStringArray() {
+        // batch(String...)
+        testFail("\"DELETE FROM table WHERE id = 1\", \"DELETE FROM table WHERE id = 2\"");
+    }
+
+    @Test
+    public void testPassStringWithBindsArray() {
+        // batch(String, Object[]...)
+        testPass("\"DELETE FROM table WHERE id = ?\", new Object[][]{{1}, {2}, {3}}");
+    }
+
+    @Test
+    public void testFailQueryList() {
+        // batch(Collection<? extends Query>)
+        testFail("QUERY_LIST");
+    }
+
+    @Test
+    public void testFailQueries() {
+        // batch(Queries)
+        testFail("QUERIES");
+    }
+
+    @Test
+    public void testPassSingleQuery() {
+        // batch(Query)
+        testPass("ctx.deleteFrom(table).where(intField.eq((Integer) null))");
+    }
+
+    @Test
+    public void testFailQueryArray() {
+        // batch(Query...)
+        testFail("ctx.deleteFrom(table).where(intField.eq(1)), ctx.selectFrom(table).where(intField.eq(2))");
+    }
+
+    @Test
+    public void testPassQueryWithBindsArray() {
+        // batch(Query, Object[]...)
+        testPass("ctx.deleteFrom(table).where(intField.eq((Integer) null)), new Object[][]{{1}, {2}, {3}}");
+    }
+}

--- a/changelog/@unreleased/pr-2506.v2.yml
+++ b/changelog/@unreleased/pr-2506.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add error-prone check JooqBatchWithoutBindArgs
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2506


### PR DESCRIPTION
## Before this PR
Jooq provides multiple methods to execute queries in batches. Some of these methods end up executing queries without bind args which can cause performance problems.

## After this PR
Disallow jOOQ's batch methods that execute queries without bind args. Batch methods that do use bind args should be used instead.

==COMMIT_MSG==
Add error-prone check JooqBatchWithoutBindArgs
==COMMIT_MSG==

## Possible downsides?


