### PR TITLE
Ignore intra-project dependencies in checkUnusedDependencies

### DIFF
--- a/changelog/@unreleased/pr-2748.v2.yml
+++ b/changelog/@unreleased/pr-2748.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Ignore intra-project dependencies in `checkUnusedDependencies`. This
+    allows `checkUnusedDependencies` to be used with Gradle test fixtures even when
+    the test fixtures are not used by the tests.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2748

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -182,6 +182,10 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
                             task.getDependenciesConfigurations().add(explicitCompile);
 
+                            // ignore intra-project dependencies, which are typically added automatically for things
+                            // like test fixtures
+                            task.ignore(project.getGroup().toString(), project.getName());
+
                             // this is liberally applied to ease the Java8 -> 11 transition
                             task.ignore("javax.annotation", "javax.annotation-api");
 
@@ -278,7 +282,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                     .append(projectComponentId.getProjectPath())
                     .append("')");
             if (withName) {
-                builder.append(" (").append(artifact.getId().getDisplayName()).append(")");
+                builder.append(" <-- ").append(artifact.getName());
             }
             return builder.toString();
         }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -163,7 +163,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         task << ['checkUnusedDependencies', 'checkImplicitDependencies']
     }
 
-    def 'checkUnusedDependenciesTest passes if dependency from main source set is not referenced in test'() {
+    def 'checkUnusedDependenciesTest passes if main source set is not referenced in test'() {
         when:
         buildFile << standardBuildFile
         buildFile << """
@@ -182,6 +182,20 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
             }
         }
         '''.stripIndent()
+
+        then:
+        def result = with('checkUnusedDependencies', '--stacktrace').build()
+        result.task(':checkUnusedDependenciesTest').getOutcome() == TaskOutcome.SUCCESS
+    }
+
+    def 'checkUnusedDependenciesTest passes if test fixture source set is not referenced in test'() {
+        when:
+        buildFile << standardBuildFile
+        buildFile << """
+        plugins {
+            id 'java-test-fixtures'
+        }
+        """
 
         then:
         def result = with('checkUnusedDependencies', '--stacktrace').build()
@@ -263,7 +277,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
 
         then:
         BuildResult result = with(':checkUnusedDependencies', '--stacktrace').withDebug(true).buildAndFail()
-        result.output.contains "project(':sub-project-with-deps') (main (project :sub-project-with-deps))"
+        result.output.contains "project(':sub-project-with-deps') <-- main"
         result.output.contains "project(':sub-project-no-deps')"
     }
 


### PR DESCRIPTION
## Before this PR

The `checkUnusedDependenciesTest` task does not work with [Gradle test fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures) if the test code does not itself use the test fixture.

The `test` configurations [extend from](https://github.com/gradle/gradle/blob/85d30969f4672bb2739550b4de784910a6810b7a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java#L416-L419) the `main` configuration, so this "dependency" is not visible to `checkUnusedDependenciesTest`. But the `test` configurations do not extend from the `testFixtures` configurations. Instead the dependency between the `test` and `testFixtures` is handled as a normal dependency, which is visible to `checkUnusedDependenciesTest`.

This PR is motivated by a code generation tool we are building where we want to generate test utilities into the `testFixture` source set. It will not be uncommon for the test classes in the project producing the generated code to not use these utilities and we want to avoid causing `checkUnusedDependenciesTest` failures.

## After this PR

Dependencies to artifacts produced by the same project are ignored by the `checkUnusedDependencies` task.

This seems like a simple way to accomplish this goal with relatively little downside. I don't think there are many other cases that would result in intra-project dependencies like this, and if there are we probably would want to ignore them also.
