### PR TITLE
baseline error-prone no longer auto-fixes PreferJavaTimeOverload

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -93,7 +93,6 @@ public class BaselineErrorProneExtension {
             "MissingOverride",
             "NarrowCalculation",
             "ObjectsHashCodePrimitive",
-            "PreferJavaTimeOverload",
             "ProtectedMembersInFinalClass",
             "UnnecessaryParentheses",
             "ZoneIdOfZ");


### PR DESCRIPTION
PreferJavaTimeOverload is not enabled by default, so updates are not enforced. Unfortunatley in many places we prefer not to make the proposed change because it introduces allocation into potentially performance sensitive paths (e.g. timer metrics).

==COMMIT_MSG==
baseline error-prone no longer auto-fixes PreferJavaTimeOverload
==COMMIT_MSG==

