### PR TITLE
Ignore `org.immutables:value::annotations` when adding Immutable incremental arg

### DIFF
--- a/changelog/@unreleased/pr-2717.v2.yml
+++ b/changelog/@unreleased/pr-2717.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Ignore `org.immutables:value::annotations` when deciding to add the
+    annotation processor arg required by immutables to run incrementally.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2717

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
@@ -21,7 +21,9 @@ import java.util.Collections;
 import java.util.Objects;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -74,12 +76,22 @@ public final class BaselineImmutables implements Plugin<Project> {
         return project
                 .getConfigurations()
                 .getByName(sourceSet.getAnnotationProcessorConfigurationName())
-                .getAllDependencies()
+                .getIncoming()
+                .getResolutionResult()
+                .getAllComponents()
                 .stream()
                 .anyMatch(BaselineImmutables::isImmutablesValue);
     }
 
-    private static boolean isImmutablesValue(Dependency dependency) {
-        return Objects.equals(dependency.getGroup(), "org.immutables") && Objects.equals(dependency.getName(), "value");
+    private static boolean isImmutablesValue(ResolvedComponentResult component) {
+        ComponentIdentifier id = component.getId();
+
+        if (!(id instanceof ModuleComponentIdentifier)) {
+            return false;
+        }
+
+        ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) id;
+
+        return Objects.equals(moduleId.getGroup(), "org.immutables") && Objects.equals(moduleId.getModule(), "value");
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineImmutables.java
@@ -21,9 +21,7 @@ import java.util.Collections;
 import java.util.Objects;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -76,22 +74,12 @@ public final class BaselineImmutables implements Plugin<Project> {
         return project
                 .getConfigurations()
                 .getByName(sourceSet.getAnnotationProcessorConfigurationName())
-                .getIncoming()
-                .getResolutionResult()
-                .getAllComponents()
+                .getAllDependencies()
                 .stream()
                 .anyMatch(BaselineImmutables::isImmutablesValue);
     }
 
-    private static boolean isImmutablesValue(ResolvedComponentResult component) {
-        ComponentIdentifier id = component.getId();
-
-        if (!(id instanceof ModuleComponentIdentifier)) {
-            return false;
-        }
-
-        ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) id;
-
-        return Objects.equals(moduleId.getGroup(), "org.immutables") && Objects.equals(moduleId.getModule(), "value");
+    private static boolean isImmutablesValue(Dependency dependency) {
+        return Objects.equals(dependency.getGroup(), "org.immutables") && Objects.equals(dependency.getName(), "value");
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineImmutablesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/plugins/BaselineImmutablesTest.groovy
@@ -41,6 +41,7 @@ class BaselineImmutablesTest extends IntegrationSpec {
                 hasImmutables
                 doesNotHaveImmutables
                 hasImmutablesAddedInAfterEvaluate
+                onlyHasImmutablesAnnotations
             }
             
             afterEvaluate {
@@ -53,6 +54,8 @@ class BaselineImmutablesTest extends IntegrationSpec {
                 annotationProcessor '$IMMUTABLES'
                 
                 hasImmutablesAnnotationProcessor '$IMMUTABLES'
+
+                onlyHasImmutablesAnnotationsAnnotationProcessor '$IMMUTABLES_ANNOTATIONS'
             }
             
             task compileAll
@@ -66,7 +69,7 @@ class BaselineImmutablesTest extends IntegrationSpec {
             }
         """.stripIndent()
 
-        ['main', 'hasImmutables', 'doesNotHaveImmutables', 'hasImmutablesAddedInAfterEvaluate'].each {
+        ['main', 'hasImmutables', 'doesNotHaveImmutables', 'hasImmutablesAddedInAfterEvaluate', 'onlyHasImmutablesAnnotations'].each {
             writeJavaSourceFile '''
                 public class Foo {}
             '''.stripIndent(), "src/$it/java"
@@ -81,6 +84,7 @@ class BaselineImmutablesTest extends IntegrationSpec {
         stdout.contains 'compileHasImmutablesJava: [-Aimmutables.gradle.incremental]'
         stdout.contains 'compileDoesNotHaveImmutablesJava: []'
         stdout.contains 'compileHasImmutablesAddedInAfterEvaluateJava: [-Aimmutables.gradle.incremental]'
+        stdout.contains 'compileOnlyHasImmutablesAnnotationsJava: []'
     }
 
     def 'Compatible with java #javaVersion'() {


### PR DESCRIPTION
https://github.com/palantir/conjure-java-runtime-api/pull/1095 broke consumers who did not themselves use the Immutables annotation processor.

```
warning: The following options were not recognized by any processor: '[immutables.gradle.incremental]'
error: warnings found and -Werror specified
1 error
1 warning
```

This is not a regression of https://github.com/palantir/gradle-baseline/pull/2465 - the test added in that PR still passes.