### PR TITLE
fix eclipse classpath generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 .java-version
 .project
 .settings
+.factorypath
+.apt_generated_tests/
+bin/
 build
 out/
 docs/node_modules/

--- a/changelog/@unreleased/pr-2563.v2.yml
+++ b/changelog/@unreleased/pr-2563.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Fix eclipse classpath generation.
+
+    Generating eclipse classpath will merge new entries into the existing classpath. This will delete the existing classpath, which makes the classpath correct when it changes.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2563

--- a/changelog/@unreleased/pr-2563.v2.yml
+++ b/changelog/@unreleased/pr-2563.v2.yml
@@ -1,8 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    Fix eclipse classpath generation.
-
-    Generating eclipse classpath will merge new entries into the existing classpath. This will delete the existing classpath, which makes the classpath correct when it changes.
+    Fix eclipse classpath generation by deleting the existing classpath, which makes the classpath correct when it changes.
   links:
   - https://github.com/palantir/gradle-baseline/pull/2563

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineEclipse.groovy
@@ -140,6 +140,8 @@ class BaselineEclipse extends AbstractBaselinePlugin {
                             containers.add(eclipseClassPath)
                         }
                     }
+                    // Delete classpath instead of merging with existing classpath
+                    dependsOn "cleanEclipseClasspath"
                 }
             }
         })


### PR DESCRIPTION
Before, generating eclipse classpath will merge new entries into the existing classpath. This will delete the existing classpath, which makes the classpath correct when it changes.

Also add a few eclipse generated files to gitignore.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Eclipse classpath generation doesn't work when it merges the new classpath with the old classpath. It produces incorrect entries and eclipse will complain that the classpath is invalid.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix eclipse classpath generation by deleting the existing classpath, which makes the classpath correct when it changes.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None.
