### PR TITLE
Suppress more checks in Gradle plugin projects

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -104,12 +104,14 @@ public final class BaselineErrorProne implements Plugin<Project> {
                             javaCompile.getOptions())
                     .getExtensions()
                     .configure(ErrorProneOptions.class, errorProneOptions -> {
-                        errorProneOptions.check("Slf4jLogsafeArgs", CheckSeverity.OFF);
-                        errorProneOptions.check("PreferSafeLoggableExceptions", CheckSeverity.OFF);
-                        errorProneOptions.check("PreferSafeLogger", CheckSeverity.OFF);
-                        errorProneOptions.check("PreferSafeLoggingPreconditions", CheckSeverity.OFF);
-                        errorProneOptions.check("PreconditionsConstantMessage", CheckSeverity.OFF);
-                        errorProneOptions.check("JavaxInjectOnAbstractMethod", CheckSeverity.OFF);
+                        errorProneOptions.disable("CatchBlockLogException");
+                        errorProneOptions.disable("JavaxInjectOnAbstractMethod");
+                        errorProneOptions.disable("PreconditionsConstantMessage");
+                        errorProneOptions.disable("PreferSafeLoggableExceptions");
+                        errorProneOptions.disable("PreferSafeLogger");
+                        errorProneOptions.disable("PreferSafeLoggingPreconditions");
+                        errorProneOptions.disable("Slf4jConstantLogMessage");
+                        errorProneOptions.disable("Slf4jLogsafeArgs");
                     }));
         });
     }


### PR DESCRIPTION
Disable the `CatchBlockLogException` and `Slf4jConstantLogMessage` checks in Gradle plugins.

The Gradle [`Logger`](https://docs.gradle.org/current/javadoc/org/gradle/api/logging/Logger.html) interface extends the slf4j [`Logger`](https://www.slf4j.org/api/org/slf4j/Logger.html) interface which triggers these checks when certain log levels are used.