### PR TITLE
Stop suggesting the save actions plugin

### DIFF
--- a/changelog/@unreleased/pr-2547.v2.yml
+++ b/changelog/@unreleased/pr-2547.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: No longer suggest the "Save Actions" IntelliJ plugin which does not
+    work in IntelliJ 2023.1 for use with Palantir Java Format. Instead, Palantir Java
+    Format will support the IntelliJ native "Actions on save" reformat capability
+    in a future release.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2547

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineIdeaIntegrationTest.groovy
@@ -313,56 +313,6 @@ class BaselineIdeaIntegrationTest extends AbstractPluginTest {
         !otherSubprojectIml.exists()
     }
 
-    def "idea configures the save-action plugin when PJF is enabled on a subproject"() {
-        buildFile << standardBuildFile
-        multiProject.addSubproject('formatted-project', """
-            apply plugin: 'com.palantir.java-format'
-        """.stripIndent())
-
-        when:
-        with('idea').build()
-
-        then:
-        def iprFile = new File(projectDir, "${moduleName}.ipr")
-        def ipr = new XmlSlurper().parse(iprFile)
-        ipr.component.find { it.@name == "ExternalDependencies" }
-        ipr.component.find { it.@name == "SaveActionSettings" }
-    }
-
-    def "idea does not configure the save-action plugin when PJF is not enabled"() {
-        buildFile << standardBuildFile
-
-        when:
-        with('idea').build()
-
-        then:
-        def iprFile = new File(projectDir, "${moduleName}.ipr")
-        def ipr = new XmlSlurper().parse(iprFile)
-        !ipr.component.find { it.@name == "ExternalDependencies" }
-        !ipr.component.find { it.@name == "SaveActionSettings" }
-    }
-
-    @RestoreSystemProperties
-    def "idea configures the save-action plugin for IntelliJ import"() {
-        buildFile << standardBuildFile
-        multiProject.addSubproject('formatted-project', """
-            apply plugin: 'com.palantir.java-format'
-        """.stripIndent())
-
-        when:
-        System.setProperty("idea.active", "true")
-        with().build()
-
-        then:
-        def saveActionsSettingsFile = new File(projectDir, ".idea/saveactions_settings.xml")
-        def settings = new XmlSlurper().parse(saveActionsSettingsFile)
-        settings.component.find { it.@name == "SaveActionSettings" }
-
-        def externalDepsSettingsFile = new File(projectDir, ".idea/externalDependencies.xml")
-        def deps = new XmlSlurper().parse(externalDepsSettingsFile)
-        deps.component.find { it.@name == "ExternalDependencies" }
-    }
-
     def 'Idea files use versions derived from the baseline-java-versions plugin'() {
         when:
         buildFile << standardBuildFile


### PR DESCRIPTION
## Before this PR
The save actions plugin is broken in IntelliJ 2023.1. It is unmaintained and there is no official fix.

In 2021.2, IntelliJ introduced a [new built in reformat on save feature](https://blog.jetbrains.com/idea/2021/07/intellij-idea-2021-2/#key_updates:~:text=We%E2%80%99ve%20added%20several%20actions%20that%20the%20IDE%20will%20initiate%20when%20you%20save%20the%20project%2C%20including%20reformatting%20code).

## After this PR
==COMMIT_MSG==
No longer suggest the "Save Actions" IntelliJ plugin which does not work in IntelliJ 2023.1 for use with Palantir Java Format. Instead, Palantir Java Format will support the IntelliJ native "Actions on save" reformat capability in a future release.
==COMMIT_MSG==

## Possible downsides?
Why this code is in gradle-baseline rather than the palantir-java-format gradle plugin I _do not_ understand. It's going to make fixing this issue quite a bit harder.