### PR TITLE
Add instructions for turning error-prone's warnings into errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ tasks.withType(JavaCompile).configureEach(new Action<Task>() {
 })
 ```
 
+To turn all of error-prone's warnings into errors:
+
+```gradle
+allprojects {
+    tasks.withType(JavaCompile) {
+        options.compilerArgs += ['-Werror']
+    }
+}
+```
+
 More information on error-prone severity handling can be found at [errorprone.info/docs/flags](http://errorprone.info/docs/flags).
 
 #### Baseline error-prone checks


### PR DESCRIPTION
## Before this PR
Users looking to turn error-prone's warnings into errors have to find it by copying another project, instead of referring to canonical docs.

## After this PR
==COMMIT_MSG==
Add instructions for turning error-prone's warnings into errors
==COMMIT_MSG==

## Possible downsides?
There seem to be several ways to do this, and the one I've picked may not be the most idiomatic gradle.  I've also seen:

- in this [gradle-baseline](https://github.com/palantir/gradle-baseline/blob/370f4a66ac1693d9ef1adaee2e3f14b1a977a284/build.gradle#L48) repo (only enabled for projects with java plugins):
```
allprojects {
    pluginManager.withPlugin('java') {
        tasks.withType(JavaCompile) {
            options.compilerArgs += ['-Werror']
        }
    }
}
```

- in [gradle-git-version](https://github.com/palantir/gradle-git-version/blob/8feef51ad1e75e1fd224e10760f4eb60beb083f1/build.gradle#L74-L76) (not inside allprojects):
```
tasks.withType(JavaCompile) {
    options.compilerArgs += ['-Werror', '-Xlint:deprecation']
}
```

- in [conjure](https://github.com/palantir/conjure/blob/1c904a86a85a65d22c8a282e7b1e73dce7ac69ec/build.gradle#L66) (configured on some subprojects):
```
configure(subprojects - project(':conjure-api')) {
    tasks.withType(JavaCompile) {
        options.compilerArgs += ['-Werror']
    }
}
```