### PR TITLE
Make custom jdks work with gradle 8 😅 

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaCompiler.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaCompiler.java
@@ -16,102 +16,23 @@
 
 package com.palantir.baseline.plugins.javaversions;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Proxy;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.internal.file.FileFactory;
-import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
-import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainJavaCompiler;
 import org.gradle.jvm.toolchain.internal.JavaCompilerFactory;
-import org.gradle.jvm.toolchain.internal.JavaToolchain;
-import org.gradle.jvm.toolchain.internal.JavaToolchainInput;
-import org.gradle.jvm.toolchain.internal.ToolchainToolFactory;
-import org.gradle.util.GradleVersion;
+import org.gradle.language.base.internal.compile.CompileSpec;
 
 final class BaselineJavaCompiler extends DefaultToolchainJavaCompiler {
 
     private final JavaInstallationMetadata javaInstallationMetadata;
+    private final JavaCompilerFactory compilerFactory;
 
     BaselineJavaCompiler(JavaInstallationMetadata javaInstallationMetadata, ServiceRegistry serviceRegistry) {
-        super(toolchain(javaInstallationMetadata, serviceRegistry), serviceRegistry.get(JavaCompilerFactory.class));
+        super(null, null);
         this.javaInstallationMetadata = javaInstallationMetadata;
-    }
-
-    private static JavaToolchain toolchain(JavaInstallationMetadata metadata, ServiceRegistry serviceRegistry) {
-        try {
-            JvmInstallationMetadata jvmInstallationMetadata = jvmInstallationMetadata(metadata);
-            if (GradleVersion.current().compareTo(GradleVersion.version("7.6")) < 0) {
-                return new JavaToolchain(
-                        jvmInstallationMetadata,
-                        serviceRegistry.get(JavaCompilerFactory.class),
-                        serviceRegistry.get(ToolchainToolFactory.class),
-                        serviceRegistry.get(FileFactory.class),
-                        null);
-            } else if (GradleVersion.current().compareTo(GradleVersion.version("8.0")) < 0) {
-                Constructor<JavaToolchain> gradle76Constructor = JavaToolchain.class.getDeclaredConstructor(
-                        JvmInstallationMetadata.class,
-                        JavaCompilerFactory.class,
-                        ToolchainToolFactory.class,
-                        FileFactory.class,
-                        JavaToolchainInput.class,
-                        BuildOperationProgressEventEmitter.class);
-                return gradle76Constructor.newInstance(
-                        jvmInstallationMetadata,
-                        serviceRegistry.get(JavaCompilerFactory.class),
-                        serviceRegistry.get(ToolchainToolFactory.class),
-                        serviceRegistry.get(FileFactory.class),
-                        null,
-                        null);
-            } else if (GradleVersion.current().compareTo(GradleVersion.version("8.2")) < 0) {
-                Constructor<JavaToolchain> gradle8Constructor = JavaToolchain.class.getDeclaredConstructor(
-                        JvmInstallationMetadata.class,
-                        JavaCompilerFactory.class,
-                        ToolchainToolFactory.class,
-                        FileFactory.class,
-                        JavaToolchainInput.class,
-                        boolean.class,
-                        BuildOperationProgressEventEmitter.class);
-                return gradle8Constructor.newInstance(
-                        jvmInstallationMetadata,
-                        serviceRegistry.get(JavaCompilerFactory.class),
-                        serviceRegistry.get(ToolchainToolFactory.class),
-                        serviceRegistry.get(FileFactory.class),
-                        null,
-                        false,
-                        null);
-            } else {
-                Constructor<JavaToolchain> gradle82Constructor = JavaToolchain.class.getDeclaredConstructor(
-                        JvmInstallationMetadata.class, FileFactory.class, JavaToolchainInput.class, boolean.class);
-                return gradle82Constructor.newInstance(
-                        jvmInstallationMetadata, serviceRegistry.get(FileFactory.class), null, false);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static JvmInstallationMetadata jvmInstallationMetadata(JavaInstallationMetadata metadata) {
-        return (JvmInstallationMetadata) Proxy.newProxyInstance(
-                JvmInstallationMetadata.class.getClassLoader(),
-                new Class[] {JvmInstallationMetadata.class},
-                (proxy, method, args) -> {
-                    switch (method.getName()) {
-                        case "getJavaHome":
-                            return metadata.getInstallationPath().getAsFile().toPath();
-                        case "getLanguageVersion":
-                            return JavaVersion.toVersion(
-                                    metadata.getLanguageVersion().asInt());
-                        case "getImplementationVersion":
-                        case "getJavaVersion":
-                            return "1.8.0_221"; // fake version to appease runtime
-                        default:
-                            throw new UnsupportedOperationException(method.getName() + " not implemented here");
-                    }
-                });
+        this.compilerFactory = serviceRegistry.get(JavaCompilerFactory.class);
     }
 
     @Override
@@ -122,5 +43,11 @@ final class BaselineJavaCompiler extends DefaultToolchainJavaCompiler {
     @Override
     public RegularFile getExecutablePath() {
         return JavaInstallationMetadataUtils.findExecutable(javaInstallationMetadata, "javac");
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends CompileSpec> WorkResult execute(T spec) {
+        final Class<T> specType = (Class<T>) spec.getClass();
+        return compilerFactory.create(specType).execute(spec);
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaCompiler.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaCompiler.java
@@ -16,15 +16,102 @@
 
 package com.palantir.baseline.plugins.javaversions;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Proxy;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.file.RegularFile;
-import org.gradle.jvm.toolchain.JavaCompiler;
+import org.gradle.api.internal.file.FileFactory;
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
+import org.gradle.jvm.toolchain.internal.DefaultToolchainJavaCompiler;
+import org.gradle.jvm.toolchain.internal.JavaCompilerFactory;
+import org.gradle.jvm.toolchain.internal.JavaToolchain;
+import org.gradle.jvm.toolchain.internal.JavaToolchainInput;
+import org.gradle.jvm.toolchain.internal.ToolchainToolFactory;
+import org.gradle.util.GradleVersion;
 
-final class BaselineJavaCompiler implements JavaCompiler {
+final class BaselineJavaCompiler extends DefaultToolchainJavaCompiler {
+
     private final JavaInstallationMetadata javaInstallationMetadata;
 
-    BaselineJavaCompiler(JavaInstallationMetadata javaInstallationMetadata) {
+    BaselineJavaCompiler(JavaInstallationMetadata javaInstallationMetadata, ServiceRegistry serviceRegistry) {
+        super(toolchain(javaInstallationMetadata, serviceRegistry), serviceRegistry.get(JavaCompilerFactory.class));
         this.javaInstallationMetadata = javaInstallationMetadata;
+    }
+
+    private static JavaToolchain toolchain(JavaInstallationMetadata metadata, ServiceRegistry serviceRegistry) {
+        try {
+            JvmInstallationMetadata jvmInstallationMetadata = jvmInstallationMetadata(metadata);
+            if (GradleVersion.current().compareTo(GradleVersion.version("7.6")) < 0) {
+                return new JavaToolchain(
+                        jvmInstallationMetadata,
+                        serviceRegistry.get(JavaCompilerFactory.class),
+                        serviceRegistry.get(ToolchainToolFactory.class),
+                        serviceRegistry.get(FileFactory.class),
+                        null);
+            } else if (GradleVersion.current().compareTo(GradleVersion.version("8.0")) < 0) {
+                Constructor<JavaToolchain> gradle76Constructor = JavaToolchain.class.getDeclaredConstructor(
+                        JvmInstallationMetadata.class,
+                        JavaCompilerFactory.class,
+                        ToolchainToolFactory.class,
+                        FileFactory.class,
+                        JavaToolchainInput.class,
+                        BuildOperationProgressEventEmitter.class);
+                return gradle76Constructor.newInstance(
+                        jvmInstallationMetadata,
+                        serviceRegistry.get(JavaCompilerFactory.class),
+                        serviceRegistry.get(ToolchainToolFactory.class),
+                        serviceRegistry.get(FileFactory.class),
+                        null,
+                        null);
+            } else if (GradleVersion.current().compareTo(GradleVersion.version("8.2")) < 0) {
+                Constructor<JavaToolchain> gradle8Constructor = JavaToolchain.class.getDeclaredConstructor(
+                        JvmInstallationMetadata.class,
+                        JavaCompilerFactory.class,
+                        ToolchainToolFactory.class,
+                        FileFactory.class,
+                        JavaToolchainInput.class,
+                        boolean.class,
+                        BuildOperationProgressEventEmitter.class);
+                return gradle8Constructor.newInstance(
+                        jvmInstallationMetadata,
+                        serviceRegistry.get(JavaCompilerFactory.class),
+                        serviceRegistry.get(ToolchainToolFactory.class),
+                        serviceRegistry.get(FileFactory.class),
+                        null,
+                        false,
+                        null);
+            } else {
+                Constructor<JavaToolchain> gradle82Constructor = JavaToolchain.class.getDeclaredConstructor(
+                        JvmInstallationMetadata.class, FileFactory.class, JavaToolchainInput.class, boolean.class);
+                return gradle82Constructor.newInstance(
+                        jvmInstallationMetadata, serviceRegistry.get(FileFactory.class), null, false);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static JvmInstallationMetadata jvmInstallationMetadata(JavaInstallationMetadata metadata) {
+        return (JvmInstallationMetadata) Proxy.newProxyInstance(
+                JvmInstallationMetadata.class.getClassLoader(),
+                new Class[] {JvmInstallationMetadata.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getJavaHome":
+                            return metadata.getInstallationPath().getAsFile().toPath();
+                        case "getLanguageVersion":
+                            return JavaVersion.toVersion(
+                                    metadata.getLanguageVersion().asInt());
+                        case "getImplementationVersion":
+                        case "getJavaVersion":
+                            return "1.8.0_221"; // fake version to appease runtime
+                        default:
+                            throw new UnsupportedOperationException(method.getName() + " not implemented here");
+                    }
+                });
     }
 
     @Override

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/ConfiguredJavaToolchain.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/ConfiguredJavaToolchain.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.plugins.javaversions;
 
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.JavaLauncher;
@@ -25,16 +26,22 @@ import org.gradle.jvm.toolchain.JavadocTool;
 
 final class ConfiguredJavaToolchain implements BaselineJavaToolchain {
     private final ObjectFactory objectFactory;
+
+    private final ServiceRegistry serviceRegistry;
     private final Provider<JavaInstallationMetadata> javaInstallationMetadata;
 
-    ConfiguredJavaToolchain(ObjectFactory objectFactory, Provider<JavaInstallationMetadata> javaInstallationMetadata) {
+    ConfiguredJavaToolchain(
+            ObjectFactory objectFactory,
+            ServiceRegistry serviceRegistry,
+            Provider<JavaInstallationMetadata> javaInstallationMetadata) {
         this.objectFactory = objectFactory;
+        this.serviceRegistry = serviceRegistry;
         this.javaInstallationMetadata = javaInstallationMetadata;
     }
 
     @Override
     public Provider<JavaCompiler> javaCompiler() {
-        return javaInstallationMetadata.map(BaselineJavaCompiler::new);
+        return javaInstallationMetadata.map(metadata -> new BaselineJavaCompiler(metadata, serviceRegistry));
     }
 
     @Override

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/JavaToolchains.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/JavaToolchains.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.plugins.javaversions;
 
 import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.JavaToolchainService;
@@ -43,8 +44,10 @@ public final class JavaToolchains {
                                     .get()
                                     .getMetadata()));
 
+            ProjectInternal internalProject = (ProjectInternal) project;
             return new ConfiguredJavaToolchain(
                     project.getObjects(),
+                    internalProject.getServices(),
                     project.provider(() -> JavaInstallationMetadataProxy.proxyForVersion(
                             chosenJavaVersion.javaLanguageVersion(), configuredJdkMetadata)));
         });

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -277,6 +277,25 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         assertBytecodeVersion(compiledClass, JAVA_11_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE)
     }
 
+    def 'works on gradle 8'() {
+        when:
+        gradleVersion = '8.1.1'
+        buildFile << '''
+        javaVersions {
+            libraryTarget = 11
+            runtime = 17
+        }
+        '''.stripIndent(true)
+
+        file('src/main/java/Main.java') << java11CompatibleCode
+        File compiledClass = new File(projectDir, "build/classes/java/main/Main.class")
+
+        then:
+        ExecutionResult result = runTasksSuccessfully('run')
+        result.standardOutput.contains 'jdk11 features on runtime 17'
+        assertBytecodeVersion(compiledClass, JAVA_11_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE)
+    }
+
     def 'java 11 execution succeeds on java 17'() {
         when:
         buildFile << '''


### PR DESCRIPTION
## Before this PR
`BaselineJavaCompiler` needs to be of type `DefaultToolchainJavaCompiler` to work correctly in Gradle 8. In Gradle 7, when it came to compile, there was a codepath that meant that the values from the `BaselineJavaCompiler` were used, but when it came to compile, it used the normal `DefaultToolchainJavaCompiler`. This all happened to work, because of some potentially unintended side effect. In Gradle 8, that has been cleaned up, making this approach non-viable as it fails to be cast to `DefaultToolchainJavaCompiler. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
~So the idea here, is to then make `BaselineJavaCompiler` extend `DefaultToolchainJavaCompiler` and that should be okay?~

~However, the method signature for `JavaToolchain` has changed between multiple versions of gradle, so you effectively 
have this massive switch statement. All in all, it's pretty grim, and I hope we can find a better solution here.~

I was in too deep, fortunately @CRogers rescued me and said we could instead just use a `null` toolchain, and just copy-pasta the code that uses it to not use it.

Worked much better + no reflection. Also didn't produce weird stack overflow errors when used by an actual internal product.

==COMMIT_MSG==
Ensure custom jdks work with gradle 8.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This is ~so~  a bit fragile, ~I'm breaking even writing this description~. There is zero protection from any version of gradle higher than 8.2 changing the signature and breaking us. After all, we are heavily using internal properties ~*and* reflection~.

If we are happy with just using internal properties, another potential approach is:
* register our own implementation of `InstallationSupplier` which supplies a `Set<InstallationLocation>`.
* disable auto registration + auto detection, if we've set these up.

Don't think we have to worry about any reflection issues between 7.6 to 8.2, but it's substantially less reflection however, a bit more work to uproot the existing jdks stuff.
