### PR TITLE
Exclude JUnit5 extensions from StrictUnusedVariable

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -144,6 +144,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             "javax.persistence.Version",
             "javax.xml.bind.annotation.XmlElement",
             "org.junit.Rule",
+            "org.junit.jupiter.api.extension.RegisterExtension",
             "org.mockito.Mock",
             "org.openqa.selenium.support.FindBy",
             "org.openqa.selenium.support.FindBys");

--- a/changelog/@unreleased/pr-2664.v2.yml
+++ b/changelog/@unreleased/pr-2664.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Variables annotated with `@RegisterExtension` are now exempt from the
+    `StrictUnusedVariable` check.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2664


### PR DESCRIPTION
If you have a JUnit5 extension that needs to be explicitly constructed (ie. you can't use `@ExtendWith`), then this will trigger the `StrictUnusedVariable` check if that extension isn't used by test code.

This affects nearly every internal repo that uses our internal integration testing extension. These repos are forced to add `@SuppressWarnings("StrictUnusedVariable")` which is unfortunate.

This is the JUnit5 equivalent of the existing `org.junit.Rule` exemption.