### PR TITLE
Simplify error-prone refactoring code

### DIFF
--- a/changelog/@unreleased/pr-2843.v2.yml
+++ b/changelog/@unreleased/pr-2843.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Simplify error-prone refactoring code
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2843


### PR DESCRIPTION
## Before this PR
Now we've upgraded to recent errorprone, there are some workarounds we had for bugs that are no longer necessary. Now that https://github.com/google/error-prone/issues/3908 is fixed (and [released in 2.26.0](https://github.com/google/error-prone/commit/9da2d5580e3939f97ef2e91278b330a56b5ed1fe)) we can avoid explicitly disabling checks when patching.

## After this PR
==COMMIT_MSG==
Simplify error-prone refactoring code
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

