### PR TITLE
Re-enable GradleProviderToString

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,6 @@ allprojects {
                 disable("PreferSafeLogger")
                 disable("PreferSafeLoggingPreconditions")
                 disable("PreconditionsConstantMessage")
-                // TODO(pkoenig): Remove after upgrading baseline
-                disable("GradleProviderToString")
             }
         }
     }


### PR DESCRIPTION
FLUP to https://github.com/palantir/gradle-baseline/pull/2695 where we had to temporarily disable the `GradleProviderToString` due to an ABI break in the `AbstractToString` constructor. Unblocked by the Baseline upgrade in https://github.com/palantir/gradle-baseline/pull/2744.