### PR TITLE
Reduce memory usage of `checkClasspathCompatible`

### DIFF
--- a/changelog/@unreleased/pr-2791.v2.yml
+++ b/changelog/@unreleased/pr-2791.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Reduce memory usage of `checkClasspathCompatible`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2791

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/CheckClasspathCompatible.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/CheckClasspathCompatible.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.stream.Collectors;
-import org.apache.commons.io.input.BoundedInputStream;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
@@ -89,8 +88,7 @@ public abstract class CheckClasspathCompatible extends DefaultTask {
                     continue;
                 }
 
-                InputStream classInputStream = new BoundedInputStream(jarInputStream, entry.getSize());
-                Optional<String> bytecodeMajorVersionTooHigh = bytecodeMajorVersionForClassFile(classInputStream)
+                Optional<String> bytecodeMajorVersionTooHigh = bytecodeMajorVersionForClassFile(jarInputStream)
                         .filter(bytecodeMajorVersion ->
                                 bytecodeMajorVersion > getJavaVersion().get().asBytecodeMajorVersion())
                         .map(bytecodeMajorVersion -> entryName + " has bytecode major version " + bytecodeMajorVersion);


### PR DESCRIPTION
## Before this PR
A project internally was running out of heap in CI. We did a JFR and determined that `JarFile` and the sheer number of `InflaterInputStream`s it creates was using up gigabytes of space. `DataInputStream` was also allocating a lot (it allocates 240+ bytes [the moment you create it](https://github.com/openjdk/jdk17/blob/4afbcaf55383ec2f5da53282a1547bac3d099e9d/src/java.base/share/classes/java/io/DataInputStream.java#L57-L61)).

## After this PR
Use `JarInputStream` instead, which does not appear to have the same issue.

==COMMIT_MSG==
Reduce memory usage of `checkClasspathCompatible`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

