### PR TITLE
Add `Visitor` to the list of `DO_NOT_IMPORT_INNER` for intellij formatting

### DIFF
--- a/changelog/@unreleased/pr-2677.v2.yml
+++ b/changelog/@unreleased/pr-2677.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add `Visitor` to the list of `DO_NOT_IMPORT_INNER`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2677

--- a/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
+++ b/gradle-baseline-java-config/resources/idea/intellij-java-palantir-style.xml
@@ -58,6 +58,7 @@
             <CLASS name="Id" />
             <CLASS name="Identifier" />
             <CLASS name="Provider" />
+            <CLASS name="Visitor" />
           </DO_NOT_IMPORT_INNER>
         </GroovyCodeStyleSettings>
         <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />


### PR DESCRIPTION
- Putting this up as a suggestion
- Personally I find it very annoying that Intellij auto-imports the inner visitor calls so that you only see:
```java
.map(value -> value.accept(new Visitor<>() {
  ....
```
- It makes it pretty hard to know what is being visited without mousing-over etc.
- This is just the intellij setting so it doesn't ban the usage, just makes it a conscious choice

==COMMIT_MSG==
Add `Visitor` to the list of `DO_NOT_IMPORT_INNER`
==COMMIT_MSG==

## Possible downsides?
Maybe people rely on this? I searched our internal repos and the usage of inline raw visitors is pretty uncommon in general

