### PR TITLE
Disable DistinctVarargsChecker

### DIFF
--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -133,6 +133,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "AutoCloseableMustBeClosed",
                 "CatchSpecificity",
                 "CanIgnoreReturnValueSuggester",
+                // https://github.com/google/error-prone/issues/4544
+                "DistinctVarargsChecker",
                 "InlineMeSuggester",
                 // We often use javadoc comments without javadoc parameter information.
                 "NotJavadoc",


### PR DESCRIPTION
FLUP from https://github.com/palantir/gradle-baseline/pull/2840.

The current implementation of this check is rather flawed, particularly after https://github.com/google/error-prone/pull/4449. See https://github.com/google/error-prone/issues/4544.