### PR TITLE
Refactor: move to abstract classes for baseline-java-versions extensions

### DIFF
--- a/changelog/@unreleased/pr-2834.v2.yml
+++ b/changelog/@unreleased/pr-2834.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Move to abstract classes for baseline-java-versions extensions
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2834

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineIdea.groovy
@@ -203,21 +203,21 @@ class BaselineIdea extends AbstractBaselinePlugin {
     private void updateCompilerConfiguration(Node node, BaselineJavaVersionsExtension versions) {
         Node compilerConfiguration = node.component.find { it.'@name' == 'CompilerConfiguration' }
         Node bytecodeTargetLevel = GroovyXmlUtils.matchOrCreateChild(compilerConfiguration, "bytecodeTargetLevel")
-        JavaLanguageVersion defaultBytecodeVersion = versions.libraryTarget().get()
+        JavaLanguageVersion defaultBytecodeVersion = versions.libraryTarget.get()
         bytecodeTargetLevel.attributes().put("target", defaultBytecodeVersion.toString())
         project.allprojects.forEach({ project ->
             BaselineJavaVersionExtension version = project.getExtensions().findByType(BaselineJavaVersionExtension.class)
-            if (version != null && version.target().get().javaLanguageVersion().asInt() != defaultBytecodeVersion.asInt()) {
+            if (version != null && version.target.get().javaLanguageVersion().asInt() != defaultBytecodeVersion.asInt()) {
                 bytecodeTargetLevel.appendNode("module", ImmutableMap.of(
                         "name", project.getName(),
-                        "target", version.target().get().toString()))
+                        "target", version.target.get().toString()))
             }
         })
     }
 
     private void updateProjectRootManager(Node node, BaselineJavaVersionsExtension versions) {
         Node projectRootManager = node.component.find { it.'@name' == 'ProjectRootManager' }
-        ChosenJavaVersion chosenJavaVersion = versions.distributionTarget().get()
+        ChosenJavaVersion chosenJavaVersion = versions.distributionTarget.get()
         int featureRelease = chosenJavaVersion.javaLanguageVersion().asInt()
         projectRootManager.attributes().put("project-jdk-name", featureRelease)
         projectRootManager.attributes().put("languageLevel", chosenJavaVersion.asIdeaLanguageLevel())
@@ -228,7 +228,7 @@ class BaselineIdea extends AbstractBaselinePlugin {
             // Extension must be checked lazily within the transformer
             BaselineJavaVersionExtension versionExtension = currentProject.extensions.findByType(BaselineJavaVersionExtension.class)
             if (versionExtension != null) {
-                ChosenJavaVersion chosenJavaVersion = versionExtension.target().get()
+                ChosenJavaVersion chosenJavaVersion = versionExtension.target.get()
                 Node node = provider.asNode()
                 Node newModuleRootManager = node.component.find { it.'@name' == 'NewModuleRootManager' }
                 newModuleRootManager.attributes().put("LANGUAGE_LEVEL", chosenJavaVersion.asIdeaLanguageLevel())

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -235,7 +235,7 @@ public final class BaselineModuleJvmArgs implements Plugin<Project> {
             project.getPlugins().withType(BaselineJavaVersion.class, _unused -> {
                 BaselineJavaVersionExtension javaVersionsExtension =
                         project.getExtensions().getByType(BaselineJavaVersionExtension.class);
-                extension.setEnablePreview(javaVersionsExtension.runtime().map(chosenJavaVersion -> {
+                extension.setEnablePreview(javaVersionsExtension.getRuntime().map(chosenJavaVersion -> {
                     return chosenJavaVersion.enablePreview()
                             ? Optional.of(chosenJavaVersion.javaLanguageVersion())
                             : Optional.empty();

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -71,7 +71,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                 public void execute(JavaToolchainSpec javaToolchainSpec) {
                     javaToolchainSpec
                             .getLanguageVersion()
-                            .set(extension.runtime().map(ChosenJavaVersion::javaLanguageVersion));
+                            .set(extension.getRuntime().map(ChosenJavaVersion::javaLanguageVersion));
                 }
             });
 
@@ -86,19 +86,19 @@ public final class BaselineJavaVersion implements Plugin<Project> {
 
             // Execution tasks (using the runtime version)
             configureExecutionTasks(
-                    project, extension.runtime(), baselineConfiguredJavaToolchains, rootExtension, toolchainService);
+                    project, extension.getRuntime(), baselineConfiguredJavaToolchains, rootExtension, toolchainService);
 
             // Validation
             TaskProvider<CheckJavaVersionsTask> checkJavaVersions = project.getTasks()
                     .register("checkJavaVersions", CheckJavaVersionsTask.class, task -> {
                         task.getTargetVersion().set(extension.target());
-                        task.getRuntimeVersion().set(extension.runtime());
+                        task.getRuntimeVersion().set(extension.getRuntime());
                     });
 
             TaskProvider<CheckClasspathCompatible> checkRuntimeClasspathCompatible = project.getTasks()
                     .register("checkRuntimeClasspathCompatible", CheckClasspathCompatible.class, task -> {
                         task.getClasspathName().set("runtime");
-                        task.getJavaVersion().set(extension.runtime());
+                        task.getJavaVersion().set(extension.getRuntime());
                         task.getClasspath().setFrom(project.getConfigurations().getByName("runtimeClasspath"));
                     });
 

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionExtension.java
@@ -24,24 +24,8 @@ import org.gradle.api.provider.Property;
  * Extension named {@code javaVersion} used to set the
  * target and runtime java versions used for a single project.
  */
-public class BaselineJavaVersionExtension {
-
-    private final Property<ChosenJavaVersion> target;
-    private final Property<ChosenJavaVersion> runtime;
-
-    private final Property<Boolean> overrideLibraryAutoDetection;
-
-    @Inject
-    public BaselineJavaVersionExtension(Project project) {
-        target = project.getObjects().property(ChosenJavaVersion.class);
-        runtime = project.getObjects().property(ChosenJavaVersion.class);
-        overrideLibraryAutoDetection = project.getObjects().property(Boolean.class);
-
-        target.finalizeValueOnRead();
-        runtime.finalizeValueOnRead();
-        overrideLibraryAutoDetection.finalizeValueOnRead();
-    }
-
+@SuppressWarnings("SummaryJavadoc")
+public abstract class BaselineJavaVersionExtension {
     /**
      * Target {@link ChosenJavaVersion} for compilation.
      *
@@ -49,40 +33,59 @@ public class BaselineJavaVersionExtension {
      * minor version of '65535'. Unlike normal bytecode, this bytecode cannot be run by a higher version of Java that
      * it was compiled by.
      */
-    public final Property<ChosenJavaVersion> target() {
-        return target;
-    }
-
-    public final void setTarget(int value) {
-        target.set(ChosenJavaVersion.of(value));
-    }
-
-    public final void setTarget(String value) {
-        target.set(ChosenJavaVersion.fromString(value));
-    }
+    public abstract Property<ChosenJavaVersion> getTarget();
 
     /** Runtime {@link ChosenJavaVersion} for testing and distributions. */
-    public final Property<ChosenJavaVersion> runtime() {
-        return runtime;
-    }
-
-    public final void setRuntime(int value) {
-        runtime.set(ChosenJavaVersion.of(value));
-    }
-
-    public final void setRuntime(String value) {
-        runtime.set(ChosenJavaVersion.fromString(value));
-    }
+    public abstract Property<ChosenJavaVersion> getRuntime();
 
     /**
      * Overrides auto-detection if a value is present to force this module to be a
      * library ({@code true}) or a distribution {@code false}).
      */
+    public abstract Property<Boolean> getOverrideLibraryAutoDetection();
+
+    @Inject
+    public BaselineJavaVersionExtension(Project project) {
+        getTarget().finalizeValueOnRead();
+        getRuntime().finalizeValueOnRead();
+        getOverrideLibraryAutoDetection().finalizeValueOnRead();
+    }
+
+    /** @deprecated Use {@link #getTarget} instead. */
+    @Deprecated
+    public final Property<ChosenJavaVersion> target() {
+        return getTarget();
+    }
+
+    public final void setTarget(int value) {
+        getTarget().set(ChosenJavaVersion.of(value));
+    }
+
+    public final void setTarget(String value) {
+        getTarget().set(ChosenJavaVersion.fromString(value));
+    }
+
+    /** @deprecated Use {@link #getRuntime} instead. */
+    @Deprecated
+    public final Property<ChosenJavaVersion> runtime() {
+        return getRuntime();
+    }
+
+    public final void setRuntime(int value) {
+        getRuntime().set(ChosenJavaVersion.of(value));
+    }
+
+    public final void setRuntime(String value) {
+        getRuntime().set(ChosenJavaVersion.fromString(value));
+    }
+
+    /** @deprecated Use {@link #getOverrideLibraryAutoDetection()} instead. */
+    @Deprecated
     public final Property<Boolean> overrideLibraryAutoDetection() {
-        return overrideLibraryAutoDetection;
+        return getOverrideLibraryAutoDetection();
     }
 
     public final void library() {
-        overrideLibraryAutoDetection.set(true);
+        getOverrideLibraryAutoDetection().set(true);
     }
 }

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionExtension.java
@@ -51,7 +51,7 @@ public abstract class BaselineJavaVersionExtension {
         getOverrideLibraryAutoDetection().finalizeValueOnRead();
     }
 
-    /** @deprecated Use {@link #getTarget} instead. */
+    /** @deprecated Use {@link #getTarget()} instead. */
     @Deprecated
     public final Property<ChosenJavaVersion> target() {
         return getTarget();
@@ -65,7 +65,7 @@ public abstract class BaselineJavaVersionExtension {
         getTarget().set(ChosenJavaVersion.fromString(value));
     }
 
-    /** @deprecated Use {@link #getRuntime} instead. */
+    /** @deprecated Use {@link #getRuntime()} instead. */
     @Deprecated
     public final Property<ChosenJavaVersion> runtime() {
         return getRuntime();

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -64,16 +64,16 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                     proj.getExtensions().getByType(BaselineJavaVersionExtension.class);
 
             Provider<ChosenJavaVersion> suggestedTarget = proj.provider(() -> isLibrary(proj, projectVersions)
-                    ? ChosenJavaVersion.of(rootExtension.libraryTarget().get())
-                    : rootExtension.distributionTarget().get());
+                    ? ChosenJavaVersion.of(rootExtension.getLibraryTarget().get())
+                    : rootExtension.getDistributionTarget().get());
 
             projectVersions.target().convention(suggestedTarget);
-            projectVersions.runtime().convention(rootExtension.runtime());
+            projectVersions.getRuntime().convention(rootExtension.getRuntime());
         }));
     }
 
     private static boolean isLibrary(Project project, BaselineJavaVersionExtension projectVersions) {
-        Property<Boolean> libraryOverride = projectVersions.overrideLibraryAutoDetection();
+        Property<Boolean> libraryOverride = projectVersions.getOverrideLibraryAutoDetection();
         if (libraryOverride.isPresent()) {
             log.debug(
                     "Project '{}' is considered a library because it has been overridden with library = true",

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionsExtension.java
@@ -105,6 +105,12 @@ public abstract class BaselineJavaVersionsExtension implements BaselineJavaVersi
         getDistributionTarget().set(ChosenJavaVersion.fromString(value));
     }
 
+    /** @deprecated Use {@link #getRuntime()} instead. */
+    @Deprecated
+    public final Property<ChosenJavaVersion> runtime() {
+        return getRuntime();
+    }
+
     @Override
     public final void setRuntime(int value) {
         getRuntime().set(ChosenJavaVersion.of(value));


### PR DESCRIPTION
## Before this PR
The `baseline-java-versions` extensions use the old "manually making properties" style of Gradle.

## After this PR
==COMMIT_MSG==
Move to abstract classes for baseline-java-versions extensions
==COMMIT_MSG==

...which is more modern Gradle, before I add to these.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

