### PR TITLE
stream to iterator is unsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `JooqBatchWithoutBindArgs`: jOOQ batch methods that execute without bind args can cause performance problems.
 - `InvocationTargetExceptionGetTargetException`: InvocationTargetException.getTargetException() predates the general-purpose exception chaining facility. The Throwable.getCause() method is now the preferred means of obtaining this information. [(source)](https://docs.oracle.com/en/java/javase/17/docs/api//java.base/java/lang/reflect/InvocationTargetException.html#getTargetException())
 - `PreferInputStreamTransferTo`: Prefer JDK `InputStream.transferTo(OutputStream)` over utility methods such as `com.google.common.io.ByteStreams.copy(InputStream, OutputStream)`, `org.apache.commons.io.IOUtils.copy(InputStream, OutputStream)`, `org.apache.commons.io.IOUtils.copyLong(InputStream, OutputStream)`.
+- `StreamToIterator`: Avoid calling iterator on stream, as it buffers the stream into memory and may cause unexpected OOMs. For small streams, consider collecting the stream first to make it clear to readers that the stream will be loaded into memory. See [(JDK-8202307)|(https://bugs.openjdk.org/browse/JDK-8202307)] for more details.
 
 ### Programmatic Application
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamToIterator.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamToIterator.java
@@ -33,7 +33,10 @@ import java.util.stream.Stream;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.WARNING,
-        summary = "Calling iterator on stream buffers the stream into memory.")
+        summary =
+                "Avoid calling iterator on stream, as it buffers the stream into memory and may cause unexpected OOMs."
+                        + "For small streams, consider collecting the stream first to make it clear to readers that"
+                        + " the stream will be loaded into memory.")
 public final class StreamToIterator extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
     private static final Matcher<ExpressionTree> MATCHER = MethodMatchers.instanceMethod()
             .onDescendantOf(Stream.class.getName())

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamToIterator.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamToIterator.java
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.stream.Stream;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.WARNING,
+        summary = "Calling iterator on stream buffers the stream into memory.")
+public final class StreamToIterator extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+    private static final Matcher<ExpressionTree> MATCHER = MethodMatchers.instanceMethod()
+            .onDescendantOf(Stream.class.getName())
+            .named("iterator");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (MATCHER.matches(tree, state)) {
+            return describeMatch(tree);
+        }
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamToIteratorTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamToIteratorTest.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+public class StreamToIteratorTest {
+    @Test
+    void testFix() {
+        CompilationTestHelper.newInstance(StreamToIterator.class, getClass())
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.stream.Stream;",
+                        "public class Test {",
+                        "private Object test() {",
+                        "// BUG: Diagnostic contains: StreamToIterator",
+                        "  return Stream.of(1, 2).iterator();",
+                        "}",
+                        "}")
+                .doTest();
+    }
+}

--- a/changelog/@unreleased/pr-2667.v2.yml
+++ b/changelog/@unreleased/pr-2667.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Adds an error prone warning for calling Stream.iterator, which loads
+    the entire stream into memory and may cause OOMs.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2667


### PR DESCRIPTION
Adds an error prone warning for calling `Stream.iterator`, which loads the entire stream into memory and may cause OOMs ([JDK issue](https://bugs.openjdk.org/browse/JDK-8202307)). 

## Possible downsides?
For small streams, calling iterator on stream may be reasonable. I think it's clearer to explicitly collect the stream because users may not realize that `iterator` loads the stream into memory, but open to ideas.

