### PR TITLE
Lint records with array fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `ConsistentLoggerName`: Ensure Loggers are named consistently.
 - `PreferImmutableStreamExCollections`: It's common to use toMap/toSet/toList() as the terminal operation on a stream, but would be extremely surprising to rely on the mutability of these collections. Prefer `toImmutableMap`, `toImmutableSet` and `toImmutableList`. (If the performance overhead of a stream is already acceptable, then the `UnmodifiableFoo` wrapper is likely tolerable).
 - `DangerousIdentityKey`: Key type does not override equals() and hashCode, so comparisons will be done on reference equality only.
+- `DangerousRecordArrayField`: Array fields in records perform reference equality when comparing records.
 - `ConsistentOverrides`: Ensure values are bound to the correct variables when overriding methods
 - `FilterOutputStreamSlowMultibyteWrite`: Subclasses of FilterOutputStream should provide a more efficient implementation of `write(byte[], int, int)` to avoid slow writes.
 - `BugCheckerAutoService`: Concrete BugChecker implementations should be annotated `@AutoService(BugChecker.class)` for auto registration with error-prone.

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousRecordArrayField.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousRecordArrayField.java
@@ -37,8 +37,8 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 @AutoService(BugChecker.class)
 @BugPattern(
         summary = "Record type has an array field and hasn't overridden equals/hashcode. By default array equality"
-                + " performs reference equality only. Consider using a List, using Immutables, or overriding"
-                + " equals/hashCode.",
+                + " performs reference equality only. Consider using an immutable Collection for the field, using"
+                + " Immutables instead of the record, or overriding equals/hashCode in the record.",
         severity = SeverityLevel.WARNING)
 public final class DangerousRecordArrayField extends BugChecker implements BugChecker.ClassTreeMatcher {
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousRecordArrayField.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousRecordArrayField.java
@@ -29,6 +29,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 
 /**
@@ -43,12 +44,8 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 public final class DangerousRecordArrayField extends BugChecker implements BugChecker.ClassTreeMatcher {
 
     private static final Matcher<VariableTree> IS_ARRAY_VARIABLE = Matchers.isArrayType();
-    private static final Matcher<MethodTree> NON_TRIVIAL_EQUALS = Matchers.allOf(
-            Matchers.equalsMethodDeclaration(),
-            Matchers.not(Matchers.singleStatementReturnMatcher(Matchers.instanceEqualsInvocation())));
-    private static final Matcher<MethodTree> NON_TRIVIAL_HASHCODE = Matchers.allOf(
-            Matchers.hashCodeMethodDeclaration(),
-            Matchers.not(Matchers.singleStatementReturnMatcher(Matchers.instanceHashCodeInvocation())));
+    private static final Matcher<MethodTree> EQUALS_MATCHER = Matchers.equalsMethodDeclaration();
+    private static final Matcher<MethodTree> HASHCODE_MATCHER = Matchers.hashCodeMethodDeclaration();
 
     @Override
     public Description matchClass(ClassTree classTree, VisitorState state) {
@@ -89,8 +86,8 @@ public final class DangerousRecordArrayField extends BugChecker implements BugCh
 
                 // We want to check if the equals & hashCode methods have actually been overridden (i.e. don't just
                 // call Object.equals)
-                hasEquals = hasEquals || NON_TRIVIAL_EQUALS.matches(methodTree, state);
-                hasHashCode = hasHashCode || NON_TRIVIAL_HASHCODE.matches(methodTree, state);
+                hasEquals = hasEquals || EQUALS_MATCHER.matches(methodTree, state);
+                hasHashCode = hasHashCode || HASHCODE_MATCHER.matches(methodTree, state);
             }
         }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousRecordArrayField.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousRecordArrayField.java
@@ -29,7 +29,6 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
-import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 
 /**

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousRecordArrayFieldTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousRecordArrayFieldTest.java
@@ -65,7 +65,7 @@ public final class DangerousRecordArrayFieldTest {
                         "import java.util.regex.Pattern;",
                         "class Test {",
                         "    // BUG: Diagnostic contains: Record type has an array field and",
-                        "    private record MyRecordE(String name, byte[] payload) {",
+                        "    private record MyRecord(String name, byte[] payload) {",
                         "        public boolean equals(Object other) { return false; }",
                         "    }",
                         "}")
@@ -81,7 +81,7 @@ public final class DangerousRecordArrayFieldTest {
                         "import java.util.regex.Pattern;",
                         "class Test {",
                         "    // BUG: Diagnostic contains: Record type has an array field and",
-                        "    private record MyRecordH(String name, byte[] payload) {",
+                        "    private record MyRecord(String name, byte[] payload) {",
                         "        public int hashCode() { return 0; }",
                         "    }",
                         "}")
@@ -96,7 +96,7 @@ public final class DangerousRecordArrayFieldTest {
                         "import java.util.*;",
                         "import java.util.regex.Pattern;",
                         "class Test {",
-                        "    private record MyRecordEH(String name, byte[] payload) {",
+                        "    private record MyRecord(String name, byte[] payload) {",
                         "        public boolean equals(Object other) { return false; }",
                         "        public int hashCode() { return 0; }",
                         "    }",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousRecordArrayFieldTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousRecordArrayFieldTest.java
@@ -1,0 +1,122 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class DangerousRecordArrayFieldTest {
+
+    private CompilationTestHelper compilationHelper;
+
+    @BeforeEach
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(DangerousRecordArrayField.class, getClass());
+    }
+
+    @Test
+    public void testSimpleRecord() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.regex.Pattern;",
+                        "class Test {",
+                        "    private record MyRecord(String name, List<Integer> payload) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testArray() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.regex.Pattern;",
+                        "class Test {",
+                        "    // BUG: Diagnostic contains: Record type has an array field and",
+                        "    private record MyRecord(String name, byte[] payload) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testArray_withEqualsNoHashcode() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.regex.Pattern;",
+                        "class Test {",
+                        "    // BUG: Diagnostic contains: Record type has an array field and",
+                        "    private record MyRecordE(String name, byte[] payload) {",
+                        "        public boolean equals(Object other) { return false; }",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testArray_noEqualsWithHashcode() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.regex.Pattern;",
+                        "class Test {",
+                        "    // BUG: Diagnostic contains: Record type has an array field and",
+                        "    private record MyRecordH(String name, byte[] payload) {",
+                        "        public int hashCode() { return 0; }",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testArray_withEqualsWithHashcode() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.regex.Pattern;",
+                        "class Test {",
+                        "    private record MyRecordEH(String name, byte[] payload) {",
+                        "        public boolean equals(Object other) { return false; }",
+                        "        public int hashCode() { return 0; }",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testArrayInMethod() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.regex.Pattern;",
+                        "class Test {",
+                        "    private void myMethod() {",
+                        "       // BUG: Diagnostic contains: Record type has an array field and",
+                        "       record MyRecord(String name, byte[] payload) {}",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+}

--- a/changelog/@unreleased/pr-2672.v2.yml
+++ b/changelog/@unreleased/pr-2672.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Warn when using records with array fields as their equality behavior
+    is surprising
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2672


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Records with array fields end up with surprising equality behavior: comparisons are performed using `.equals`, which end up being value comparisons on most types, but are reference comparisons for arrays.

```
byte[] a = new byte[] {1, 2};
byte[] b = new byte[] {1, 2};

System.out.println(a.equals(b)); // -> false
System.out.println(Arrays.equals(a, b)); // -> true
```

Note that this is already warned for when done in code: https://errorprone.info/bugpattern/ArrayEquals

This is also handled explicitly by immutables: https://github.com/immutables/immutables/blob/7c78f66766bd96e9f37ed02b866c2a08871cd89a/mirror/src/org/immutables/mirror/processor/Mirrors.generator#L510

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Warn when using records with array fields as their equality behavior is surprising
==COMMIT_MSG==

Question for reviewer: should we attempt to auto-gen equals/hashCode? I'd prefer not to, as these tend to be more stylistic/converting to immutables might be preferable in these cases.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

