### PR TITLE
Fix unintentional suppression of StrictUnusedVariable

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -67,7 +67,10 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.UnusedVariable;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.ChildMultiMatcher.MatchType;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
@@ -92,6 +95,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.VariableTree;
@@ -124,7 +128,6 @@ import javax.lang.model.element.Name;
  */
 @AutoService(BugChecker.class)
 @BugPattern(
-        altNames = {"unused", "UnusedVariable"},
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         summary = "Unused.",
@@ -159,6 +162,21 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             // TAG fields are used by convention in Android apps.
             "TAG");
     private static final String UNUSED = "unused";
+
+    private static final Matcher<Tree> ALTERNATIVE_SUPPRESSED = Matchers.allOf(
+            // Matchers.annotations will throw given a tree that doesn't support annotations, so we must enumerate
+            // supported types.
+            Matchers.kindAnyOf(Set.of(
+                    Kind.CLASS, Kind.VARIABLE, Kind.METHOD, Kind.ANNOTATED_TYPE, Kind.PACKAGE, Kind.COMPILATION_UNIT)),
+            Matchers.annotations(
+                    MatchType.AT_LEAST_ONE,
+                    Matchers.allOf(
+                            Matchers.isType("java.lang.SuppressWarnings"),
+                            Matchers.hasArgumentWithValue(
+                                    "value",
+                                    Matchers.anyOf(
+                                            Matchers.stringLiteral("UnusedVariable"),
+                                            Matchers.stringLiteral(UNUSED))))));
 
     @Override
     public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
@@ -275,6 +293,11 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                     .addFix(constructUsedVariableSuggestedFix(usageSites, state))
                     .build());
         });
+    }
+
+    @Override
+    public boolean isSuppressed(Tree tree, VisitorState state) {
+        return super.isSuppressed(tree, state) || ALTERNATIVE_SUPPRESSED.matches(tree, state);
     }
 
     private static SuggestedFix constructUsedVariableSuggestedFix(List<TreePath> usagePaths, VisitorState state) {

--- a/changelog/@unreleased/pr-2599.v2.yml
+++ b/changelog/@unreleased/pr-2599.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix unintentional suppression of StrictUnusedVariable
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2599

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -96,6 +96,24 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         result.output.contains("[ArrayEquals] Reference equality used to compare arrays")
     }
 
+    def 'compileJava fails when StrictUnusedVariable finds errors'() {
+        when:
+        buildFile << standardBuildFile
+        file('src/main/java/test/Test.java') << '''
+        package test;
+        public class Test {
+            void test() {
+                int a = 5;
+            }
+        }
+        '''.stripIndent()
+
+        then:
+        BuildResult result = with('compileJava').buildAndFail()
+        result.task(":compileJava").outcome == TaskOutcome.FAILED
+        result.output.contains("[StrictUnusedVariable]")
+    }
+
     def 'error-prone can be disabled using property'() {
         when:
         buildFile << standardBuildFile


### PR DESCRIPTION
StrictUnusedVariable was suppressed due to disablement of the upstream UnusedVariable check matched in alt-names.
==COMMIT_MSG==
Fix unintentional suppression of StrictUnusedVariable
==COMMIT_MSG==

