### PR TITLE
StrictUnusedVariable is not suppressed when UnusedVariable is disabled

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -325,7 +325,7 @@ public class StrictUnusedVariableTest {
     }
 
     @Test
-    public void testSuppression() {
+    public void testParameterSuppression() {
         refactoringTestHelper
                 .addInputLines(
                         "Test.java",
@@ -334,6 +334,47 @@ public class StrictUnusedVariableTest {
                         "  public static void b(@SuppressWarnings(\"UnusedVariable\") int val) {}",
                         "  public static void c(@SuppressWarnings(\"unused\") int val) {}",
                         "  public static void d(int _val) {}",
+                        "}")
+                .expectUnchanged()
+                .doTest(TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testMethodSuppression() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  @SuppressWarnings(\"StrictUnusedVariable\")",
+                        "  public static void a(int val) {}",
+                        "  @SuppressWarnings(\"UnusedVariable\")",
+                        "  public static void b(int val) {}",
+                        "  @SuppressWarnings(\"unused\")",
+                        "  public static void c(int val) {}",
+                        "  public static void d(int _val) {}",
+                        "}")
+                .expectUnchanged()
+                .doTest(TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void testClassSuppression() {
+        refactoringTestHelper
+                .addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "  @SuppressWarnings(\"StrictUnusedVariable\")",
+                        "  class Test1 {",
+                        "    public static void a(int val) {}",
+                        "  }",
+                        "  @SuppressWarnings(\"UnusedVariable\")",
+                        "  class Test2 {",
+                        "    public static void a(int val) {}",
+                        "  }",
+                        "  @SuppressWarnings(\"unused\")",
+                        "  class Test3 {",
+                        "    public static void a(int val) {}",
+                        "  }",
                         "}")
                 .expectUnchanged()
                 .doTest(TestMode.TEXT_MATCH);

--- a/changelog/@unreleased/pr-2537.v2.yml
+++ b/changelog/@unreleased/pr-2537.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: StrictUnusedVariable is not suppressed when UnusedVariable is disabled
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2537


### PR DESCRIPTION
This is a workaround for error-prone#3831

Unfortunately, we disable UnusedVariable by default because it duplicates StrictUnusedVariable. I've removed the `UnusedVariable` alternative name from StrictUnusedVariable to avoid this collateral damage, while updating the `isSuppressed` check with an override which handles existing suppressions gracefully.

==COMMIT_MSG==
StrictUnusedVariable is not suppressed when UnusedVariable is disabled
==COMMIT_MSG==

## Possible downsides?
Rollout will catch the places where StrictUnusedVariable has regressed, slowing adoption.

