### PR TITLE
When `com.palantir.external-publish-jar` is applied, the module should be considered a library

### DIFF
--- a/changelog/@unreleased/pr-2722.v2.yml
+++ b/changelog/@unreleased/pr-2722.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: When `com.palantir.external-publish-jar` is applied, the module should
+    be considered a library
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2722

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -42,7 +42,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
     // 'nebula.maven-publish' and 'com.palantir.shadow-jar' create publications lazily which cause inconsistencies
     // based on ordering.
     private static final ImmutableSet<String> LIBRARY_PLUGINS =
-            ImmutableSet.of("nebula.maven-publish", "com.palantir.shadow-jar");
+            ImmutableSet.of("nebula.maven-publish", "com.palantir.shadow-jar", "com.palantir.external-publish-jar");
 
     @Override
     public void apply(Project project) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
For a module that has the `java-library` & `com.palantir.external-publish-jar` I would be getting the following contradicting debug messages: 
```
2024-02-14T13:13:19.288+0100 [DEBUG] [com.palantir.baseline.plugins.javaversions.BaselineJavaVersions] Project 'project ':gradle-failure-reports-exceptions'' is considered a distribution because it does not publish jars
...
2024-02-14T13:13:19.292+0100 [DEBUG] [com.palantir.baseline.plugins.javaversions.BaselineJavaVersions] Project 'project ':gradle-failure-reports-exceptions'' is considered a library because it publishes jars: [maven]
```

## After this PR
Anything that applies `com.palantir.external-publish-jar` will be considered a library. 

==COMMIT_MSG==
When `com.palantir.external-publish-jar` is applied, the module should be considered a library
==COMMIT_MSG==


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

