### PR TITLE
Allow leading underscore in variable names

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -439,7 +439,7 @@
         <module name="LocalFinalVariableName"/> <!-- Java Style Guide: Local variable names -->
         <module name="LocalVariableName"> <!-- Java Style Guide: Local variable names -->
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+            <property name="format" value="^_?[a-z][a-zA-Z0-9]+$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern" value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
This checkstyle rules conflicts with the `StrictUnusedVariable` check and is difficult or impossible to work around. Devs have run into this conflict numerous times over the years.

For example, I recently had a legitimate case where I wanted to ignore a return value annotated with `@CheckReturnValue`. The [`CheckReturnValue` docs](https://errorprone.info/bugpattern/CheckReturnValue) recommend assigning the value to an unused variable instead of using `@SuppressWarnings` (which seems like good advice given that `@SuppressWarnings` applies to the entire method). However it's impossible to do this with the checkstyle rule and `StrictUnusedVariable` check as they exist today.

This feels like a fairly minor concession with some meaningful ergonomic improvements.