### PR TITLE
Lazily provide self coordinate to checkUnusedDependencies

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -184,7 +184,8 @@ public final class BaselineExactDependencies implements Plugin<Project> {
 
                             // ignore intra-project dependencies, which are typically added automatically for things
                             // like test fixtures
-                            task.ignore(project.getGroup().toString(), project.getName());
+                            task.ignore(project.provider(() ->
+                                    Set.of(ignoreCoordinate(project.getGroup().toString(), project.getName()))));
 
                             // this is liberally applied to ease the Java8 -> 11 transition
                             task.ignore("javax.annotation", "javax.annotation-api");


### PR DESCRIPTION
Small follow up to https://github.com/palantir/gradle-baseline/pull/2748

Misbehaving Gradle plugins may trigger eager configuration of the `checkUnusedDependencies` tasks, [although this is discouraged](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html). If this happens before the project group is set, then intra-project dependencies will not be ignored because the ignored project coordinate is incorrect.

This PR changes the ignored coordinate to be lazy so we always look at the current project group ID when resolving the ignored coordinates in the task.