### PR TITLE
suppressing test factory warnings

### DIFF
--- a/changelog/@unreleased/pr-2810.v2.yml
+++ b/changelog/@unreleased/pr-2810.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Adding [TestFactory](https://junit.org/junit5/docs/5.4.1/api/org/junit/jupiter/api/TestFactory.html)
+    (for DynamicTests) as part of the methods that ignore this annotation.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2810

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -424,7 +424,7 @@
             <property name="switchBlockAsSingleDecisionPoint" value="true"/>
         </module>
         <module name="DesignForExtension"> <!-- Java Coding Guidelines: Design for extension -->
-            <property name="ignoredAnnotations" value="ParameterizedTest, Test, Before, BeforeEach, After, AfterEach, BeforeClass, BeforeAll, AfterClass, AfterAll"/>
+            <property name="ignoredAnnotations" value="ParameterizedTest, Test, Before, BeforeEach, After, AfterEach, BeforeClass, BeforeAll, AfterClass, AfterAll, TestFactory"/>
         </module>
         <module name="JavadocMethod"> <!-- Java Style Guide: Where Javadoc is used -->
             <property name="accessModifiers" value="public"/>


### PR DESCRIPTION
## Before this PR
Have to manually suppress DesignForExtension every time.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adding [TestFactory](https://junit.org/junit5/docs/5.4.1/api/org/junit/jupiter/api/TestFactory.html) (for DynamicTests) as part of the methods that ignore this annotation.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

