### PR TITLE
SafeLoggingPropagation uses new ASTHelpers.isRecord function

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -114,7 +114,7 @@ public final class SafeLoggingPropagation extends BugChecker
         if (classSymbol == null || classSymbol.isAnonymous()) {
             return Description.NO_MATCH;
         }
-        if (isRecord(classSymbol)) {
+        if (ASTHelpers.isRecord(classSymbol)) {
             return matchRecord(classTree, classSymbol, state);
         } else {
             return matchClassOrInterface(classTree, classSymbol, state);
@@ -163,11 +163,6 @@ public final class SafeLoggingPropagation extends BugChecker
         return MoreAnnotations.getValue(styleAnnotation, "defaultAsDefault")
                 .map(attr -> (boolean) attr.getValue())
                 .orElse(false);
-    }
-
-    private static boolean isRecord(ClassSymbol classSymbol) {
-        // Can use classSymbol.isRecord() in future versions
-        return (classSymbol.flags() & 1L << 61) != 0;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
No need to declare this ourselves. Introduced in 2.17 by https://github.com/google/error-prone/commit/640bc78870f1100ee38b96566de988d7b433de26

==COMMIT_MSG==
SafeLoggingPropagation uses new ASTHelpers.isRecord function
==COMMIT_MSG==

