### PR TITLE
Document how to enable checkUnusedDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,16 @@ checkImplicitDependencies {
 }
 ```
 
+These tasks are created by default, but are not configured to run as part of `check`.  To do that, add to the root `/build.gradle`:
+
+```gradle
+allprojects {
+    apply plugin: 'java-library'
+
+    tasks.check.dependsOn checkUnusedDependencies, checkImplicitDependencies
+}
+```
+
 ## com.palantir.baseline-encoding
 
 This plugin sets the encoding for JavaCompile tasks to `UTF-8`.


### PR DESCRIPTION
## Before this PR
I mistakenly thought that com.palantir.baseline-exact-dependencies being applied (by default) meant that that `check` would run `checkUnusedDependencies`.  Actually it does not, and repos wanting this behavior need to opt into it.

## After this PR
==COMMIT_MSG==
Document how to enable checkUnusedDependencies
==COMMIT_MSG==

This PR documents how repos can do that, so it's an easy copy+paste if desired.

## Possible downsides?
None known