### PR TITLE
Improve SafeLoggingPropagation on Immutables

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -227,7 +227,7 @@ public final class SafeLoggingPropagation extends BugChecker
                         // unsafe data may be redacted, however we assume redaction means do-not-log by default
                         getterSafety = Safety.DO_NOT_LOG;
                     }
-                    safety = Safety.mergeAssumingUnknownIsSame(getterSafety, safety);
+                    safety = safety.leastUpperBound(getterSafety);
                 }
             }
         }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -247,7 +247,6 @@ public final class SafeLoggingPropagation extends BugChecker
         return safety;
     }
 
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private Description matchImmutables(ClassTree classTree, ClassSymbol classSymbol, VisitorState state) {
         Safety existingClassSafety = SafetyAnnotations.getAnnotatedSafety(classTree, state);
         Safety safety = SafetyAnnotations.getTypeSafetyFromAncestors(classTree, state);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Multimap;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
@@ -68,6 +69,24 @@ public final class SafetyAnnotations {
             new TypeArgumentHandler(Multimap.class),
             new TypeArgumentHandler(Stream.class),
             new TypeArgumentHandler(Optional.class));
+
+    public static Safety getAnnotatedSafety(Tree tree, VisitorState state) {
+        Safety safety = Safety.UNKNOWN;
+        for (AnnotationTree annotationTree : ASTHelpers.getAnnotations(tree)) {
+            Tree annotationType = annotationTree.getAnnotationType();
+            Type type = ASTHelpers.getType(annotationType);
+            if (type != null) {
+                if (type.tsym.getQualifiedName().equals(doNotLogName.get(state))) {
+                    safety = Safety.mergeAssumingUnknownIsSame(safety, Safety.DO_NOT_LOG);
+                } else if (type.tsym.getQualifiedName().equals(unsafeName.get(state))) {
+                    safety = Safety.mergeAssumingUnknownIsSame(safety, Safety.UNSAFE);
+                } else if (type.tsym.getQualifiedName().equals(safeName.get(state))) {
+                    safety = Safety.mergeAssumingUnknownIsSame(safety, Safety.SAFE);
+                }
+            }
+        }
+        return safety;
+    }
 
     public static Safety getSafety(Tree tree, VisitorState state) {
         // Check the symbol itself:

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -45,6 +45,70 @@ class SafeLoggingPropagationTest {
     }
 
     @Test
+    void testAddsAnnotation_extendsDnlInterface() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import org.immutables.value.Value;",
+                        "class Test {",
+                        "  @DoNotLog",
+                        "  interface DnlIface {",
+                        "      Object value();",
+                        "  }",
+                        "  @Value.Immutable",
+                        "  interface ImmutablesIface extends DnlIface {",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import org.immutables.value.Value;",
+                        "class Test {",
+                        "  @DoNotLog",
+                        "  interface DnlIface {",
+                        "      Object value();",
+                        "  }",
+                        "  @DoNotLog",
+                        "  @Value.Immutable",
+                        "  interface ImmutablesIface extends DnlIface {",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testAddsAnnotation_extendsInterfaceWithDnlType() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.tokens.auth.*;",
+                        "import com.palantir.logsafe.*;",
+                        "import org.immutables.value.Value;",
+                        "class Test {",
+                        "  interface DnlIface {",
+                        "      BearerToken value();",
+                        "  }",
+                        "  @Value.Immutable",
+                        "  interface ImmutablesIface extends DnlIface {",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.tokens.auth.*;",
+                        "import com.palantir.logsafe.*;",
+                        "import org.immutables.value.Value;",
+                        "class Test {",
+                        "  interface DnlIface {",
+                        "      BearerToken value();",
+                        "  }",
+                        "  @DoNotLog",
+                        "  @Value.Immutable",
+                        "  interface ImmutablesIface extends DnlIface {",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     void testMixedSafety() {
         fix().addInputLines(
                         "Test.java",

--- a/changelog/@unreleased/pr-2629.v2.yml
+++ b/changelog/@unreleased/pr-2629.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Improve SafeLoggingPropagation on Immutables, taking into account fields
+    from superinterfaces
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2629

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -67,6 +67,7 @@ public class BaselineErrorProneExtension {
             "ReadReturnValueIgnored",
             "RedundantMethodReference",
             "RedundantModifier",
+            "SafeLoggingPropagation",
             "Slf4jLevelCheck",
             "Slf4jLogsafeArgs",
             "Slf4jThrowable",


### PR DESCRIPTION
==COMMIT_MSG==
Improve SafeLoggingPropagation on Immutables, taking into account fields from superinterfaces
==COMMIT_MSG==

This change migrates much of the immutables safety logic from `Tree` analysis to `Symbol` analysis, allowing us to introspect linked code rather than immediate sources. This is required in order to take fields from superinterfaces into account.

Note that because this change will suggest changes that we weren't able to enforce before, I've added `SafeLoggingPropagation` to `BaselineErrorProneExtension` in order to apply the requested changes by default on upgrade instead of failing to compile.