### PR TITLE
Make checkJavaVersions task more amenable to gradle8 configuration cache

### DIFF
--- a/changelog/@unreleased/pr-2739.v2.yml
+++ b/changelog/@unreleased/pr-2739.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Make checkJavaVersions task more amenable to gradle8 configuration
+    cache
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2739

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -84,6 +84,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                         public void execute(CheckJavaVersionsTask task) {
                             task.getTargetVersion().set(extension.target());
                             task.getRuntimeVersion().set(extension.runtime());
+                            task.getProjectDisplayName().set(project.getDisplayName());
                         }
                     });
             project.getTasks().named("check").configure(check -> check.dependsOn(checkJavaVersions));
@@ -218,6 +219,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
 
         private final Property<ChosenJavaVersion> targetVersion;
         private final Property<ChosenJavaVersion> runtimeVersion;
+        private final Property<String> projectDisplayName;
 
         @Inject
         public CheckJavaVersionsTask() {
@@ -226,6 +228,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                     + "The runtime version must be greater than or equal to the target version.");
             targetVersion = getProject().getObjects().property(ChosenJavaVersion.class);
             runtimeVersion = getProject().getObjects().property(ChosenJavaVersion.class);
+            projectDisplayName = getProject().getObjects().property(String.class);
         }
 
         @Input
@@ -238,6 +241,11 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             return runtimeVersion;
         }
 
+        @Input
+        Property<String> getProjectDisplayName() {
+            return projectDisplayName;
+        }
+
         @TaskAction
         public final void checkJavaVersions() {
             ChosenJavaVersion target = getTargetVersion().get();
@@ -245,7 +253,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             getLogger()
                     .debug(
                             "BaselineJavaVersion configured project {} with target version {} and runtime version {}",
-                            getProject(),
+                            projectDisplayName,
                             target,
                             runtime);
 


### PR DESCRIPTION
Addresses https://github.com/palantir/gradle-baseline/issues/1719

## Before this PR
The checkJavaVersions task directly accessed the project during execution, which is flagged in the configuration cache report:

![Screenshot 2024-03-06 at 10 28 50 PM](https://github.com/palantir/gradle-baseline/assets/357170/5b394a9d-ff91-48c4-87e1-6bfaa95a01b3)


Looking at the [gradle docs here](https://docs.gradle.org/8.5/userguide/configuration_cache.html#config_cache:requirements:disallowed_types:~:text=For%20example%2C%20if%20you%20reference%20a%20Project%20in%20order%20to%20get%20the%20project.version%20at%20execution%20time%2C%20you%20should%20instead%20directly%20declare%20the%20project%20version%20as%20an%20input%20to%20your%20task%20using%20a%20Property%3CString%3E.), the recommendation is to use a `Property<String>` instead of accessing the `Project` directly.

## After this PR
==COMMIT_MSG==
Make checkJavaVersions task more amenable to gradle8 configuration cache
==COMMIT_MSG==

## Possible downsides?
I don't really know what I'm doing.

