### PR TITLE
baseline-java-versions: Support Gradle 8.6+ by not inspecting publications

### DIFF
--- a/changelog/@unreleased/pr-2820.v2.yml
+++ b/changelog/@unreleased/pr-2820.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Prevent "Circular evaluation detected" error when using baseline-java-versions
+    on Gradle 8.6+.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2820

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -16,19 +16,15 @@
 
 package com.palantir.baseline.plugins.javaversions;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import java.util.Objects;
 import org.gradle.api.GradleException;
-import org.gradle.api.Named;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublishingExtension;
-import org.gradle.api.publish.ivy.IvyPublication;
-import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +35,12 @@ public final class BaselineJavaVersions implements Plugin<Project> {
     public static final String EXTENSION_NAME = "javaVersions";
 
     public static final GradleVersion MIN_GRADLE_VERSION = GradleVersion.version("7.0");
-    // 'nebula.maven-publish' and 'com.palantir.shadow-jar' create publications lazily which cause inconsistencies
-    // based on ordering.
+
     private static final ImmutableSet<String> LIBRARY_PLUGINS =
-            ImmutableSet.of("nebula.maven-publish", "com.palantir.shadow-jar", "com.palantir.external-publish-jar");
+            ImmutableSet.of("com.palantir.external-publish-jar", "com.palantir.publish-jar");
+
+    private static final ImmutableSet<String> DISTRIBUTION_PLUGINS =
+            ImmutableSet.of("com.palantir.external-publish-dist", "com.palantir.publish-dist");
 
     @Override
     public void apply(Project project) {
@@ -81,6 +79,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                     project.getDisplayName());
             return libraryOverride.get();
         }
+
         for (String plugin : LIBRARY_PLUGINS) {
             if (project.getPluginManager().hasPlugin(plugin)) {
                 log.debug(
@@ -90,6 +89,25 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                 return true;
             }
         }
+
+        for (String plugin : DISTRIBUTION_PLUGINS) {
+            if (project.getPluginManager().hasPlugin(plugin)) {
+                log.debug(
+                        "Project '{}' is considered a distribution because the '{}' plugin is applied",
+                        project.getDisplayName(),
+                        plugin);
+                return false;
+            }
+        }
+
+        if (anySlsPackagingVariantsExtensionsExist(project)) {
+            log.debug(
+                    "Project '{}' is considered a distribution, not a library, because "
+                            + "it applies an sls-packaging plugin",
+                    project.getDisplayName());
+            return false;
+        }
+
         PublishingExtension publishing = project.getExtensions().findByType(PublishingExtension.class);
         if (publishing == null) {
             log.debug(
@@ -98,38 +116,30 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                     project.getDisplayName());
             return false;
         }
-        ImmutableList<String> jarPublications = publishing.getPublications().stream()
-                .filter(pub -> isLibraryPublication(project, pub))
-                .map(Named::getName)
-                .collect(ImmutableList.toImmutableList());
-        if (jarPublications.isEmpty()) {
-            log.debug(
-                    "Project '{}' is considered a distribution because it does not publish jars",
-                    project.getDisplayName());
-            return false;
-        }
-        log.debug(
-                "Project '{}' is considered a library because it publishes jars: {}",
-                project.getDisplayName(),
-                jarPublications);
+
+        // Better to be conservative with the java version rather than release something that is too high to be used.
+        log.debug("Project '{}' is considered a library as no other conditions matched", project.getDisplayName());
         return true;
     }
 
-    private static boolean isLibraryPublication(Project project, Publication publication) {
-        if (publication instanceof MavenPublication) {
-            MavenPublication mavenPublication = (MavenPublication) publication;
-            return mavenPublication.getArtifacts().stream().anyMatch(artifact -> "jar".equals(artifact.getExtension()));
+    private static boolean anySlsPackagingVariantsExtensionsExist(Project project) {
+        // Doing this avoids having to list every sls-packaging plugin as there is no base plugin
+        // Avoids bringing in a dependency on sls-packaging too by using strings rather than the actual class
+        return Iterables.any(
+                project.getExtensions().getExtensionsSchema().getElements(),
+                extensionSchema -> anySuperClassHasCanonicalName(
+                        extensionSchema.getPublicType().getConcreteClass(),
+                        "com.palantir.gradle.dist.BaseDistributionExtension"));
+    }
+
+    private static boolean anySuperClassHasCanonicalName(Class<?> clazz, String canonicalName) {
+        Class<?> currentSuperClass = clazz.getSuperclass();
+        while (currentSuperClass != null) {
+            if (currentSuperClass.getCanonicalName().equals(canonicalName)) {
+                return true;
+            }
+            currentSuperClass = currentSuperClass.getSuperclass();
         }
-        if (publication instanceof IvyPublication) {
-            IvyPublication ivyPublication = (IvyPublication) publication;
-            return ivyPublication.getArtifacts().stream().anyMatch(artifact -> "jar".equals(artifact.getExtension()));
-        }
-        // Default to true for unknown publication types to avoid setting higher jvm targets than necessary
-        log.warn(
-                "Unknown publication '{}' of type '{}'. Assuming project {} is a library",
-                publication,
-                publication.getClass().getName(),
-                project.getName());
-        return true;
+        return false;
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -109,7 +109,7 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
     def setup() {
         // Fork needed or build fails on circleci with "SystemInfo is not supported on this operating system."
         // Comment out locally in order to get debugging to work
-        // setFork(true)
+        setFork(true)
 
         buildFile << standardBuildFile
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -35,7 +35,7 @@ import java.util.regex.Pattern
  */
 @Unroll
 class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
-    private static final List<String> GRADLE_TEST_VERSIONS = ['8.4', GradleVersion.current().getVersion()]
+    private static final List<String> GRADLE_TEST_VERSIONS = ['8.8', GradleVersion.current().getVersion()]
 
     private static final int JAVA_8_BYTECODE = 52
     private static final int JAVA_11_BYTECODE = 55


### PR DESCRIPTION
## Before this PR
baseline-java-versions does not work in Gradle 8.6+. This error is produced:

```
   > Circular evaluation detected: task ':log-receiver-api:log-receiver-api-dialogue:compileJava' property 'javaCompiler'
      -> map(org.gradle.jvm.toolchain.JavaCompiler flatmap(map(property(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion, map(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion provider(?) check-type())))) check-type())
      -> flatmap(map(property(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion, map(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion provider(?) check-type()))))
      -> map(property(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion, map(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion provider(?) check-type())))
      -> property(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion, map(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion provider(?) check-type()))
      -> map(com.palantir.baseline.plugins.javaversions.ChosenJavaVersion provider(?) check-type())
      -> provider(?)
      -> set(interface org.gradle.api.publish.maven.MavenArtifact, org.gradle.api.internal.provider.AbstractCollectionProperty$CollectingSupplier@48eab27f)
      -> map(property 'component')
      -> provider(?)
      -> task ':log-receiver-api:log-receiver-api-dialogue:compileJava' property 'javaCompiler'
```

On further inspection, it appears that accessing information about the `MavenArtifact`s for jars in the maven publishing extension requires forcing the `javaCompiler` property the compile task in Gradle 8.6+. Since we use info from `MavenArtifact` to configure the `javaCompiler` property (checking to see whether there are any jar artifacts), this makes an unresolvable circular evaluation.

## After this PR
==COMMIT_MSG==
Prevent "Circular evaluation detected" error when using baseline-java-versions on Gradle 8.6+.
==COMMIT_MSG==

We avoid this by just not looking the published artifacts. Instead, we expand the list of known library and known distribution plugins and only check with them.

## Possible downsides?
* This may work less generally for non-palantir consumers of this plugin who do not use our distribution plugins. This plugin has always been focused on making it easy for Palantir consumers though.
* The behaviour is now different. If someone was using non-standard plugins but depended on this plugin checking for jar non-artifacts to determine library status, it would now downgrade the java version they used to the libraryTarget, possibly causing errors.