### PR TITLE
Handle relocated multi-release class files in checkRuntimeClasspathCompatible

### DIFF
--- a/changelog/@unreleased/pr-2752.v2.yml
+++ b/changelog/@unreleased/pr-2752.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle relocated multi-release class files in checkRuntimeClasspathCompatible
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2752

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/CheckClasspathCompatible.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/CheckClasspathCompatible.java
@@ -76,7 +76,7 @@ public abstract class CheckClasspathCompatible extends DefaultTask {
                     .flatMap(entry -> {
                         // We don't care about higher versions of classes in multi-release jars as JVMs will only
                         // load classes from here that match or are higher than their current version
-                        boolean isMultiReleaseClass = entry.getName().startsWith("META-INF/versions");
+                        boolean isMultiReleaseClass = entry.getName().contains("META-INF/versions");
                         boolean isntClassFile = !entry.getName().endsWith(".class");
 
                         if (isMultiReleaseClass || isntClassFile) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -57,8 +57,6 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         
         apply plugin: 'com.palantir.baseline-java-versions'
         
-        }
-        
         application {
             mainClass = 'Main'
         }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -41,6 +41,7 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
     private static final int ENABLE_PREVIEW_BYTECODE = 65535
     private static final int NOT_ENABLE_PREVIEW_BYTECODE = 0
 
+    // language=Gradle
     def standardBuildFile = '''
         buildscript {
             repositories { mavenCentral() }
@@ -53,6 +54,12 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         plugins {
             id 'java-library'
             id 'application'
+        }
+        
+        allprojects {
+            repositories {
+                mavenCentral()
+            }
         }
         
         apply plugin: 'com.palantir.baseline-java-versions'


### PR DESCRIPTION
See https://github.com/gradle/gradle/issues/24515

The `checkRuntimeClasspathCompatible` check added in https://github.com/palantir/gradle-baseline/pull/2749 produces false positives when using `gradleApi()`.

```
The runtime classpath has the following jars which contain classes that have too high a java language version. We're expecting the bytecode major version to be no more than 61 for java language version 17. Examples classes in each jar:

/home/circleci/.gradle/caches/8.5/generated-gradle-jars/gradle-api-8.5.jar: org/gradle/internal/impldep/META-INF/versions/19/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class has bytecode major version 63

* Causal chain is:
	org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':my-gradle-plugin:checkRuntimeClasspathCompatible'.
	java.lang.RuntimeException: The runtime classpath has the following jars which contain classes that have too high a java language version. We're expecting the bytecode major version to be no more than 61 for java language version 17. Examples classes in each jar:

/home/circleci/.gradle/caches/8.5/generated-gradle-jars/gradle-api-8.5.jar: org/gradle/internal/impldep/META-INF/versions/19/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class has bytecode major version 63
```