### PR TITLE
Add error-prone check to prefer ZoneId constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `UnnecessarilyQualified`: Types should not be qualified if they are also imported.
 - `DeprecatedGuavaObjects`: `com.google.common.base.Objects` has been obviated by `java.util.Objects`.
 - `JavaTimeSystemDefaultTimeZone`: Avoid using the system default time zone.
+- `ZoneIdConstant`: Prefer `ZoneId` constants.
 - `IncubatingMethod`: Prevents calling Conjure incubating APIs unless you explicitly opt-out of the check on a per-use or per-project basis.
 - `CompileTimeConstantViolatesLiskovSubstitution`: Requires consistent application of the `@CompileTimeConstant` annotation to resolve inconsistent validation based on the reference type on which the met is invoked.
 - `ClassInitializationDeadlock`: Detect type structures which can cause deadlocks initializing classes.

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ZoneIdConstant.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ZoneIdConstant.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.MethodInvocationTree;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.WARNING,
+        summary = "Prefer ZoneId constants.")
+public final class ZoneIdConstant extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final Matcher<MethodInvocationTree> ZONE_ID_OF_UTC_MATCHER = Matchers.allOf(
+            Matchers.staticMethod().onClass(ZoneId.class.getName()).named("of").withParameters(String.class.getName()),
+            Matchers.argument(0, Matchers.stringLiteral("UTC")));
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (ZONE_ID_OF_UTC_MATCHER.matches(tree, state)) {
+            SuggestedFix.Builder fix = SuggestedFix.builder();
+            return buildDescription(tree)
+                    .addFix(fix.replace(
+                                    tree, SuggestedFixes.qualifyType(state, fix, ZoneOffset.class.getName()) + ".UTC")
+                            .build())
+                    .build();
+        }
+
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ZoneIdConstantTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ZoneIdConstantTest.java
@@ -1,0 +1,47 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.baseline.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+final class ZoneIdConstantTest {
+
+    @Test
+    void zoneIdUtc() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import java.time.ZoneId;",
+                        "class Test {",
+                        "  static void f() {",
+                        "    ZoneId zoneId = ZoneId.of(\"UTC\");",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.time.ZoneId;",
+                        "import java.time.ZoneOffset;",
+                        "class Test {",
+                        "  static void f() {",
+                        "    ZoneId zoneId = ZoneOffset.UTC;",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(ZoneIdConstant.class, getClass());
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ZoneIdConstantTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ZoneIdConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.palantir.baseline.errorprone;
 
 import org.junit.jupiter.api.Test;
 
 final class ZoneIdConstantTest {
+
+    @Test
+    void zoneIdZ() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import java.time.ZoneId;",
+                        "class Test {",
+                        "  static void f() {",
+                        "    ZoneId zoneId = ZoneId.of(\"Z\");",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.time.ZoneId;",
+                        "import java.time.ZoneOffset;",
+                        "class Test {",
+                        "  static void f() {",
+                        "    ZoneId zoneId = ZoneOffset.UTC;",
+                        "  }",
+                        "}")
+                .doTest();
+    }
 
     @Test
     void zoneIdUtc() {
@@ -34,6 +57,30 @@ final class ZoneIdConstantTest {
                         "import java.time.ZoneId;",
                         "import java.time.ZoneOffset;",
                         "class Test {",
+                        "  static void f() {",
+                        "    ZoneId zoneId = ZoneOffset.UTC;",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void zoneIdConstant() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import java.time.ZoneId;",
+                        "class Test {",
+                        "  static final String Z = \"Z\";",
+                        "  static void f() {",
+                        "    ZoneId zoneId = ZoneId.of(Z);",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import java.time.ZoneId;",
+                        "import java.time.ZoneOffset;",
+                        "class Test {",
+                        "  static final String Z = \"Z\";",
                         "  static void f() {",
                         "    ZoneId zoneId = ZoneOffset.UTC;",
                         "  }",

--- a/changelog/@unreleased/pr-2596.v2.yml
+++ b/changelog/@unreleased/pr-2596.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add error-prone check to prefer ZoneId constants
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2596

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -80,6 +80,7 @@ public class BaselineErrorProneExtension {
             "UnsafeGaugeRegistration",
             "VarUsage",
             "ZeroWarmupRateLimiter",
+            "ZoneIdConstant",
 
             // Built-in checks
             "ArrayEquals",


### PR DESCRIPTION
Replaces `ZoneId.of("UTC")` with the equivalent, but simpler `ZoneOffset.UTC`.