### PR TITLE
Lazy exact dependencies - take two

### DIFF
--- a/changelog/@unreleased/pr-2644.v2.yml
+++ b/changelog/@unreleased/pr-2644.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: '`baseline-exact-dependencies` is now far more lazy around `Configuration`
+    creation in order to support Gradle 8. Fixed attempt to make this work that should
+    not break `--write-locks`.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2644

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -61,6 +61,7 @@ tasks.test.dependsOn tasks.publishToMavenLocal
 test {
     environment 'CIRCLE_ARTIFACTS', "${buildDir}/artifacts"
     environment 'CIRCLE_TEST_REPORTS', "${buildDir}/circle-reports"
+    systemProperty 'ignoreDeprecations', 'true'
 }
 
 gradlePlugin {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -39,6 +39,7 @@ import org.apache.maven.shared.dependency.analyzer.ClassAnalyzer;
 import org.apache.maven.shared.dependency.analyzer.DefaultClassAnalyzer;
 import org.apache.maven.shared.dependency.analyzer.DependencyAnalyzer;
 import org.apache.maven.shared.dependency.analyzer.asm.ASMDependencyAnalyzer;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -79,7 +80,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
             project.getConvention()
                     .getPlugin(JavaPluginConvention.class)
                     .getSourceSets()
-                    .all(sourceSet ->
+                    .configureEach(sourceSet ->
                             configureSourceSet(project, sourceSet, checkUnusedDependencies, checkImplicitDependencies));
         });
     }
@@ -89,15 +90,15 @@ public final class BaselineExactDependencies implements Plugin<Project> {
             SourceSet sourceSet,
             TaskProvider<CheckUnusedDependenciesParentTask> checkUnusedDependencies,
             TaskProvider<CheckImplicitDependenciesParentTask> checkImplicitDependencies) {
-        Configuration implementation =
-                project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName());
+        NamedDomainObjectProvider<Configuration> implementation =
+                project.getConfigurations().named(sourceSet.getImplementationConfigurationName());
         Optional<Configuration> maybeCompile =
                 Optional.ofNullable(project.getConfigurations().findByName(getCompileConfigurationName(sourceSet)));
-        Configuration compileClasspath =
-                project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName());
+        NamedDomainObjectProvider<Configuration> compileClasspath =
+                project.getConfigurations().named(sourceSet.getCompileClasspathConfigurationName());
 
-        Configuration explicitCompile = project.getConfigurations()
-                .create("baseline-exact-dependencies-" + sourceSet.getName(), conf -> {
+        NamedDomainObjectProvider<Configuration> explicitCompile = project.getConfigurations()
+                .register("baseline-exact-dependencies-" + sourceSet.getName(), conf -> {
                     conf.setDescription(String.format(
                             "Tracks the explicit (not inherited) dependencies added to either %s "
                                     + "or compile (deprecated)",
@@ -127,10 +128,38 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                     // compileClasspath in JavaBasePlugin.defineConfigurationsForSourceSet, but we can't reference it
                     // directly because that would require us to depend on Gradle 5.6.
                     // Instead, we just copy the attributes from compileClasspath.
-                    compileClasspath.getAttributes().keySet().forEach(attribute -> {
-                        Object value = compileClasspath.getAttributes().getAttribute(attribute);
+                    compileClasspath.get().getAttributes().keySet().forEach(attribute -> {
+                        Object value = compileClasspath.get().getAttributes().getAttribute(attribute);
                         conf.getAttributes().attribute((Attribute<Object>) attribute, value);
                     });
+
+                    conf.withDependencies(deps -> {
+                        // Pick up GCV locks. We're making an internal assumption that this configuration exists,
+                        // but we can rely on this since we control GCV.
+                        // Alternatively, we could tell GCV to lock this configuration, at the cost of a slightly more
+                        // expensive 'unifiedClasspath' resolution during lock computation.
+                        if (project.getRootProject().getPluginManager().hasPlugin("com.palantir.versions-lock")) {
+                            conf.extendsFrom(project.getConfigurations().getByName("lockConstraints"));
+                        }
+                        // Inherit the excludes from compileClasspath too (that get aggregated from all its
+                        // super-configurations).
+                        compileClasspath.get().getExcludeRules().forEach(rule -> conf.exclude(excludeRuleAsMap(rule)));
+                    });
+
+                    // Since we are copying configurations before resolving 'explicitCompile', make double sure that
+                    // it's not
+                    // being resolved (or dependencies realized via `.getIncoming().getDependencies()`) too early.
+                    AtomicBoolean projectsEvaluated = new AtomicBoolean();
+                    project.getGradle().projectsEvaluated(g -> projectsEvaluated.set(true));
+                    conf.getIncoming()
+                            .beforeResolve(ir -> Preconditions.checkState(
+                                    projectsEvaluated.get()
+                                            || (project.getGradle()
+                                                            .getStartParameter()
+                                                            .isConfigureOnDemand()
+                                                    && project.getState().getExecuted()),
+                                    "Tried to resolve %s too early.",
+                                    conf));
                 });
 
         // Figure out what our compile dependencies are while ignoring dependencies we've inherited from other source
@@ -140,12 +169,12 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         // We therefore want to look at only the dependencies _directly_ declared in the implementation and compile
         // configurations (belonging to our source set)
         project.afterEvaluate(p -> {
-            Configuration implCopy = implementation.copy();
+            Configuration implCopy = implementation.get().copy();
             // Without these, explicitCompile will successfully resolve 0 files and you'll waste 1 hour trying
             // to figure out why.
             project.getConfigurations().add(implCopy);
 
-            explicitCompile.extendsFrom(implCopy);
+            explicitCompile.get().extendsFrom(implCopy);
 
             // For Gradle 6 and below, the compile configuration might still be used.
             maybeCompile.ifPresent(compile -> {
@@ -158,41 +187,16 @@ public final class BaselineExactDependencies implements Plugin<Project> {
 
                 project.getConfigurations().add(compileCopy);
 
-                explicitCompile.extendsFrom(compileCopy);
+                explicitCompile.get().extendsFrom(compileCopy);
             });
         });
-
-        explicitCompile.withDependencies(deps -> {
-            // Pick up GCV locks. We're making an internal assumption that this configuration exists,
-            // but we can rely on this since we control GCV.
-            // Alternatively, we could tell GCV to lock this configuration, at the cost of a slightly more
-            // expensive 'unifiedClasspath' resolution during lock computation.
-            if (project.getRootProject().getPluginManager().hasPlugin("com.palantir.versions-lock")) {
-                explicitCompile.extendsFrom(project.getConfigurations().getByName("lockConstraints"));
-            }
-            // Inherit the excludes from compileClasspath too (that get aggregated from all its super-configurations).
-            compileClasspath.getExcludeRules().forEach(rule -> explicitCompile.exclude(excludeRuleAsMap(rule)));
-        });
-
-        // Since we are copying configurations before resolving 'explicitCompile', make double sure that it's not
-        // being resolved (or dependencies realized via `.getIncoming().getDependencies()`) too early.
-        AtomicBoolean projectsEvaluated = new AtomicBoolean();
-        project.getGradle().projectsEvaluated(g -> projectsEvaluated.set(true));
-        explicitCompile
-                .getIncoming()
-                .beforeResolve(ir -> Preconditions.checkState(
-                        projectsEvaluated.get()
-                                || (project.getGradle().getStartParameter().isConfigureOnDemand()
-                                        && project.getState().getExecuted()),
-                        "Tried to resolve %s too early.",
-                        explicitCompile));
 
         TaskProvider<CheckUnusedDependenciesTask> sourceSetUnusedDependencies = project.getTasks()
                 .register(
                         checkUnusedDependenciesNameForSourceSet(sourceSet), CheckUnusedDependenciesTask.class, task -> {
                             task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
-                            task.dependenciesConfiguration(explicitCompile);
+                            task.getDependenciesConfigurations().add(explicitCompile);
 
                             // this is liberally applied to ease the Java8 -> 11 transition
                             task.ignore("javax.annotation", "javax.annotation-api");
@@ -211,7 +215,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                         task -> {
                             task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
-                            task.dependenciesConfiguration(compileClasspath);
+                            task.getDependenciesConfigurations().add(compileClasspath);
                             task.suggestionConfigurationName(sourceSet.getImplementationConfigurationName());
 
                             task.ignore("org.slf4j", "slf4j-api");
@@ -227,7 +231,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     }
 
     /**
-     * The {@link SourceSet#getCompileConfigurationName()} method got removed in Gradle 7. Because we want to stay
+     * The {@code SourceSet#getCompileConfigurationName()} method got removed in Gradle 7. Because we want to stay
      * compatible with Gradle 6 but can't compile this method, we reimplement it temporarily.
      * TODO(fwindheuser): Remove after dropping support for Gradle 6.
      */

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -148,7 +148,7 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
     }
 
     @Classpath
-    public final Provider<List<Configuration>> getDependenciesConfigurations() {
+    public final ListProperty<Configuration> getDependenciesConfigurations() {
         return dependenciesConfigurations;
     }
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -173,7 +173,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
     }
 
     @Classpath
-    public final Provider<List<Configuration>> getDependenciesConfigurations() {
+    public final ListProperty<Configuration> getDependenciesConfigurations() {
         return dependenciesConfigurations;
     }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/GradleTestVersions.java
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/GradleTestVersions.java
@@ -21,7 +21,7 @@ import com.palantir.baseline.plugins.Baseline;
 
 public final class GradleTestVersions {
     public static final ImmutableList<String> VERSIONS =
-            ImmutableList.of(Baseline.MIN_GRADLE_VERSION.getVersion(), "7.1.1", "7.3");
+            ImmutableList.of(Baseline.MIN_GRADLE_VERSION.getVersion(), "7.6.2", "8.4");
 
     private GradleTestVersions() {}
 }


### PR DESCRIPTION
## Before this PR
We tried to make baseline-exact-dependencies lazier so it works with Gradle 8 in #2639. However, it caused issues with writing locks and we had to revert in #2642.

## After this PR
Redo the PR, but this time only make the _minimal_ changes to make accessing the configurations lazy.

==COMMIT_MSG==
`baseline-exact-dependencies` is now far more lazy around `Configuration` creation in order to support Gradle 8. Fixed attempt to make this work that should not break `--write-locks`.
==COMMIT_MSG==

I've tested, and the repos that had this problem now work with write-locks.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

