### PR TITLE
fix #2676: Safety propagation traverses complex record components

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/SafeLoggingPropagation.java
@@ -148,8 +148,9 @@ public final class SafeLoggingPropagation extends BugChecker
         Safety safety = SafetyAnnotations.getTypeSafetyFromAncestors(classTree, state);
         for (VarSymbol recordComponent : Records.getRecordComponents(classSymbol)) {
             Safety symbolSafety = SafetyAnnotations.getSafety(recordComponent, state);
+            Safety typeSafety = SafetyAnnotations.getSafety(recordComponent.type, state);
             Safety typeSymSafety = SafetyAnnotations.getSafety(recordComponent.type.tsym, state);
-            Safety recordComponentSafety = Safety.mergeAssumingUnknownIsSame(symbolSafety, typeSymSafety);
+            Safety recordComponentSafety = Safety.mergeAssumingUnknownIsSame(symbolSafety, typeSafety, typeSymSafety);
             safety = safety.leastUpperBound(recordComponentSafety);
         }
         return handleSafety(classTree, classTree.getModifiers(), state, existingClassSafety, safety);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -275,8 +275,7 @@ class SafeLoggingPropagationTest {
 
     @Test
     void testRecordWithUnsafeTypes() {
-        fix("--release", "17")
-                .addInputLines(
+        fix().addInputLines(
                         "Test.java",
                         "import com.palantir.tokens.auth.*;",
                         "import com.palantir.logsafe.*;",
@@ -287,6 +286,36 @@ class SafeLoggingPropagationTest {
                         "import com.palantir.logsafe.*;",
                         "@DoNotLog",
                         "record Test(BearerToken token) {}")
+                .doTest();
+    }
+
+    @Test
+    void testWrappedRecordComponents() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  @Unsafe",
+                        "  class UnsafeType {}",
+                        "  record Rec1(UnsafeType val) {}",
+                        "  record Rec2(List<UnsafeType> val) {}",
+                        "  record Rec3(Optional<UnsafeType> val) {}",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  @Unsafe",
+                        "  class UnsafeType {}",
+                        "  @Unsafe",
+                        "  record Rec1(UnsafeType val) {}",
+                        "  @Unsafe",
+                        "  record Rec2(List<UnsafeType> val) {}",
+                        "  @Unsafe",
+                        "  record Rec3(Optional<UnsafeType> val) {}",
+                        "}")
                 .doTest();
     }
 

--- a/changelog/@unreleased/pr-2700.v2.yml
+++ b/changelog/@unreleased/pr-2700.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Safety propagation traverses complex record components
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2700


### PR DESCRIPTION
See #2676

Previously record safety only viewed top-level safety info, but failed to inspect more complex types like `List<T>` and `Optional<T>`.

==COMMIT_MSG==
Safety propagation traverses complex record components
==COMMIT_MSG==
