### PR TITLE
reenable error-prone after pr2653

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,6 @@ allprojects {
         tasks.withType(JavaCompile) {
             options.compilerArgs += ['-Werror', '-Xlint:deprecation']
             options.errorprone {
-                // errorprone must be temporarily disabled in order to bump the errorprone dependency
-                // to a version without `ErrorProneFlags.getList(String)`.
-                enabled = false
                 check("Slf4jLogsafeArgs", CheckSeverity.OFF)
                 check("PreferSafeLoggableExceptions", CheckSeverity.OFF)
                 check("PreferSafeLogger", CheckSeverity.OFF)


### PR DESCRIPTION
## Before this PR
Temporarily opted out of error-prone due to the upgrade with errorprone api breaks in #2651
We can opt back into errorprone because #2653 has merged
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
reenable error-prone after #2653
==COMMIT_MSG==

