### PR TITLE
Optional.toString() should throw error

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalToString.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalToString.java
@@ -32,9 +32,8 @@ import java.util.Optional;
 @BugPattern(
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = SeverityLevel.ERROR,
-        summary = "Optional.toString() does not stringifies the value contained by the Optional"
-                + " object. Did you mean Optional.get().toString() instead?")
+        severity = SeverityLevel.WARNING,
+        summary = "Optional.toString() does not stringifies the value contained by the Optional object.")
 public final class OptionalToString extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
     private static final Matcher<ExpressionTree> OPTIONAL_TO_STRING_METHOD = MethodMatchers.instanceMethod()

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalToString.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/OptionalToString.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Optional;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.ERROR,
+        summary = "Optional.toString() does not stringifies the value contained by the Optional"
+                + " object. Did you mean Optional.get().toString() instead?")
+public final class OptionalToString extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final Matcher<ExpressionTree> OPTIONAL_TO_STRING_METHOD = MethodMatchers.instanceMethod()
+            .onExactClassAny(Optional.class.getName(), com.google.common.base.Optional.class.getName())
+            .named("toString")
+            .withNoParameters();
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree methodInvocationTree, VisitorState visitorState) {
+        if (OPTIONAL_TO_STRING_METHOD.matches(methodInvocationTree, visitorState)) {
+            return describeMatch(methodInvocationTree);
+        }
+
+        return Description.NO_MATCH;
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalToStringUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalToStringUsageTest.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OptionalToStringUsageTest {
+
+    private CompilationTestHelper compilationHelper;
+
+    @BeforeEach
+    public void before() {
+        compilationHelper = CompilationTestHelper.newInstance(OptionalToString.class, getClass());
+    }
+
+    @Test
+    public void should_throw_error_if_to_string_is_invoked_on_java_optional() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.Optional;",
+                        "class Test {",
+                        "   String f() {",
+                        "       // BUG: Diagnostic contains: Optional.toString() does not stringifies the value",
+                        "       return Optional.of(\"This is an optional value\").toString();",
+                        "   }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void should_throw_error_if_to_string_is_invoked_on_guava_optional() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.base.Optional;",
+                        "class Test {",
+                        "   String f() {",
+                        "       // BUG: Diagnostic contains: Optional.toString() does not stringifies the value",
+                        "       return Optional.of(\"This is an optional value\").toString();",
+                        "   }",
+                        "}")
+                .doTest();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalToStringUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/OptionalToStringUsageTest.java
@@ -58,4 +58,18 @@ public class OptionalToStringUsageTest {
                         "}")
                 .doTest();
     }
+
+    @Test
+    public void should_not_throw_error_if_to_string_is_invoked_on_optional_get() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import com.google.common.base.Optional;",
+                        "class Test {",
+                        "   String f() {",
+                        "       return Optional.of(\"This is an optional value\").get().toString();",
+                        "   }",
+                        "}")
+                .doTest();
+    }
 }

--- a/changelog/@unreleased/pr-2833.v2.yml
+++ b/changelog/@unreleased/pr-2833.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Optional.toString() should throw error
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2833


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Any usages of Optional.toString() are allowed and cause hard to debug runtime bugs where the actual serialized string is either of:
```text
Optional[ACTUAL_VALUE]
Optional.empty
```
depending on the value contained by the optional.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Usages of Optional.toString() will be discouraged and users will be prompted to use Optional.get().toString() instead.

==COMMIT_MSG==
Optional.toString() should throw error
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

