### PR TITLE
Propagate safety through Multimap stream collectors

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Multimaps;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.errorprone.dataflow.AccessPath;
@@ -408,7 +409,16 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
             MethodMatchers.staticMethod().onClass(ImmutableMap.class.getName()).named("toImmutableMap"),
             MethodMatchers.staticMethod()
                     .onClass(ImmutableBiMap.class.getName())
-                    .named("toImmutableBiMap"));
+                    .named("toImmutableBiMap"),
+            MethodMatchers.staticMethod()
+                    .onClass(Multimaps.class.getName())
+                    .namedAnyOf("toMultimap", "flatteningToMultimap"),
+            MethodMatchers.staticMethod()
+                    .onClass(ImmutableListMultimap.class.getName())
+                    .namedAnyOf("toImmutableListMultimap", "flatteningToImmutableListMultimap"),
+            MethodMatchers.staticMethod()
+                    .onClass(ImmutableSetMultimap.class.getName())
+                    .namedAnyOf("toImmutableSetMultimap", "flatteningToImmutableSetMultimap"));
 
     private static final Matcher<ExpressionTree> COLLECT_INCLUDES_STREAM_SAFETY = Matchers.methodInvocation(
             MethodMatchers.instanceMethod()

--- a/changelog/@unreleased/pr-2827.v2.yml
+++ b/changelog/@unreleased/pr-2827.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Stream collectors for multimaps now properly propagate safety information
+    based on their key and value types.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2827


### PR DESCRIPTION
## Before this PR
Safety annotations were already properly propagated for `of` and `copyOf` static factories, but the stream collectors for multimaps were not properly propagating safety information.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Stream collectors for multimaps now properly propagate safety information based on their key and value types.
==COMMIT_MSG==