### PR TITLE
Add OptionalOrElseMethodInvocation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `DangerousStringInternUsage`: Disallow String.intern() invocations in favor of more predictable, scalable alternatives.
 - `OptionalOrElseThrowThrows`: Optional.orElseThrow argument must return an exception, not throw one.
 - `OptionalOrElseGetValue`: Prefer `Optional.orElse(value)` over `Optional.orElseGet(() -> value)` for trivial expressions.
+- `OptionalOrElseMethodInvocation`: Prefer `Optional.orElseGet(() -> methodInvocation())` over `Optional.orElse(methodInvocation())`.
 - `LambdaMethodReference`: Lambda should use a method reference.
 - `SafeLoggingExceptionMessageFormat`: SafeLoggable exceptions do not interpolate parameters.
 - `StrictUnusedVariable`: Functions shouldn't have unused parameters.


### PR DESCRIPTION
## Before this PR
The OptionalOrElseMethodInvocation error-prone check was missing from the README.

## After this PR
==COMMIT_MSG==
Add a line for an error-prone check added in #655, which is missing from the README.
==COMMIT_MSG==

## Possible downsides?
None known

