### PR TITLE
Fix #2543 CardinalityEqualsZero equality comparison check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CardinalityEqualsZero.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/CardinalityEqualsZero.java
@@ -31,7 +31,9 @@ import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.Tree.Kind;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import org.immutables.value.Value.Immutable;
 
@@ -58,8 +60,11 @@ public final class CardinalityEqualsZero extends BugChecker implements BugChecke
 
         EqualsZeroExpression equalsZeroExpression = maybeEqualsZeroExpression.get();
         ExpressionTree operand = equalsZeroExpression.operand();
-        ExpressionTree collectionInstance = ASTHelpers.getReceiver(operand);
+        if (!Objects.equals(operand.getKind(), Kind.METHOD_INVOCATION)) {
+            return Description.NO_MATCH;
+        }
 
+        ExpressionTree collectionInstance = ASTHelpers.getReceiver(operand);
         if (collectionInstance == null || isExpressionThis(collectionInstance)) {
             return Description.NO_MATCH;
         }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CardinalityEqualsZeroTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/CardinalityEqualsZeroTest.java
@@ -267,6 +267,28 @@ public class CardinalityEqualsZeroTest {
     }
 
     @Test
+    public void test_equals_on_non_collection() {
+        fix().addInputLines(
+                        "TestNonCollection.java",
+                        "class TestNonCollection {",
+                        "  public int size() {",
+                        "    return 0;",
+                        "  }",
+                        "  public boolean foo(String key) {",
+                        "    String current = \"x\";",
+                        "    int comparisonResult = current.compareTo(key);",
+                        "    if (comparisonResult == 0) {",
+                        "         return true;",
+                        "    } else {",
+                        "         return false;",
+                        "    }",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
     public void test_qualified_this() {
         fix().addInputLines(
                         "TestQualifiedThis.java",

--- a/changelog/@unreleased/pr-2544.v2.yml
+++ b/changelog/@unreleased/pr-2544.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Fix #2543 CardinalityEqualsZero equality comparison check'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2544


### PR DESCRIPTION
## Before this PR

Closes #2543 

## What happened?

PR https://github.com/palantir/tritium/pull/1688 is failing attempting to upgrade to gradle-baseline  5.2.0 with change https://github.com/palantir/gradle-baseline/pull/2530 on https://github.com/palantir/tritium/blob/13799047a8b715b4ebf395de80deed78a86b734c/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java#L120-L123

```
> Task :tritium-registry:compileJava FAILED
/home/circleci/project/tritium-registry/src/main/java/com/palantir/tritium/metrics/registry/TagMap.java:123: error: An unhandled exception was thrown by the Error Prone static analysis plugin.
            if (comparisonResult == 0) {
                                 ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.18.0
     BugPattern: CardinalityEqualsZero
     Stack Trace:
     java.lang.IllegalStateException: Expected expression 'comparisonResult' to be a method invocation or field access, but was IDENTIFIER
  	at com.google.errorprone.util.ASTHelpers.getReceiver(ASTHelpers.java:605)
  	at com.palantir.baseline.errorprone.CardinalityEqualsZero.matchBinary(CardinalityEqualsZero.java:61)
  	at com.google.errorprone.scanner.ErrorProneScanner.processMatchers(ErrorProneScanner.java:449)
  	at com.google.errorprone.scanner.ErrorProneScanner.visitBinary(ErrorProneScanner.java:512)
  	at com.google.errorprone.scanner.ErrorProneScanner.visitBinary(ErrorProneScanner.java:150)
```




## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix #2543 CardinalityEqualsZero equality comparison check
==COMMIT_MSG==



## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

