### PR TITLE
Lazy exact deps - take three

### DIFF
--- a/changelog/@unreleased/pr-2645.v2.yml
+++ b/changelog/@unreleased/pr-2645.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Ensure that the baseline-exact-dependencies plugin does not eagerly
+    force the creation of the `compileClasspath` configuration, which causes "'languageVersion'
+    is final and cannot be changed any further." errors in Gradle >=8.3.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2645

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -55,7 +55,6 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.util.GUtil;
-import org.gradle.util.GradleVersion;
 
 /** Validates that java projects declare exactly the dependencies they rely on, no more and no less. */
 public final class BaselineExactDependencies implements Plugin<Project> {
@@ -109,12 +108,10 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                         attributes.attribute(
                                 Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_API));
                         // Ensure we resolve the classes directory for local projects where possible, rather than the
-                        // 'jar' file. We can only do this on Gradle 5.6+, otherwise do nothing.
-                        if (GradleVersion.current().compareTo(GradleVersion.version("5.6")) >= 0) {
-                            attributes.attribute(
-                                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                                    project.getObjects().named(LibraryElements.class, LibraryElements.CLASSES));
-                        }
+                        // 'jar' file.
+                        attributes.attribute(
+                                LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                                project.getObjects().named(LibraryElements.class, LibraryElements.CLASSES));
                     });
 
                     conf.withDependencies(deps -> {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -23,6 +23,7 @@ import spock.lang.Unroll
 
 class BaselineExactDependenciesTest extends AbstractPluginTest {
 
+    // language=Gradle
     def standardBuildFile = '''
         plugins {
             id 'java'
@@ -30,7 +31,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
             id 'com.palantir.baseline' apply false
             id 'com.palantir.consistent-versions' version '2.0.0' apply false
         }
-    '''.stripIndent()
+    '''.stripIndent(true)
 
     def minimalJavaFile = '''
     package pkg;
@@ -275,6 +276,26 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
 
         expect:
         with(':checkUnusedConstraints', '--stacktrace', '--write-locks').withDebug(true).build()
+    }
+
+    def 'in Gradle >=8.3 you can set the toolchain language version without it being finalised'() {
+        when:
+        buildFile << standardBuildFile
+        // language=Gradle
+        buildFile << '''
+            pluginManager.withPlugin('java') {
+                java {
+                    toolchain {
+                        languageVersion.set(JavaLanguageVersion.of(16))
+                    }
+                }
+            }
+        '''.stripIndent(true)
+
+        then:
+        with('tasks', '--stacktrace')
+                .withGradleVersion('8.4')
+                .build()
     }
 
     /**


### PR DESCRIPTION
## Before this PR
The previous PR (#2644) was not actually lazy enough to fix the original problem (described in #2639). There are still errors of the form:

```
**A problem occurred evaluating root project 'log-receiver-root'.
> Failed to apply plugin class 'com.palantir.baseline.plugins.javaversions.BaselineJavaVersion'.
   > The value for property 'languageVersion' is final and cannot be changed any further.
```

It turns out these are from the eager copying of attributes from the `compileClasspath` configuration.

## After this PR
==COMMIT_MSG==
Ensure that the baseline-exact-dependencies plugin does not eagerly force the creation of the `compileClasspath` configuration, which causes "'languageVersion' is final and cannot be changed any further." errors in Gradle >=8.3.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

