### PR TITLE
Don't ignore all directories named build/

### DIFF
--- a/changelog/@unreleased/pr-2578.v2.yml
+++ b/changelog/@unreleased/pr-2578.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Don't ignore all directories named build/
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2578

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -186,7 +186,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // Error-prone normalizes filenames to use '/' path separator:
         // https://github.com/google/error-prone/blob/c601758e81723a8efc4671726b8363be7a306dce
         // /check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java#L1277-L1285
-        return ".*/(build|generated_.*[sS]rc|src/generated.*)/.*";
+        return ".*/((build/.*)?generated_.*[sS]rc|src/generated.*)/.*";
     }
 
     private static Optional<Stream<String>> getSpecificErrorProneChecks(Project project) {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -186,7 +186,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // Error-prone normalizes filenames to use '/' path separator:
         // https://github.com/google/error-prone/blob/c601758e81723a8efc4671726b8363be7a306dce
         // /check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java#L1277-L1285
-        return ".*/((build/.*)?generated_.*[sS]rc|src/generated.*)/.*";
+        return ".*/(build/generated.*|src/generated.*|generated_[^/]*[sS]rc)/.*";
     }
 
     private static Optional<Stream<String>> getSpecificErrorProneChecks(Project project) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineErrorProneTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineErrorProneTest.groovy
@@ -26,7 +26,8 @@ class BaselineErrorProneTest extends Specification {
         def predicate = Pattern.compile(excludedPaths).asPredicate()
 
         then:
-        predicate.test 'tritium-core/build/metricSchema/generated_src'
+        predicate.negate().test 'service/src/main/java/com/palantir/service/build/output/ServiceOutputManager.java'
+        predicate.test 'tritium-core/build/metricSchema/generated_src/'
         predicate.test 'tritium-registry/generated_src/com/palantir/tritium/metrics/registry/ImmutableMetricName.java'
         predicate.test 'tritium-metrics/build/metricSchema/generated_src/com/palantir/tritium/metrics/TlsMetrics.java'
         predicate.test 'tritium-jmh/generated_testSrc/com/palantir/tritium/microbenchmarks/generated/ProxyBenchmark_jmhType.java'

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineErrorProneTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineErrorProneTest.groovy
@@ -27,6 +27,8 @@ class BaselineErrorProneTest extends Specification {
 
         then:
         predicate.negate().test 'service/src/main/java/com/palantir/service/build/output/ServiceOutputManager.java'
+        predicate.negate().test 'service/src/main/java/com/palantir/service/build/output/generated/'
+        predicate.test 'tritium-core/build/generated/'
         predicate.test 'tritium-core/build/metricSchema/generated_src/'
         predicate.test 'tritium-registry/generated_src/com/palantir/tritium/metrics/registry/ImmutableMetricName.java'
         predicate.test 'tritium-metrics/build/metricSchema/generated_src/com/palantir/tritium/metrics/TlsMetrics.java'


### PR DESCRIPTION
## Before this PR
Previously, error prone would ignore all directories with build/ anywhere in the path, even for non-generated source code. This PR switches to only ignoring directories with both `build/` and `generated_src` somewhere in the full path.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Don't ignore all directories named build/
==COMMIT_MSG==

## Possible downsides?
If there are build/ directories containing generated code without a generated directory, gradle baseline will now scan the code and could block merge/release.