### PR TITLE
Add fix parameter to checkClassUniqueness

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineClassUniquenessPlugin.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineClassUniquenessPlugin.java
@@ -41,6 +41,8 @@ public class BaselineClassUniquenessPlugin extends AbstractBaselinePlugin {
         TaskProvider<CheckClassUniquenessLockTask> checkClassUniqueness = project.getTasks()
                 .register("checkClassUniqueness", CheckClassUniquenessLockTask.class, task -> {
                     task.jarClassHasher.set(jarClassHasher);
+                    task.shouldFix.convention(
+                            project.getGradle().getStartParameter().isWriteDependencyLocks());
                     task.usesService(jarClassHasher);
                 });
         project.getPlugins().apply(LifecycleBasePlugin.class);

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
@@ -56,9 +56,11 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
         result.getOutput().contains("javax.el.ArrayELResolver");
         !lockfile.exists()
 
+        when:
         with("checkClassUniqueness", "--fix").build()
-        lockfile.exists()
 
+        then:
+        lockfile.exists()
         File expected = new File("src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock")
         if (Boolean.getBoolean("recreate")) {
             GFileUtils.writeFile(lockfile.text, expected)
@@ -85,9 +87,11 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
         result.getOutput().contains("javax.el.ArrayELResolver");
         !lockfile.exists()
 
+        when:
         with("checkClassUniqueness", "--write-locks").build()
-        lockfile.exists()
 
+        then:
+        lockfile.exists()
         File expected = new File("src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock")
         if (Boolean.getBoolean("recreate")) {
             GFileUtils.writeFile(lockfile.text, expected)

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
@@ -37,6 +37,35 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
         }
     """.stripIndent()
 
+    def 'detect duplicates in two external jars, then --fix captures'() {
+        File lockfile = new File(projectDir, 'baseline-class-uniqueness.lock')
+
+        when:
+        buildFile << standardBuildFile
+        buildFile << """
+        dependencies {
+            api group: 'javax.el', name: 'javax.el-api', version: '3.0.0'
+            api group: 'javax.servlet.jsp', name: 'jsp-api', version: '2.1'
+        }
+        """.stripIndent()
+        BuildResult result = with('check', '-s').buildAndFail()
+
+        then:
+        result.getOutput().contains("baseline-class-uniqueness detected multiple jars containing identically named classes.")
+        result.getOutput().contains("[javax.el:javax.el-api, javax.servlet.jsp:jsp-api]")
+        result.getOutput().contains("javax.el.ArrayELResolver");
+        !lockfile.exists()
+
+        with("checkClassUniqueness", "--fix").build()
+        lockfile.exists()
+
+        File expected = new File("src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock")
+        if (Boolean.getBoolean("recreate")) {
+            GFileUtils.writeFile(lockfile.text, expected)
+        }
+        lockfile.text == expected.text
+    }
+
     def 'detect duplicates in two external jars, then --write-locks captures'() {
         File lockfile = new File(projectDir, 'baseline-class-uniqueness.lock')
 

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/baseline-class-uniqueness.expected.lock
@@ -1,5 +1,5 @@
 # Danger! Multiple jars contain identically named classes. This may cause different behaviour depending on classpath ordering.
-# Run ./gradlew checkClassUniqueness --write-locks to update this file
+# Run ./gradlew checkClassUniqueness --fix to update this file
 
 ## runtimeClasspath
 [javax.el:javax.el-api, javax.servlet.jsp:jsp-api]


### PR DESCRIPTION
Our internal upgrade automation tool attempts to run `./gradlew checkClassUniqueness --fix`, but `--fix` is not a valid option for `checkClassUniqueness`. This results in a number of failing automated upgrades.

This PR also fixes the exception message, which accidentally lost the suggested command after https://github.com/palantir/gradle-baseline/pull/2724.