### PR TITLE
Prevent Unnecessary Propagation When Using Array Containers

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -1037,6 +1037,49 @@ class SafeLoggingPropagationTest {
                 .doTest();
     }
 
+    @Test
+    void testSafetyAnnotatedReturnTypeDoesNotAnnotateMethod() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "public final class Test {",
+                        "  @Unsafe",
+                        "  private static class UnsafeType {}",
+                        "  public UnsafeType getType() { return new UnsafeType(); }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    void testSafetyAnnotatedArrayTypeDoesNotAnnotateMethod() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "public final class Test {",
+                        "  @Unsafe",
+                        "  private static class UnsafeType {}",
+                        "  public UnsafeType[] getType() { return new UnsafeType[]{ new UnsafeType() }; }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    void testSafetyAnnotatedCollectionTypeDoesNotAnnotateMethod() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.*;",
+                        "public final class Test {",
+                        "  @Unsafe",
+                        "  private static class UnsafeType {}",
+                        "  public List<UnsafeType> getType() { return new ArrayList<UnsafeType>(); }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
     private RefactoringValidator fix(String... args) {
         return RefactoringValidator.of(SafeLoggingPropagation.class, getClass(), args);
     }


### PR DESCRIPTION
## Before this PR
The tests have extremely clear examples, but TLDR when the return type of a method was `UnsafeType[]` it would cause that method to propagate its safety information. This differs from returning `UnsafeType` and `List<UnsafeType>`.

## After this PR
`Array` containers are treated more similarly to `Collection` types.

