### PR TITLE
Fix #2812

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StringBuilderConstantParameters.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StringBuilderConstantParameters.java
@@ -95,6 +95,8 @@ public final class StringBuilderConstantParameters extends BugChecker
         return buildDescription(tree)
                 .setMessage(MESSAGE)
                 .addFix(SuggestedFix.builder()
+                        .prefixWith(tree, "(")
+                        .postfixWith(tree, ")")
                         .replace(
                                 tree,
                                 Streams.concat(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StringBuilderConstantParametersTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StringBuilderConstantParametersTests.java
@@ -312,6 +312,30 @@ public class StringBuilderConstantParametersTests {
     }
 
     @Test
+    public void suggestedFixHandlesMethodCalledOnBuilt() {
+        RefactoringValidator.of(StringBuilderConstantParameters.class, getClass())
+                .addInputLines(
+                        "Test.java",
+                        "class Test {",
+                        "   String f() {",
+                        "       return new StringBuilder()",
+                        "           .append(\"foo\")",
+                        "           .append(\"bar\")",
+                        "           .toString()",
+                        "           .toLowerCase();",
+                        "   }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "class Test {",
+                        "   String f() {",
+                        "       return (\"foo\"  + \"bar\").toLowerCase();",
+                        "   }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void negativeDynamicStringBuilder() {
         compilationHelper
                 .addSourceLines(

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StringBuilderConstantParametersTests.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StringBuilderConstantParametersTests.java
@@ -54,7 +54,7 @@ public class StringBuilderConstantParametersTests {
                         "   }",
                         "}")
                 .addOutputLines(
-                        "Test.java", "class Test {", "   String f() {", "       return \"foo\" + 1;", "   }", "}")
+                        "Test.java", "class Test {", "   String f() {", "       return (\"foo\" + 1);", "   }", "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
@@ -86,7 +86,7 @@ public class StringBuilderConstantParametersTests {
                         "Test.java",
                         "class Test {",
                         "   String f() {",
-                        "       return \"ctor\" + \"foo\" + 1;",
+                        "       return (\"ctor\" + \"foo\" + 1);",
                         "   }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -120,7 +120,7 @@ public class StringBuilderConstantParametersTests {
                         "Test.java",
                         "class Test {",
                         "   String f(CharSequence charSequence) {",
-                        "       return \"\" + charSequence + \"foo\" + 1;",
+                        "       return (\"\" + charSequence + \"foo\" + 1);",
                         "   }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -154,7 +154,7 @@ public class StringBuilderConstantParametersTests {
                         "Test.java",
                         "class Test {",
                         "   String f(long param0, double param1) {",
-                        "       return \"\" + param0 + param1;",
+                        "       return (\"\" + param0 + param1);",
                         "   }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -174,7 +174,7 @@ public class StringBuilderConstantParametersTests {
                         "Test.java",
                         "class Test {",
                         "   String f(String param0, double param1) {",
-                        "       return param0 + param1;",
+                        "       return (param0 + param1);",
                         "   }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -239,7 +239,7 @@ public class StringBuilderConstantParametersTests {
                         "       return new StringBuilder().toString();",
                         "   }",
                         "}")
-                .addOutputLines("Test.java", "class Test {", "   String f() {", "       return \"\";", "   }", "}")
+                .addOutputLines("Test.java", "class Test {", "   String f() {", "       return (\"\");", "   }", "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
 
@@ -257,7 +257,7 @@ public class StringBuilderConstantParametersTests {
                         "Test.java",
                         "class Test {",
                         "   String f(Object obj) {",
-                        "       return (String) obj + 1;",
+                        "       return ((String) obj + 1);",
                         "   }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -281,7 +281,7 @@ public class StringBuilderConstantParametersTests {
                         "Test.java",
                         "class Test {",
                         "   String f(Object obj) {",
-                        "       return \"a\" + (obj == null ? \"nil\" : obj) + \"b\";",
+                        "       return (\"a\" + (obj == null ? \"nil\" : obj) + \"b\");",
                         "   }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -305,7 +305,7 @@ public class StringBuilderConstantParametersTests {
                         "Test.java",
                         "class Test {",
                         "   String f(int param0, int param1) {",
-                        "       return \"a\" + (param0 + param1) + \"b\";",
+                        "       return (\"a\" + (param0 + param1) + \"b\");",
                         "   }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);


### PR DESCRIPTION
## Before this PR
Tests miss the case when a method is called on the built string, see https://github.com/palantir/gradle-baseline/issues/2812

## After this PR
Parens are now surround the append result, ensuring that the post-build method call is applied to the entire built string, not just the last element.

## Possible downsides?
Adds parens even when unnecessary. These can be caught and fixed by [UnnecessaryParentheses](https://errorprone.info/bugpattern/UnnecessaryParentheses), but ideally they'd only be added if necessary.