### PR TITLE
Only pass posix file attributes if not on Windows

### DIFF
--- a/changelog/@unreleased/pr-2577.v2.yml
+++ b/changelog/@unreleased/pr-2577.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+improvement:
+  description: |-
+    Only pass posix file attributes if not on Windows
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2577

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCircleCi.java
@@ -104,7 +104,8 @@ public final class BaselineCircleCi implements Plugin<Project> {
     }
 
     private static void createDirectories(Path directoryPath) throws IOException {
-        boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
+        boolean isWindows =
+                System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
         if (isWindows) {
             Files.createDirectories(directoryPath);
         } else {


### PR DESCRIPTION
The CircleCI plugin fails to apply if running on a Windows circle runner because of unsupported file attributes being passed on creating directories.

==COMMIT_MSG==
Only pass posix file attributes if not on Windows
==COMMIT_MSG==
