### PR TITLE
Opt out of the 'NotJavadoc' errorprone check

### DIFF
--- a/changelog/@unreleased/pr-2591.v2.yml
+++ b/changelog/@unreleased/pr-2591.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Opt out of the 'NotJavadoc' errorprone check
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2591

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -132,6 +132,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "CatchSpecificity",
                 "CanIgnoreReturnValueSuggester",
                 "InlineMeSuggester",
+                // We often use javadoc comments without javadoc parameter information.
+                "NotJavadoc",
                 "PreferImmutableStreamExCollections",
                 // StringCaseLocaleUsage duplicates our existing DefaultLocale check which is already
                 // enforced in some places.


### PR DESCRIPTION
We often use this style, it's not worth blocking baseline upgrades.
==COMMIT_MSG==
Opt out of the 'NotJavadoc' errorprone check
==COMMIT_MSG==
