### PR TITLE
Allow safe implementations of unsafe classes

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -349,7 +349,7 @@ public final class IllegalSafeLoggingArgument extends BugChecker
             return Description.NO_MATCH;
         }
         Safety ancestorSafety = SafetyAnnotations.getTypeSafetyFromAncestors(tree, state);
-        if (directSafety.allowsValueWith(ancestorSafety)) {
+        if (ancestorSafety.allowsValueWith(directSafety)) {
             return Description.NO_MATCH;
         }
         return buildDescription(tree)

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
@@ -147,7 +147,7 @@ public final class SafetyAnnotations {
     public static Safety getTypeSafetyFromAncestors(ClassTree classTree, VisitorState state) {
         Safety safety = SafetyAnnotations.getSafety(classTree.getExtendsClause(), state);
         for (Tree implemented : classTree.getImplementsClause()) {
-            safety = safety.leastUpperBound(SafetyAnnotations.getSafety(implemented, state));
+            safety = Safety.mergeAssumingUnknownIsSame(safety, SafetyAnnotations.getSafety(implemented, state));
         }
         return safety;
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1826,14 +1826,26 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
-    public void testSubclassWithLenientSafety() {
+    public void testUnsafeExtendsSafe() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  @Safe interface SafeClass {}",
+                        "  // BUG: Diagnostic contains: "
+                                + "Dangerous type: annotated 'UNSAFE' but ancestors declare 'SAFE'.",
+                        "  @Unsafe interface UnsafeSubclass extends SafeClass {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testSafeExtendsUnsafe() {
         helper().addSourceLines(
                         "Test.java",
                         "import com.palantir.logsafe.*;",
                         "class Test {",
                         "  @Unsafe interface UnsafeClass {}",
-                        "  // BUG: Diagnostic contains: "
-                                + "Dangerous type: annotated 'SAFE' but ancestors declare 'UNSAFE'.",
                         "  @Safe interface SafeSubclass extends UnsafeClass {}",
                         "}")
                 .doTest();


### PR DESCRIPTION
## Before this PR

The `IllegalSafeLoggingArgument` check allows an `@Unsafe` subtype of `@Safe` type, which is can be dangerous.

```java
// This is allowed

@Safe
interface Foo {}

@Unsafe
class Bar implements Foo {}

// Oops, we will now safe log an unsafe value
Foo getFoo() {
    return new Bar();
}
```

Conversely, the `IllegalSafeLoggingArgument` check does not allow a `@Safe` subtype of an `@Unsafe` type, even though this should be safe.

```java
// This is not allowed

@Unsafe
interface Foo {}

@Safe
class Bar implements Foo {}
```

This just seems like a bug in the `IllegalSafeLoggingArgument` check.

## After this PR

Inverts the ancestor check in `IllegalSafeLoggingArgument` to:
- Disallow an `@Unsafe` subtype of `@Safe` type 
- Allow a `@Safe` subtype of `@Unsafe` type

This appears to be a subset of the functionality in https://github.com/palantir/gradle-baseline/pull/2699.

## Possible downsides?

Is there something I'm not understanding about this check?