### PR TITLE
Lazy exact dependencies

### DIFF
--- a/changelog/@unreleased/pr-2639.v2.yml
+++ b/changelog/@unreleased/pr-2639.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`baseline-exact-dependencies` is now far more lazy around `Configuration`
+    creation in order to support Gradle 8.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2639

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -61,6 +61,7 @@ tasks.test.dependsOn tasks.publishToMavenLocal
 test {
     environment 'CIRCLE_ARTIFACTS', "${buildDir}/artifacts"
     environment 'CIRCLE_TEST_REPORTS', "${buildDir}/circle-reports"
+    systemProperty 'ignoreDeprecations', 'true'
 }
 
 gradlePlugin {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -49,6 +49,7 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -115,20 +116,24 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                         }
                     });
 
-                    // Without this, the 'checkUnusedDependencies correctly picks up project dependency on java-library'
-                    // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
-                    // than to the classes directory), which then doesn't exist.
-                    // Specifically, we need to pick up the LIBRARY_ELEMENTS_ATTRIBUTE, which is being configured on
-                    // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference it
-                    // directly because that would require us to depend on Gradle 5.6.
-                    // Instead, we just copy the attributes from compileClasspath.
-                    conf.getAttributes()
-                            .attributeProvider(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.provider(() -> {
-                                return compileClasspath
-                                        .get()
-                                        .getAttributes()
-                                        .getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);
-                            }));
+                    conf.getDependencies().addAllLater(project.provider(() -> {
+                        // Without this, the 'checkUnusedDependencies correctly picks up project dependency on
+                        // java-library'
+                        // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
+                        // than to the classes directory), which then doesn't exist.
+                        // Specifically, we need to pick up the LIBRARY_ELEMENTS_ATTRIBUTE, which is being configured on
+                        // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference
+                        // it
+                        // directly because that would require us to depend on Gradle 5.6.
+                        // Instead, we just copy the attributes from compileClasspath.
+                        compileClasspath.get().getAttributes().keySet().forEach(attribute -> {
+                            Object value =
+                                    compileClasspath.get().getAttributes().getAttribute(attribute);
+                            conf.getAttributes().attribute((Attribute<Object>) attribute, value);
+                        });
+
+                        return Set.of();
+                    }));
 
                     conf.withDependencies(deps -> {
                         // Pick up GCV locks. We're making an internal assumption that this configuration exists,

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -237,7 +237,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     }
 
     /**
-     * The SourceSet#getCompileConfigurationName() method got removed in Gradle 7. Because we want to stay
+     * The {@code SourceSet#getCompileConfigurationName()} method got removed in Gradle 7. Because we want to stay
      * compatible with Gradle 6 but can't compile this method, we reimplement it temporarily.
      * TODO(fwindheuser): Remove after dropping support for Gradle 6.
      */

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -49,7 +49,6 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -116,24 +115,20 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                         }
                     });
 
-                    conf.getDependencies().addAllLater(project.provider(() -> {
-                        // Without this, the 'checkUnusedDependencies correctly picks up project dependency on
-                        // java-library'
-                        // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
-                        // than to the classes directory), which then doesn't exist.
-                        // Specifically, we need to pick up the LIBRARY_ELEMENTS_ATTRIBUTE, which is being configured on
-                        // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference
-                        // it
-                        // directly because that would require us to depend on Gradle 5.6.
-                        // Instead, we just copy the attributes from compileClasspath.
-                        compileClasspath.get().getAttributes().keySet().forEach(attribute -> {
-                            Object value =
-                                    compileClasspath.get().getAttributes().getAttribute(attribute);
-                            conf.getAttributes().attribute((Attribute<Object>) attribute, value);
-                        });
-
-                        return Set.of();
-                    }));
+                    // Without this, the 'checkUnusedDependencies correctly picks up project dependency on java-library'
+                    // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
+                    // than to the classes directory), which then doesn't exist.
+                    // Specifically, we need to pick up the LIBRARY_ELEMENTS_ATTRIBUTE, which is being configured on
+                    // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference it
+                    // directly because that would require us to depend on Gradle 5.6.
+                    // Instead, we just copy the attributes from compileClasspath.
+                    conf.getAttributes()
+                            .attributeProvider(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.provider(() -> {
+                                return compileClasspath
+                                        .get()
+                                        .getAttributes()
+                                        .getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);
+                            }));
 
                     conf.withDependencies(deps -> {
                         // Pick up GCV locks. We're making an internal assumption that this configuration exists,

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -118,13 +118,11 @@ public final class BaselineExactDependencies implements Plugin<Project> {
 
                     project.afterEvaluate(_ignored -> {
                         // Without this, the 'checkUnusedDependencies correctly picks up project dependency on
-                        // java-library'
-                        // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
-                        // than to the classes directory), which then doesn't exist.
+                        // java-library' test fails, by not causing gradle run the jar task, but resolving the path to
+                        // the jar (rather than to the classes directory), which then doesn't exist.
                         // Specifically, we need to pick up the LIBRARY_ELEMENTS_ATTRIBUTE, which is being configured on
                         // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference
-                        // it
-                        // directly because that would require us to depend on Gradle 5.6.
+                        // it directly because that would require us to depend on Gradle 5.6.
                         // Instead, we just copy the attributes from compileClasspath.
                         compileClasspath.get().getAttributes().keySet().forEach(attribute -> {
                             Object value =
@@ -157,8 +155,8 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             Configuration compileCopy = compile.copy();
                             // Ensure it's not resolvable, otherwise plugins that resolve all configurations might have
                             // a bad time resolving this with GCV, if you have direct dependencies without corresponding
-                            // entries in
-                            // versions.props, but instead rely on getting a version for them from the lock file.
+                            // entries in versions.props, but instead rely on getting a version for them from the lock
+                            // file.
                             compileCopy.setCanBeResolved(false);
                             compileCopy.setCanBeConsumed(false);
 
@@ -182,8 +180,8 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                     });
 
                     // Since we are copying configurations before resolving 'explicitCompile', make double sure that
-                    // it's not
-                    // being resolved (or dependencies realized via `.getIncoming().getDependencies()`) too early.
+                    // it's not being resolved (or dependencies realized via `.getIncoming().getDependencies()`)
+                    // too early.
                     AtomicBoolean projectsEvaluated = new AtomicBoolean();
                     project.getGradle().projectsEvaluated(g -> projectsEvaluated.set(true));
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -49,6 +49,7 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -115,20 +116,22 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                         }
                     });
 
-                    // Without this, the 'checkUnusedDependencies correctly picks up project dependency on java-library'
-                    // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
-                    // than to the classes directory), which then doesn't exist.
-                    // Specifically, we need to pick up the LIBRARY_ELEMENTS_ATTRIBUTE, which is being configured on
-                    // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference it
-                    // directly because that would require us to depend on Gradle 5.6.
-                    // Instead, we just copy the attributes from compileClasspath.
-                    conf.getAttributes()
-                            .attributeProvider(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.provider(() -> {
-                                return compileClasspath
-                                        .get()
-                                        .getAttributes()
-                                        .getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);
-                            }));
+                    project.afterEvaluate(_ignored -> {
+                        // Without this, the 'checkUnusedDependencies correctly picks up project dependency on
+                        // java-library'
+                        // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
+                        // than to the classes directory), which then doesn't exist.
+                        // Specifically, we need to pick up the LIBRARY_ELEMENTS_ATTRIBUTE, which is being configured on
+                        // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference
+                        // it
+                        // directly because that would require us to depend on Gradle 5.6.
+                        // Instead, we just copy the attributes from compileClasspath.
+                        compileClasspath.get().getAttributes().keySet().forEach(attribute -> {
+                            Object value =
+                                    compileClasspath.get().getAttributes().getAttribute(attribute);
+                            conf.getAttributes().attribute((Attribute<Object>) attribute, value);
+                        });
+                    });
 
                     conf.withDependencies(deps -> {
                         // Pick up GCV locks. We're making an internal assumption that this configuration exists,

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -39,6 +39,7 @@ import org.apache.maven.shared.dependency.analyzer.ClassAnalyzer;
 import org.apache.maven.shared.dependency.analyzer.DefaultClassAnalyzer;
 import org.apache.maven.shared.dependency.analyzer.DependencyAnalyzer;
 import org.apache.maven.shared.dependency.analyzer.asm.ASMDependencyAnalyzer;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -48,7 +49,6 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -79,7 +79,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
             project.getConvention()
                     .getPlugin(JavaPluginConvention.class)
                     .getSourceSets()
-                    .all(sourceSet ->
+                    .configureEach(sourceSet ->
                             configureSourceSet(project, sourceSet, checkUnusedDependencies, checkImplicitDependencies));
         });
     }
@@ -89,19 +89,15 @@ public final class BaselineExactDependencies implements Plugin<Project> {
             SourceSet sourceSet,
             TaskProvider<CheckUnusedDependenciesParentTask> checkUnusedDependencies,
             TaskProvider<CheckImplicitDependenciesParentTask> checkImplicitDependencies) {
-        Configuration implementation =
-                project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName());
-        Optional<Configuration> maybeCompile =
-                Optional.ofNullable(project.getConfigurations().findByName(getCompileConfigurationName(sourceSet)));
-        Configuration compileClasspath =
-                project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName());
 
-        Configuration explicitCompile = project.getConfigurations()
-                .create("baseline-exact-dependencies-" + sourceSet.getName(), conf -> {
-                    conf.setDescription(String.format(
-                            "Tracks the explicit (not inherited) dependencies added to either %s "
-                                    + "or compile (deprecated)",
-                            implementation));
+        NamedDomainObjectProvider<Configuration> compileClasspath =
+                project.getConfigurations().named(sourceSet.getCompileClasspathConfigurationName());
+
+        NamedDomainObjectProvider<Configuration> explicitCompile = project.getConfigurations()
+                .register("baseline-exact-dependencies-" + sourceSet.getName(), conf -> {
+                    conf.setDescription(
+                            "Tracks the explicit (not inherited) dependencies added to either implementation "
+                                    + "or compile (deprecated)");
                     conf.setVisible(false);
                     conf.setCanBeConsumed(false);
 
@@ -122,77 +118,91 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                     // Without this, the 'checkUnusedDependencies correctly picks up project dependency on java-library'
                     // test fails, by not causing gradle run the jar task, but resolving the path to the jar (rather
                     // than to the classes directory), which then doesn't exist.
-
                     // Specifically, we need to pick up the LIBRARY_ELEMENTS_ATTRIBUTE, which is being configured on
                     // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference it
                     // directly because that would require us to depend on Gradle 5.6.
                     // Instead, we just copy the attributes from compileClasspath.
-                    compileClasspath.getAttributes().keySet().forEach(attribute -> {
-                        Object value = compileClasspath.getAttributes().getAttribute(attribute);
-                        conf.getAttributes().attribute((Attribute<Object>) attribute, value);
+                    conf.getAttributes()
+                            .attributeProvider(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.provider(() -> {
+                                return compileClasspath
+                                        .get()
+                                        .getAttributes()
+                                        .getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);
+                            }));
+
+                    conf.withDependencies(deps -> {
+                        // Pick up GCV locks. We're making an internal assumption that this configuration exists,
+                        // but we can rely on this since we control GCV.
+                        // Alternatively, we could tell GCV to lock this configuration, at the cost of a slightly more
+                        // expensive 'unifiedClasspath' resolution during lock computation.
+                        if (project.getRootProject().getPluginManager().hasPlugin("com.palantir.versions-lock")) {
+                            conf.extendsFrom(project.getConfigurations().getByName("lockConstraints"));
+                        }
+                        // Inherit the excludes from compileClasspath too (that get aggregated from all its
+                        // super-configurations).
+                        compileClasspath.get().getExcludeRules().forEach(rule -> conf.exclude(excludeRuleAsMap(rule)));
+                    });
+
+                    // Since we are copying configurations before resolving 'explicitCompile', make double sure that
+                    // it's not
+                    // being resolved (or dependencies realized via `.getIncoming().getDependencies()`) too early.
+                    AtomicBoolean projectsEvaluated = new AtomicBoolean();
+                    project.getGradle().projectsEvaluated(g -> projectsEvaluated.set(true));
+
+                    conf.getIncoming().beforeResolve(_ignored -> {
+                        Preconditions.checkState(
+                                projectsEvaluated.get()
+                                        || (project.getGradle()
+                                                        .getStartParameter()
+                                                        .isConfigureOnDemand()
+                                                && project.getState().getExecuted()),
+                                "Tried to resolve %s too early.",
+                                conf);
+
+                        // Figure out what our compile dependencies are while ignoring dependencies we've inherited from
+                        // other source sets. For example, if we are `test`, some of our configurations extend from the
+                        // `main` source set:
+                        // testImplementation     extendsFrom(implementation)
+                        //  \-- testCompile       extendsFrom(compile)
+                        // We therefore want to look at only the dependencies _directly_ declared in the implementation
+                        // and compile configurations (belonging to our source set)
+                        Configuration implCopy = project.getConfigurations()
+                                .getByName(sourceSet.getImplementationConfigurationName())
+                                .copy();
+
+                        // Without these, explicitCompile will successfully resolve 0 files and you'll waste 1 hour
+                        // trying
+                        // to figure out why.
+                        project.getConfigurations().add(implCopy);
+
+                        conf.extendsFrom(implCopy);
+
+                        Optional<Configuration> maybeCompile = Optional.ofNullable(
+                                project.getConfigurations().findByName(getCompileConfigurationName(sourceSet)));
+
+                        // For Gradle 6 and below, the compile configuration might still be used.
+                        maybeCompile.ifPresent(compile -> {
+                            Configuration compileCopy = compile.copy();
+                            // Ensure it's not resolvable, otherwise plugins that resolve all configurations might have
+                            // a bad time resolving this with GCV, if you have direct dependencies without corresponding
+                            // entries in
+                            // versions.props, but instead rely on getting a version for them from the lock file.
+                            compileCopy.setCanBeResolved(false);
+                            compileCopy.setCanBeConsumed(false);
+
+                            project.getConfigurations().add(compileCopy);
+
+                            conf.extendsFrom(compileCopy);
+                        });
                     });
                 });
-
-        // Figure out what our compile dependencies are while ignoring dependencies we've inherited from other source
-        // sets. For example, if we are `test`, some of our configurations extend from the `main` source set:
-        // testImplementation     extendsFrom(implementation)
-        //  \-- testCompile       extendsFrom(compile)
-        // We therefore want to look at only the dependencies _directly_ declared in the implementation and compile
-        // configurations (belonging to our source set)
-        project.afterEvaluate(p -> {
-            Configuration implCopy = implementation.copy();
-            // Without these, explicitCompile will successfully resolve 0 files and you'll waste 1 hour trying
-            // to figure out why.
-            project.getConfigurations().add(implCopy);
-
-            explicitCompile.extendsFrom(implCopy);
-
-            // For Gradle 6 and below, the compile configuration might still be used.
-            maybeCompile.ifPresent(compile -> {
-                Configuration compileCopy = compile.copy();
-                // Ensure it's not resolvable, otherwise plugins that resolve all configurations might have
-                // a bad time resolving this with GCV, if you have direct dependencies without corresponding entries in
-                // versions.props, but instead rely on getting a version for them from the lock file.
-                compileCopy.setCanBeResolved(false);
-                compileCopy.setCanBeConsumed(false);
-
-                project.getConfigurations().add(compileCopy);
-
-                explicitCompile.extendsFrom(compileCopy);
-            });
-        });
-
-        explicitCompile.withDependencies(deps -> {
-            // Pick up GCV locks. We're making an internal assumption that this configuration exists,
-            // but we can rely on this since we control GCV.
-            // Alternatively, we could tell GCV to lock this configuration, at the cost of a slightly more
-            // expensive 'unifiedClasspath' resolution during lock computation.
-            if (project.getRootProject().getPluginManager().hasPlugin("com.palantir.versions-lock")) {
-                explicitCompile.extendsFrom(project.getConfigurations().getByName("lockConstraints"));
-            }
-            // Inherit the excludes from compileClasspath too (that get aggregated from all its super-configurations).
-            compileClasspath.getExcludeRules().forEach(rule -> explicitCompile.exclude(excludeRuleAsMap(rule)));
-        });
-
-        // Since we are copying configurations before resolving 'explicitCompile', make double sure that it's not
-        // being resolved (or dependencies realized via `.getIncoming().getDependencies()`) too early.
-        AtomicBoolean projectsEvaluated = new AtomicBoolean();
-        project.getGradle().projectsEvaluated(g -> projectsEvaluated.set(true));
-        explicitCompile
-                .getIncoming()
-                .beforeResolve(ir -> Preconditions.checkState(
-                        projectsEvaluated.get()
-                                || (project.getGradle().getStartParameter().isConfigureOnDemand()
-                                        && project.getState().getExecuted()),
-                        "Tried to resolve %s too early.",
-                        explicitCompile));
 
         TaskProvider<CheckUnusedDependenciesTask> sourceSetUnusedDependencies = project.getTasks()
                 .register(
                         checkUnusedDependenciesNameForSourceSet(sourceSet), CheckUnusedDependenciesTask.class, task -> {
                             task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
-                            task.dependenciesConfiguration(explicitCompile);
+                            task.getDependenciesConfigurations().add(explicitCompile);
 
                             // this is liberally applied to ease the Java8 -> 11 transition
                             task.ignore("javax.annotation", "javax.annotation-api");
@@ -211,7 +221,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                         task -> {
                             task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
-                            task.dependenciesConfiguration(compileClasspath);
+                            task.getDependenciesConfigurations().add(compileClasspath);
                             task.suggestionConfigurationName(sourceSet.getImplementationConfigurationName());
 
                             task.ignore("org.slf4j", "slf4j-api");
@@ -227,7 +237,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     }
 
     /**
-     * The {@link SourceSet#getCompileConfigurationName()} method got removed in Gradle 7. Because we want to stay
+     * The SourceSet#getCompileConfigurationName() method got removed in Gradle 7. Because we want to stay
      * compatible with Gradle 6 but can't compile this method, we reimplement it temporarily.
      * TODO(fwindheuser): Remove after dropping support for Gradle 6.
      */

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -148,12 +148,8 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
     }
 
     @Classpath
-    public final Provider<List<Configuration>> getDependenciesConfigurations() {
+    public final ListProperty<Configuration> getDependenciesConfigurations() {
         return dependenciesConfigurations;
-    }
-
-    public final void dependenciesConfiguration(Configuration dependenciesConfiguration) {
-        this.dependenciesConfigurations.add(Objects.requireNonNull(dependenciesConfiguration));
     }
 
     @Classpath

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -173,12 +173,8 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
     }
 
     @Classpath
-    public final Provider<List<Configuration>> getDependenciesConfigurations() {
+    public final ListProperty<Configuration> getDependenciesConfigurations() {
         return dependenciesConfigurations;
-    }
-
-    public final void dependenciesConfiguration(Configuration dependenciesConfiguration) {
-        this.dependenciesConfigurations.add(Objects.requireNonNull(dependenciesConfiguration));
     }
 
     @Input

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/GradleTestVersions.java
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/GradleTestVersions.java
@@ -21,7 +21,7 @@ import com.palantir.baseline.plugins.Baseline;
 
 public final class GradleTestVersions {
     public static final ImmutableList<String> VERSIONS =
-            ImmutableList.of(Baseline.MIN_GRADLE_VERSION.getVersion(), "7.6.2", "8.3");
+            ImmutableList.of(Baseline.MIN_GRADLE_VERSION.getVersion(), "7.6.2", "8.4");
 
     private GradleTestVersions() {}
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/GradleTestVersions.java
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/GradleTestVersions.java
@@ -21,7 +21,7 @@ import com.palantir.baseline.plugins.Baseline;
 
 public final class GradleTestVersions {
     public static final ImmutableList<String> VERSIONS =
-            ImmutableList.of(Baseline.MIN_GRADLE_VERSION.getVersion(), "7.1.1", "7.3");
+            ImmutableList.of(Baseline.MIN_GRADLE_VERSION.getVersion(), "7.6.2", "8.3");
 
     private GradleTestVersions() {}
 }


### PR DESCRIPTION
## Before this PR
Repo upgrades to Gradle 8 are failing because of errors when using `baseline-java-versions` and `baseline-exact-dependencies` together:

```
> Failed to apply plugin class ‘com.palantir.baseline.plugins.javaversions.BaselineJavaVersion’.
The value for property ‘languageVersion’ is final and cannot be changed any further.
```

The [source of the problem is that in Gradle 8.3](https://docs.gradle.org/current/userguide/upgrading_version_8.html#eager_evaluation_of_configuration_attributes), the values of various Java toolchain related attributes are finalised for a `Configuration` the moment that `Configuration` is created. `baseline-exact-dependencies` was using `getConfigurations().getByName(...)` when configuring source sets, which means that it was forcing the creation of `Configuration`s and so finalising the values of these attributes before `baseline-java-versions` had a chance to configure the `languageVersion` etc.

## After this PR
==COMMIT_MSG==
`baseline-exact-dependencies` is now far more lazy around `Configuration` creation in order to support Gradle 8.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

