### PR TITLE
Remove Save Actions external dep from persistent .idea config

### DIFF
--- a/changelog/@unreleased/pr-2551.v2.yml
+++ b/changelog/@unreleased/pr-2551.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Ensure all recommendations to install the "Save Actions" plugin are
+    removed in persistent config in the `.idea` config directory.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2551

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/GroovyXmlUtils.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/GroovyXmlUtils.groovy
@@ -23,6 +23,7 @@ final class GroovyXmlUtils {
             Map attributes = [:],
             Map defaults = [:],
             @DelegatesTo(value = Node, strategy = Closure.DELEGATE_FIRST) Closure ifCreated = {}) {
+
         def child = base[name].find { it.attributes().entrySet().containsAll(attributes.entrySet()) }
         if (child) {
             return child
@@ -32,5 +33,10 @@ final class GroovyXmlUtils {
         ifCreated.delegate = created
         ifCreated(created)
         return created
+    }
+
+    static Optional<Node> matchChild(Node base, String name, Map attributes = [:]) {
+        Node child = base[name].find { it.attributes().entrySet().containsAll(attributes.entrySet()) }
+        return Optional.ofNullable(child)
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/XmlUtils.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/XmlUtils.java
@@ -34,6 +34,14 @@ import org.xml.sax.SAXException;
 final class XmlUtils {
     private XmlUtils() {}
 
+    static void updateXmlFileIfExists(File configurationFile, Consumer<Node> configure) {
+        if (!configurationFile.exists()) {
+            return;
+        }
+
+        createOrUpdateXmlFile(configurationFile, configure);
+    }
+
     static void createOrUpdateXmlFile(File configurationFile, Consumer<Node> configure) {
         createOrUpdateXmlFile(
                 configurationFile, configure, () -> new Node(null, "project", ImmutableMap.of("version", "4")));


### PR DESCRIPTION
## Before this PR
In #2547, we stopped adding suggestions to install the Save Actions plugin. However, `.idea` configuration is persistent and mutable - when you do a Gradle sync in IntelliJ we modify the settings files. For pre-existing repos that have had the Save Actions plugin added to the `externalDependencies.xml`, it will stay there until either removed by either a human or Gradle plugin.

## After this PR
==COMMIT_MSG==
Ensure all recommendations to install the "Save Actions" plugin are removed in persistent config in the `.idea` config directory.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

