### PR TITLE
Custom JDKs work with Gradle 8

### DIFF
--- a/changelog/@unreleased/pr-2641.v2.yml
+++ b/changelog/@unreleased/pr-2641.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`baseline-java-versions` avoids `ClassCastException` when using custom
+    JDKs under Gradle 8.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2641

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaCompiler.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaCompiler.java
@@ -16,14 +16,26 @@
 
 package com.palantir.baseline.plugins.javaversions;
 
+import javax.inject.Inject;
 import org.gradle.api.file.RegularFile;
-import org.gradle.jvm.toolchain.JavaCompiler;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.WorkResult;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
+import org.gradle.jvm.toolchain.internal.DefaultToolchainJavaCompiler;
+import org.gradle.jvm.toolchain.internal.JavaCompilerFactory;
+import org.gradle.language.base.internal.compile.CompileSpec;
 
-final class BaselineJavaCompiler implements JavaCompiler {
+final class BaselineJavaCompiler extends DefaultToolchainJavaCompiler {
+    private static final Logger log = Logging.getLogger(BaselineJavaCompiler.class);
+
+    private final JavaCompilerFactory compilerFactory;
     private final JavaInstallationMetadata javaInstallationMetadata;
 
-    BaselineJavaCompiler(JavaInstallationMetadata javaInstallationMetadata) {
+    BaselineJavaCompiler(JavaCompilerFactory compilerFactory, JavaInstallationMetadata javaInstallationMetadata) {
+        super(null, compilerFactory);
+        this.compilerFactory = compilerFactory;
         this.javaInstallationMetadata = javaInstallationMetadata;
     }
 
@@ -35,5 +47,27 @@ final class BaselineJavaCompiler implements JavaCompiler {
     @Override
     public RegularFile getExecutablePath() {
         return JavaInstallationMetadataUtils.findExecutable(javaInstallationMetadata, "javac");
+    }
+
+    @Override
+    public <T extends CompileSpec> WorkResult execute(T spec) {
+        // Copied from superclass, but avoiding using javaToolchain so we can make it null
+        log.info(
+                "Compiling with toolchain '{}'.",
+                javaInstallationMetadata.getInstallationPath().getAsFile());
+        final Class<T> specType = (Class<T>) spec.getClass();
+        return compilerFactory.create(specType).execute(spec);
+    }
+
+    public static BaselineJavaCompiler create(
+            ObjectFactory objectFactory, JavaInstallationMetadata javaInstallationMetadata) {
+        return new BaselineJavaCompiler(
+                objectFactory.newInstance(JavaCompilerFactoryGrabber.class).getJavaCompilerFactory(),
+                javaInstallationMetadata);
+    }
+
+    interface JavaCompilerFactoryGrabber {
+        @Inject
+        JavaCompilerFactory getJavaCompilerFactory();
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaCompiler.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaCompiler.java
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.plugins.javaversions;
 
+// CHECKSTYLE:OFF
 import javax.inject.Inject;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.logging.Logger;
@@ -26,6 +27,7 @@ import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainJavaCompiler;
 import org.gradle.jvm.toolchain.internal.JavaCompilerFactory;
 import org.gradle.language.base.internal.compile.CompileSpec;
+// CHECKSTYLE:ON
 
 final class BaselineJavaCompiler extends DefaultToolchainJavaCompiler {
     private static final Logger log = Logging.getLogger(BaselineJavaCompiler.class);

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/ConfiguredJavaToolchain.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/ConfiguredJavaToolchain.java
@@ -34,8 +34,7 @@ final class ConfiguredJavaToolchain implements BaselineJavaToolchain {
 
     @Override
     public Provider<JavaCompiler> javaCompiler() {
-        return javaInstallationMetadata.map(
-                javaInstallationMetadata1 -> BaselineJavaCompiler.create(objectFactory, javaInstallationMetadata1));
+        return javaInstallationMetadata.map(metadata -> BaselineJavaCompiler.create(objectFactory, metadata));
     }
 
     @Override

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/ConfiguredJavaToolchain.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/ConfiguredJavaToolchain.java
@@ -34,7 +34,8 @@ final class ConfiguredJavaToolchain implements BaselineJavaToolchain {
 
     @Override
     public Provider<JavaCompiler> javaCompiler() {
-        return javaInstallationMetadata.map(BaselineJavaCompiler::new);
+        return javaInstallationMetadata.map(
+                javaInstallationMetadata1 -> BaselineJavaCompiler.create(objectFactory, javaInstallationMetadata1));
     }
 
     @Override

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -32,7 +32,7 @@ import org.assertj.core.api.Assumptions
  */
 @Unroll
 class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
-    private static final List<String> GRADLE_TEST_VERSIONS = ['8.4.0', GradleVersion.current().getVersion()]
+    private static final List<String> GRADLE_TEST_VERSIONS = ['8.4', GradleVersion.current().getVersion()]
 
     private static final int JAVA_8_BYTECODE = 52
     private static final int JAVA_11_BYTECODE = 55


### PR DESCRIPTION
## Before this PR
`BaselineJavaCompiler` needs to be of type `DefaultToolchainJavaCompiler` to work correctly in Gradle 8. In Gradle 7, when it came to compile, there was a codepath that meant that the values from the `BaselineJavaCompiler` were used, but when it came to compile, it used the normal `DefaultToolchainJavaCompiler`. This all happened to work, because of some potentially unintended side effect. In Gradle 8, that has been cleaned up, making this approach non-viable as it fails to be cast to `DefaultToolchainJavaCompiler`. 

## After this PR
We make sure to extend the `DefaultToolchainJavaCompiler`, so it can be casted properly.

==COMMIT_MSG==
`baseline-java-versions` avoids `ClassCastException` when using custom JDKs under Gradle 8.
==COMMIT_MSG==

## Possible downsides?
This is very fragile - if Gradle changes the implementation of `DefaultToolchainJavaCompiler`, our implementation will also need to change.

Supersedes #2608 as I'd already rewritten this code and there are no merge conflicts...
