### PR TITLE
turn off "Insert imports for inner classes"

### DIFF
--- a/.baseline/idea/intellij-java-palantir-style.xml
+++ b/.baseline/idea/intellij-java-palantir-style.xml
@@ -30,7 +30,7 @@
             <package name="" static="false" withSubpackages="true" />
           </value>
         </option>
-        <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+        <option name="INSERT_INNER_CLASS_IMPORTS" value="false" />
         <GroovyCodeStyleSettings>
           <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
           <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />

--- a/changelog/@unreleased/pr-2736.v2.yml
+++ b/changelog/@unreleased/pr-2736.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: turn off "Insert imports for inner classes"
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2736


### PR DESCRIPTION
## Before this PR

Our internal ski product database tooling does a lot of codegen and creates many inner classes called `Key`. Today, I find that I often want to reference a few of these classes (e.g. `MyTable.Key key = ...` and `OtherTable.Key key2 = ...`) but IntelliJ _immediately_ simplifies the first import into `Key key = ...` which then trips over the `BadImport` static analysis which complaints about commonly-used names being ambiguous.

I have started just unticking this box:

![image](https://github.com/palantir/gradle-baseline/assets/3473798/da77b35e-3dd3-4c3c-b47d-7fb034bca089)

## After this PR
==COMMIT_MSG==
turn off "Insert imports for inner classes"
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

