### PR TITLE
Don't ignore compile time constants in OptionalOrElseGetValue

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalOrElseGetValue.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalOrElseGetValue.java
@@ -24,7 +24,6 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
-import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
@@ -47,7 +46,6 @@ public final class OptionalOrElseGetValue extends BugChecker implements MethodIn
     private static final long serialVersionUID = 1L;
     private static final Matcher<ExpressionTree> OR_ELSE_GET_METHOD =
             MethodMatchers.instanceMethod().onExactClass("java.util.Optional").named("orElseGet");
-    private static final Matcher<ExpressionTree> COMPILE_TIME_CONSTANT = new CompileTimeConstantExpressionMatcher();
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
@@ -69,9 +67,7 @@ public final class OptionalOrElseGetValue extends BugChecker implements MethodIn
         }
 
         ExpressionTree expressionBody = (ExpressionTree) lambdaExpressionTree.getBody();
-        if (!COMPILE_TIME_CONSTANT.matches(expressionBody, state)
-                && !isTrivialExpression(expressionBody)
-                && !isTrivialSelect(expressionBody)) {
+        if (!isTrivialExpression(expressionBody) && !isTrivialSelect(expressionBody)) {
             return Description.NO_MATCH;
         }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseGetValueTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalOrElseGetValueTest.java
@@ -116,21 +116,6 @@ public final class OptionalOrElseGetValueTest {
     }
 
     @Test
-    public void testOrElseGetCompileTimeConstant() {
-        compilationHelper
-                .addSourceLines(
-                        "Test.java",
-                        "import java.util.Optional;",
-                        "class Test {",
-                        "    private final String part1 = \"Hello \";",
-                        "    private final String part2 = \"World\";",
-                        "    // BUG: Diagnostic contains: Prefer Optional#orElse",
-                        "    private final String string = Optional.of(\"str\").orElseGet(() -> part1 + part2);",
-                        "}")
-                .doTest();
-    }
-
-    @Test
     public void testReplacementOfLiteral() {
         refactoringTestHelper
                 .addInputLines(

--- a/changelog/@unreleased/pr-2712.v2.yml
+++ b/changelog/@unreleased/pr-2712.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix some false positives in `OptionalOrElseGetValue`. `OptionalOrElseGetValue`
+    no longer allows compile-time constants that are not literals or identifiers.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2712


### PR DESCRIPTION
## Before this PR

The `OptionalOrElseGetValue` check produces false positives for code like:

```java
return optional.orElseGet(() -> somethingExpensive() ? 0 : 1);
```

The `CompileTimeConstantExpressionMatcher` (correctly) does not consider the condition in a conditional expression.

https://github.com/google/error-prone/blob/e5a6d0d8f9f96bda8e9952b7817cd0d2b63e51be/check_api/src/main/java/com/google/errorprone/matchers/CompileTimeConstantExpressionMatcher.java#L99-L102

"Is the value a compile-time constant?" isn't quite the check we want to perform here.

## After this PR

The compile-time constant check in `OptionalOrElseGetValue` has been removed.

In practice, I don't imagine there are many people who are using `orElseGet` with values that are compile-time constants but aren't literals or identifiers.