### PR TITLE
Revert "Don't ignore all directories named build/ (#2578)"

### DIFF
--- a/changelog/@unreleased/pr-2582.v2.yml
+++ b/changelog/@unreleased/pr-2582.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Revert "Don't ignore all directories named build/ (#2578)" which failed
+    to ignore some generated files within the build directory
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2582

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -186,7 +186,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // Error-prone normalizes filenames to use '/' path separator:
         // https://github.com/google/error-prone/blob/c601758e81723a8efc4671726b8363be7a306dce
         // /check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java#L1277-L1285
-        return ".*/(build/generated.*|src/generated.*|generated_[^/]*[sS]rc)/.*";
+        return ".*/(build|generated_.*[sS]rc|src/generated.*)/.*";
     }
 
     private static Optional<Stream<String>> getSpecificErrorProneChecks(Project project) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineErrorProneTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineErrorProneTest.groovy
@@ -26,10 +26,7 @@ class BaselineErrorProneTest extends Specification {
         def predicate = Pattern.compile(excludedPaths).asPredicate()
 
         then:
-        predicate.negate().test 'service/src/main/java/com/palantir/service/build/output/ServiceOutputManager.java'
-        predicate.negate().test 'service/src/main/java/com/palantir/service/build/output/generated/'
-        predicate.test 'tritium-core/build/generated/'
-        predicate.test 'tritium-core/build/metricSchema/generated_src/'
+        predicate.test 'tritium-core/build/metricSchema/generated_src'
         predicate.test 'tritium-registry/generated_src/com/palantir/tritium/metrics/registry/ImmutableMetricName.java'
         predicate.test 'tritium-metrics/build/metricSchema/generated_src/com/palantir/tritium/metrics/TlsMetrics.java'
         predicate.test 'tritium-jmh/generated_testSrc/com/palantir/tritium/microbenchmarks/generated/ProxyBenchmark_jmhType.java'


### PR DESCRIPTION
This reverts commit e5a61393bb56c6a8d5bc17e3912d7938bb92aa8b.

==COMMIT_MSG==
Revert "Don't ignore all directories named build/ (#2578)" which failed to ignore some generated files within the build directory
==COMMIT_MSG==

I agree with the original goal, but we must revert to unblock folks in the meantime