### PR TITLE
Allow leading _ in Java local var names

### DIFF
--- a/changelog/@unreleased/pr-2670.v2.yml
+++ b/changelog/@unreleased/pr-2670.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Allow local vars to have a leading _ to align with errorProne and be
+    consistent with method arg names.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2670

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -439,7 +439,7 @@
         <module name="LocalFinalVariableName"/> <!-- Java Style Guide: Local variable names -->
         <module name="LocalVariableName"> <!-- Java Style Guide: Local variable names -->
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+            <property name="format" value="^_?[a-z][a-zA-Z0-9]+$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern" value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION




## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
errorprone: CheckReturnValue requires methods with a return value use them (and @CanIgnoreReturnValue isn't an option).
If you really don't want to use the result, then assign it to a variable: `var unused = ...`

But doing that then results in another errorprone: StrictUnusedVariable: The local variable 'unused' is never read. Intentional occurrences are acknowledged by renaming the unused variable with a leading underscore. '_unused'

Checkstyles localVariableName rejects that (however allows method args to have leading _).
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow local vars to have a leading _ to align with errorProne and be consistent with method arg names.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

