### PR TITLE
Publish plugin marker artifact for baseline-error-prone plugin

### DIFF
--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -81,6 +81,11 @@ gradlePlugin {
             displayName = 'Palantir Baseline Configuration Plugin'
             implementationClass = 'com.palantir.baseline.plugins.BaselineConfig'
         }
+        baselineErrorPronePlugin {
+            id = 'com.palantir.baseline-error-prone'
+            displayName = 'Palantir Baseline Error Prone Plugin'
+            implementationClass = 'com.palantir.baseline.plugins.BaselineErrorProne'
+        }
         baselineExactDependenciesPlugin {
             id = 'com.palantir.baseline-exact-dependencies'
             displayName = 'Palantir Baseline Exact Dependencies Plugin'


### PR DESCRIPTION
This allows the plugin to be used with the [Gradle plugin DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block).