### PR TITLE
String.valueOf and String.copyValueOf should propagate log safety annotations

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -178,6 +178,12 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
     private static final Matcher<ExpressionTree> STRING_FORMAT =
             MethodMatchers.staticMethod().onClass(String.class.getName()).named("format");
 
+    private static final Matcher<ExpressionTree> STRING_VALUE_OF =
+            MethodMatchers.staticMethod().onClass(String.class.getName()).named("valueOf");
+
+    private static final Matcher<ExpressionTree> STRING_COPY_VALUE_OF =
+            MethodMatchers.staticMethod().onClass(String.class.getName()).named("copyValueOf");
+
     private static final Matcher<ExpressionTree> OBJECTS_TO_STRING =
             MethodMatchers.staticMethod().onClass(Objects.class.getName()).named("toString");
 
@@ -288,6 +294,8 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
     // These methods do not take the receiver (generally a static class) into account, only the inputs.
     private static final Matcher<ExpressionTree> RETURNS_SAFETY_COMBINATION_OF_ARGS = Matchers.anyOf(
             STRING_FORMAT,
+            STRING_VALUE_OF,
+            STRING_COPY_VALUE_OF,
             OBJECTS_TO_STRING,
             IMMUTABLE_COLLECTION_FACTORY,
             OPTIONAL_FACTORIES,

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -979,6 +979,46 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testStringValueOf() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  void f(@Safe String safeParam, @Unsafe String unsafeParam, @DoNotLog String dnlParam) {",
+                        "    fun(String.valueOf(safeParam));",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE' "
+                                + "but the parameter requires 'SAFE'.",
+                        "    fun(String.valueOf(unsafeParam));",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG' "
+                                + "but the parameter requires 'SAFE'.",
+                        "    fun(String.valueOf(dnlParam));",
+                        "  }",
+                        "  private static void fun(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testStringCopyValueOf() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  void f(@Safe String safeParam, @Unsafe String unsafeParam, @DoNotLog String dnlParam) {",
+                        "    fun(String.copyValueOf(safeParam.toString().toCharArray()));",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE' "
+                                + "but the parameter requires 'SAFE'.",
+                        "    fun(String.copyValueOf(unsafeParam.toString().toCharArray()));",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG' "
+                                + "but the parameter requires 'SAFE'.",
+                        "    fun(String.copyValueOf(dnlParam.toString().toCharArray()));",
+                        "  }",
+                        "  private static void fun(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testArraySafety() {
         helper().addSourceLines(
                         "Test.java",


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
String.valueOf and String.copyValueOf should propagate log safety annotations
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

