### PR TITLE
override remover fixer

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/conjure/RemoveLater.java
+++ b/baseline-error-prone/src/main/java/com/palantir/conjure/RemoveLater.java
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface RemoveLater {
+    String value() default "";
+}

--- a/baseline-error-prone/src/main/java/com/palantir/conjure/java/lib/internal/ConjureServerEndpoint.java
+++ b/baseline-error-prone/src/main/java/com/palantir/conjure/java/lib/internal/ConjureServerEndpoint.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.lib.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface ConjureServerEndpoint {}

--- a/baseline-error-prone/src/main/java/com/palantir/conjure/versioning/DeprecatedEndpointImplRemoval.java
+++ b/baseline-error-prone/src/main/java/com/palantir/conjure/versioning/DeprecatedEndpointImplRemoval.java
@@ -1,0 +1,96 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.versioning;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ModifiersTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.SUGGESTION,
+        summary = "Alters code that implements server-side conjure endpoints that are about to be deleted. It removes"
+            + " the Override annotation and adds in a RemoveLater one. This check can be auto-fixed using `./gradlew"
+            + " classes testClasses -PerrorProneApply=DeprecatedEndpointImplRemoval`")
+public class DeprecatedEndpointImplRemoval extends BugChecker implements MethodTreeMatcher {
+
+    private static final Matcher<AnnotationTree> OVERRIDE_MATCHER = Matchers.isSameType("java.lang.Override");
+
+    private static final String CONJURE_SERVER_ENDPOINT =
+            "com.palantir.conjure.java.lib.internal.ConjureServerEndpoint";
+    public static final String REMOVE_LATER = "com.palantir.conjure.RemoveLater";
+
+    @Override
+    public Description matchMethod(MethodTree methodTree, VisitorState state) {
+        if (!overridesDeprecatedForRemovalEndpoint(methodTree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        return applyFix(methodTree, methodTree.getModifiers(), state);
+    }
+
+    private static boolean overridesDeprecatedForRemovalEndpoint(MethodTree tree, VisitorState state) {
+        MethodSymbol methodSym = ASTHelpers.getSymbol(tree);
+        if (methodSym == null) {
+            return false;
+        }
+        if (!ASTHelpers.hasAnnotation(methodSym, "java.lang.Override", state)) {
+            return false;
+        }
+        // Check if this method implements a conjure server endpoint that is deprecated for removal.
+        for (MethodSymbol method : ASTHelpers.findSuperMethods(methodSym, state.getTypes())) {
+            Deprecated annotation = method.getAnnotation(Deprecated.class);
+            if (annotation != null
+                    && annotation.forRemoval()
+                    && ASTHelpers.hasAnnotation(method, CONJURE_SERVER_ENDPOINT, state)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Remove the @Override annotation and add a @RemoveLater annotation.
+     */
+    private Description applyFix(Tree tree, ModifiersTree treeModifiers, VisitorState state) {
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        String qualifiedAnnotation = SuggestedFixes.qualifyType(state, fix, REMOVE_LATER);
+        for (AnnotationTree annotationTree : treeModifiers.getAnnotations()) {
+            if (OVERRIDE_MATCHER.matches(annotationTree, state)) {
+                fix.replace(annotationTree, "");
+            }
+        }
+        fix.setShortDescription("Remove @Override and add @RemoveLater annotation");
+        fix.prefixWith(tree, String.format("@%s ", qualifiedAnnotation));
+        return buildDescription(tree).addFix(fix.build()).build();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RefactoringValidator.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/RefactoringValidator.java
@@ -27,7 +27,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
  * {@link RefactoringValidator} delegates to a {@link BugCheckerRefactoringTestHelper}, but also validates the output
  * passes validation.
  */
-final class RefactoringValidator {
+public final class RefactoringValidator {
 
     private final BugCheckerRefactoringTestHelper delegate;
     private final CompilationTestHelper compilationHelper;
@@ -42,19 +42,19 @@ final class RefactoringValidator {
     }
 
     @CheckReturnValue
-    static RefactoringValidator of(Class<? extends BugChecker> checkerClass, Class<?> clazz, String... args) {
+    public static RefactoringValidator of(Class<? extends BugChecker> checkerClass, Class<?> clazz, String... args) {
         return new RefactoringValidator(checkerClass, clazz, args);
     }
 
     @CheckReturnValue
-    OutputStage addInputLines(String path, String... input) {
+    public OutputStage addInputLines(String path, String... input) {
         // If expectUnchanged is unused, the input is used as output
         this.outputPath = path;
         this.outputLines = input;
         return new OutputStage(this, delegate.addInputLines(path, input));
     }
 
-    static final class OutputStage {
+    public static final class OutputStage {
         private final RefactoringValidator helper;
         private final BugCheckerRefactoringTestHelper.ExpectOutput delegate;
 
@@ -64,19 +64,19 @@ final class RefactoringValidator {
         }
 
         @CheckReturnValue
-        TestStage addOutputLines(String path, String... output) {
+        public TestStage addOutputLines(String path, String... output) {
             helper.outputPath = path;
             helper.outputLines = output;
             return new TestStage(helper, delegate.addOutputLines(path, output));
         }
 
         @CheckReturnValue
-        TestStage expectUnchanged() {
+        public TestStage expectUnchanged() {
             return new TestStage(helper, delegate.expectUnchanged());
         }
     }
 
-    static final class TestStage {
+    public static final class TestStage {
 
         private final RefactoringValidator helper;
         private final BugCheckerRefactoringTestHelper delegate;
@@ -86,7 +86,7 @@ final class RefactoringValidator {
             this.delegate = delegate;
         }
 
-        void doTest() {
+        public void doTest() {
             delegate.doTest();
             helper.compilationHelper
                     .addSourceLines(helper.outputPath, helper.outputLines)
@@ -94,7 +94,7 @@ final class RefactoringValidator {
                     .doTest();
         }
 
-        void doTest(BugCheckerRefactoringTestHelper.TestMode testMode) {
+        public void doTest(BugCheckerRefactoringTestHelper.TestMode testMode) {
             delegate.doTest(testMode);
             helper.compilationHelper
                     .addSourceLines(helper.outputPath, helper.outputLines)
@@ -102,7 +102,7 @@ final class RefactoringValidator {
                     .doTest();
         }
 
-        void doTestExpectingFailure(BugCheckerRefactoringTestHelper.TestMode testMode) {
+        public void doTestExpectingFailure(BugCheckerRefactoringTestHelper.TestMode testMode) {
             delegate.doTest(testMode);
             assertThatThrownBy(() -> helper.compilationHelper
                             .addSourceLines(helper.outputPath, helper.outputLines)

--- a/baseline-error-prone/src/test/java/com/palantir/conjure/versioning/DeprecatedEndpointImplRemovalTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/conjure/versioning/DeprecatedEndpointImplRemovalTest.java
@@ -1,0 +1,125 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.versioning;
+
+import com.palantir.baseline.errorprone.RefactoringValidator;
+import org.junit.jupiter.api.Test;
+
+public class DeprecatedEndpointImplRemovalTest {
+
+    @Test
+    public void testSingleEndpoint() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.conjure.java.lib.internal.ConjureServerEndpoint;",
+                        "class Test {",
+                        "  interface Iface {",
+                        "    @ConjureServerEndpoint",
+                        "    @Deprecated(forRemoval = true)",
+                        "    void deprecatedForRemovalMethod();",
+                        "  }",
+                        "  static class Impl implements Iface {",
+                        "    @Override",
+                        "    public void deprecatedForRemovalMethod() {",
+                        "      return;",
+                        "    }",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.conjure.RemoveLater;",
+                        "import com.palantir.conjure.java.lib.internal.ConjureServerEndpoint;",
+                        "class Test {",
+                        "  interface Iface {",
+                        "    @ConjureServerEndpoint",
+                        "    @Deprecated(forRemoval = true)",
+                        "    void deprecatedForRemovalMethod();",
+                        "  }",
+                        "  static class Impl implements Iface {",
+                        "    @RemoveLater",
+                        "    public void deprecatedForRemovalMethod() {",
+                        "      return;",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testMultipleEndpoints() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.conjure.java.lib.internal.ConjureServerEndpoint;",
+                        "class Test {",
+                        "  interface Iface {",
+                        "    @ConjureServerEndpoint",
+                        "    @Deprecated(forRemoval = true)",
+                        "    void deprecatedForRemovalMethod();",
+                        "    @Deprecated",
+                        "    void deprecatedMethod();",
+                        "    void normalMethod();",
+                        "  }",
+                        "  static class Impl implements Iface {",
+                        "    @Override",
+                        "    public void deprecatedForRemovalMethod() {",
+                        "      return;",
+                        "    }",
+                        "    @Override",
+                        "    public void deprecatedMethod() {",
+                        "      return;",
+                        "    }",
+                        "    @Override",
+                        "    public void normalMethod() {",
+                        "      return;",
+                        "    }",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.conjure.RemoveLater;",
+                        "import com.palantir.conjure.java.lib.internal.ConjureServerEndpoint;",
+                        "class Test {",
+                        "  interface Iface {",
+                        "    @ConjureServerEndpoint",
+                        "    @Deprecated(forRemoval = true)",
+                        "    void deprecatedForRemovalMethod();",
+                        "    @Deprecated",
+                        "    void deprecatedMethod();",
+                        "    void normalMethod();",
+                        "  }",
+                        "  static class Impl implements Iface {",
+                        "    @RemoveLater",
+                        "    public void deprecatedForRemovalMethod() {",
+                        "      return;",
+                        "    }",
+                        "    @Override",
+                        "    public void deprecatedMethod() {",
+                        "      return;",
+                        "    }",
+                        "    @Override",
+                        "    public void normalMethod() {",
+                        "      return;",
+                        "    }",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    private RefactoringValidator fix(String... args) {
+        return RefactoringValidator.of(DeprecatedEndpointImplRemoval.class, getClass(), args);
+    }
+}


### PR DESCRIPTION
this is a sample for an errorprone fixer to break connections between a class that implements a conjure interface and methods that are about to be removed from the interface.  

More than likely this should not go into baseline.  Just doing it here for now as a reference