### PR TITLE
cache key for JarClassHasher includes artifact classifier

### DIFF
--- a/changelog/@unreleased/pr-2813.v2.yml
+++ b/changelog/@unreleased/pr-2813.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: cache key for JarClassHasher includes artifact classifier
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2813

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/ClassUniquenessArtifactIdentifier.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/ClassUniquenessArtifactIdentifier.java
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.services;
+
+import java.util.Optional;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(optionalAcceptNullable = true)
+public interface ClassUniquenessArtifactIdentifier {
+    ModuleVersionIdentifier moduleVersionIdentifier();
+
+    Optional<String> classifier();
+}

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/JarClassHasher.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/JarClassHasher.java
@@ -42,14 +42,8 @@ import org.slf4j.Logger;
 
 public abstract class JarClassHasher implements BuildService<BuildServiceParameters.None>, AutoCloseable {
 
-    @Value.Immutable
-    interface CacheKey {
-        ModuleVersionIdentifier moduleVersionIdentifier();
-
-        String classifier();
-    }
-
-    private final Cache<CacheKey, Result> cache = Caffeine.newBuilder().build();
+    private final Cache<ClassUniquenessArtifactIdentifier, Result> cache =
+            Caffeine.newBuilder().build();
 
     public static final class Result {
         private final ImmutableSetMultimap<String, HashCode> hashesByClassName;
@@ -68,7 +62,7 @@ public abstract class JarClassHasher implements BuildService<BuildServiceParamet
     }
 
     public final Result hashClasses(ResolvedArtifact resolvedArtifact, Logger logger) {
-        CacheKey key = ImmutableCacheKey.builder()
+        ClassUniquenessArtifactIdentifier key = ImmutableClassUniquenessArtifactIdentifier.builder()
                 .moduleVersionIdentifier(resolvedArtifact.getModuleVersion().getId())
                 .classifier(Strings.nullToEmpty(resolvedArtifact.getClassifier()))
                 .build();

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/JarClassHasher.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/JarClassHasher.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.services;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.hash.HashCode;
@@ -36,11 +37,19 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
+import org.immutables.value.Value;
 import org.slf4j.Logger;
 
 public abstract class JarClassHasher implements BuildService<BuildServiceParameters.None>, AutoCloseable {
-    private final Cache<ModuleVersionIdentifier, Result> cache =
-            Caffeine.newBuilder().build();
+
+    @Value.Immutable
+    interface CacheKey {
+        ModuleVersionIdentifier moduleVersionIdentifier();
+
+        String classifier();
+    }
+
+    private final Cache<CacheKey, Result> cache = Caffeine.newBuilder().build();
 
     public static final class Result {
         private final ImmutableSetMultimap<String, HashCode> hashesByClassName;
@@ -59,7 +68,11 @@ public abstract class JarClassHasher implements BuildService<BuildServiceParamet
     }
 
     public final Result hashClasses(ResolvedArtifact resolvedArtifact, Logger logger) {
-        return cache.get(resolvedArtifact.getModuleVersion().getId(), _moduleId -> {
+        CacheKey key = ImmutableCacheKey.builder()
+                .moduleVersionIdentifier(resolvedArtifact.getModuleVersion().getId())
+                .classifier(Strings.nullToEmpty(resolvedArtifact.getClassifier()))
+                .build();
+        return cache.get(key, _moduleId -> {
             File file = resolvedArtifact.getFile();
             if (!file.exists()) {
                 return Result.empty();

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/JarClassHasher.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/services/JarClassHasher.java
@@ -33,11 +33,9 @@ import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.stream.Collectors;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
-import org.immutables.value.Value;
 import org.slf4j.Logger;
 
 public abstract class JarClassHasher implements BuildService<BuildServiceParameters.None>, AutoCloseable {

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -38,7 +38,6 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.specs.Spec;

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -19,6 +19,7 @@ package com.palantir.baseline.tasks;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
+import com.palantir.baseline.services.ClassUniquenessArtifactIdentifier;
 import com.palantir.baseline.services.JarClassHasher;
 import com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion;
 import difflib.DiffUtils;
@@ -111,7 +112,8 @@ public class CheckClassUniquenessLockTask extends DefaultTask {
                             ClassUniquenessAnalyzer analyzer = new ClassUniquenessAnalyzer(
                                     jarClassHasher.get(), getProject().getLogger());
                             analyzer.analyzeConfiguration(configuration);
-                            Collection<Set<ModuleVersionIdentifier>> problemJars = analyzer.getDifferingProblemJars();
+                            Collection<Set<ClassUniquenessArtifactIdentifier>> problemJars =
+                                    analyzer.getDifferingProblemJars();
 
                             if (problemJars.isEmpty()) {
                                 return Optional.empty();
@@ -148,16 +150,23 @@ public class CheckClassUniquenessLockTask extends DefaultTask {
         }
     }
 
-    private String clashingClasses(ClassUniquenessAnalyzer analyzer, Set<ModuleVersionIdentifier> clashingJars) {
+    private String clashingClasses(
+            ClassUniquenessAnalyzer analyzer, Set<ClassUniquenessArtifactIdentifier> clashingJars) {
         return analyzer.getDifferingSharedClassesInProblemJars(clashingJars).stream()
                 .sorted()
                 .map(className -> String.format("  - %s", className))
                 .collect(Collectors.joining("\n"));
     }
 
-    private String clashingJarHeader(Set<ModuleVersionIdentifier> clashingJars) {
+    private String clashingJarHeader(Set<ClassUniquenessArtifactIdentifier> clashingJars) {
         return clashingJars.stream()
-                .map(mvi -> mvi.getGroup() + ":" + mvi.getName())
+                .map(ident -> {
+                    String mvi = ident.moduleVersionIdentifier().getGroup() + ":"
+                            + ident.moduleVersionIdentifier().getName();
+                    return ident.classifier().isEmpty()
+                            ? mvi
+                            : mvi + " (classifier=" + ident.classifier().get() + ")";
+                })
                 .sorted()
                 .collect(Collectors.joining(", ", "[", "]"));
     }

--- a/gradle-baseline-java/src/test/resources/com/palantir/baseline/baseline-class-uniqueness-with-classifier.expected.lock
+++ b/gradle-baseline-java/src/test/resources/com/palantir/baseline/baseline-class-uniqueness-with-classifier.expected.lock
@@ -1,0 +1,54 @@
+# Danger! Multiple jars contain identically named classes. This may cause different behaviour depending on classpath ordering.
+# Run ./gradlew checkClassUniqueness --fix to update this file
+
+## runtimeClasspath
+[com.google.cloud.bigdataoss:gcs-connector (classifier=shaded), com.google.cloud.bigdataoss:gcsio]
+  - com.google.cloud.hadoop.gcsio.authorization.AuthorizationHandler
+[com.google.cloud.bigdataoss:gcs-connector (classifier=shaded), com.google.cloud.bigdataoss:util-hadoop]
+  - com.google.cloud.hadoop.util.AccessTokenProvider
+  - com.google.cloud.hadoop.util.AccessTokenProvider$AccessToken
+  - com.google.cloud.hadoop.util.AccessTokenProvider$AccessTokenType
+[com.google.cloud.bigdataoss:gcs-connector (classifier=shaded), com.google.cloud.bigdataoss:util]
+  - com.google.cloud.hadoop.util.AccessBoundary
+  - com.google.cloud.hadoop.util.AccessBoundary$Action
+  - com.google.cloud.hadoop.util.AutoValue_AccessBoundary
+[com.google.cloud.bigdataoss:gcs-connector, com.google.cloud.bigdataoss:gcs-connector (classifier=shaded)]
+  - com.google.cloud.hadoop.fs.gcs.AutoValue_SyncableOutputStreamOptions
+  - com.google.cloud.hadoop.fs.gcs.AutoValue_SyncableOutputStreamOptions$1
+  - com.google.cloud.hadoop.fs.gcs.AutoValue_SyncableOutputStreamOptions$Builder
+  - com.google.cloud.hadoop.fs.gcs.CoopLockFsck
+  - com.google.cloud.hadoop.fs.gcs.CoopLockFsckRunner
+  - com.google.cloud.hadoop.fs.gcs.CoopLockFsckRunner$1
+  - com.google.cloud.hadoop.fs.gcs.CoopLockFsckRunner$2
+  - com.google.cloud.hadoop.fs.gcs.FileSystemDescriptor
+  - com.google.cloud.hadoop.fs.gcs.FsBenchmark
+  - com.google.cloud.hadoop.fs.gcs.GhfsStatistic
+  - com.google.cloud.hadoop.fs.gcs.GhfsStatisticTypeEnum
+  - com.google.cloud.hadoop.fs.gcs.GhfsStorageStatistics
+  - com.google.cloud.hadoop.fs.gcs.GhfsStorageStatistics$1
+  - com.google.cloud.hadoop.fs.gcs.GhfsStorageStatistics$LongIterator
+  - com.google.cloud.hadoop.fs.gcs.GhfsStorageStatistics$MeanStatistic
+  - com.google.cloud.hadoop.fs.gcs.GhfsStreamStats
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFSInputStream
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase$1
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase$GcsFileChecksum
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase$GcsFileChecksumType
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase$GlobAlgorithm
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase$InvocationRaisingIOE
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase$OutputStreamType
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopOutputStream
+  - com.google.cloud.hadoop.fs.gcs.GoogleHadoopSyncableOutputStream
+  - com.google.cloud.hadoop.fs.gcs.HadoopConfigurationProperty
+  - com.google.cloud.hadoop.fs.gcs.HadoopCredentialConfiguration
+  - com.google.cloud.hadoop.fs.gcs.InMemoryGlobberFileSystem
+  - com.google.cloud.hadoop.fs.gcs.SyncableOutputStreamOptions
+  - com.google.cloud.hadoop.fs.gcs.SyncableOutputStreamOptions$Builder
+  - com.google.cloud.hadoop.fs.gcs.auth.AbstractDelegationTokenBinding
+  - com.google.cloud.hadoop.fs.gcs.auth.AbstractDelegationTokenBinding$TokenSecretManager
+  - com.google.cloud.hadoop.fs.gcs.auth.DelegationTokenIOException
+  - com.google.cloud.hadoop.fs.gcs.auth.GcsDelegationTokens
+  - com.google.cloud.hadoop.fs.gcs.auth.GcsDtFetcher


### PR DESCRIPTION
## Before this PR
Previously, we used the `ModuleVersionIdentifier` associated with a `ResolvedArtifact` as the key for this cache, which contains sha256 hashes of each class file within a jar. Unfortunately this is not sufficient for distinguishing artifacts with the same maven coordinate, but different classifiers, which may contain completely different content within the jars.

This leads to problems when two artifacts from the same maven coordinate but different classifiers are on the classpath, wherein `checkClassUniqueness` potentially reports incorrect results as it may rely on hashes cached from a different artifact altogether (but for the same `ModuleVersionIdentifier`).

As a practical example (and where this issue was discovered), the coordinate `com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.19` contains both a "normal" jar artifact, and one with the `shaded` classifier. The latter includes classes that may conflict with other dependencies on the classpath. If `JarClassHasher` hashes and subsequently caches the classfiles from the "normal" jar first, when we encounter the "shaded" jar we will erroneously used the cached values from the "normal" jar for the shaded one when considering classpath conflicts.

## After this PR
This change includes the artifact classifier in the cache key, to distinguish between artifacts with the same `ModuleVersionIdentifier` but different classifiers, which are actually different artifacts.

==COMMIT_MSG==
cache key for JarClassHasher includes artifact classifier
==COMMIT_MSG==

## Possible downsides?
This will possibly cause `checkClassUniqueness` to fail on consumers that may have committed lockfiles under the old behavior, where we potentially missed possible classpath conflicts due to the incorrect caching behavior.

