### PR TITLE
Adding TestFactory as a method that ignores DesignForExntesion along other test methods

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -406,7 +406,7 @@
             <property name="switchBlockAsSingleDecisionPoint" value="true"/>
         </module>
         <module name="DesignForExtension"> <!-- Java Coding Guidelines: Design for extension -->
-            <property name="ignoredAnnotations" value="ParameterizedTest, Test, Before, BeforeEach, After, AfterEach, BeforeClass, BeforeAll, AfterClass, AfterAll"/>
+            <property name="ignoredAnnotations" value="ParameterizedTest, Test, Before, BeforeEach, After, AfterEach, BeforeClass, BeforeAll, AfterClass, AfterAll, TestFactory"/>
         </module>
         <module name="JavadocMethod"> <!-- Java Style Guide: Where Javadoc is used -->
             <property name="accessModifiers" value="public"/>

--- a/changelog/@unreleased/pr-2804.v2.yml
+++ b/changelog/@unreleased/pr-2804.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Adding [TestFactory](https://junit.org/junit5/docs/5.4.1/api/org/junit/jupiter/api/TestFactory.html)
+    (for DynamicTests) as part of the methods that ignore this annotation.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2804


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Have to manually suppress DesignForExtension every time.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adding [TestFactory](https://junit.org/junit5/docs/5.4.1/api/org/junit/jupiter/api/TestFactory.html) (for DynamicTests) as part of the methods that ignore this annotation.

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

