### PR TITLE
Safety propagation avoids recursive analysis for pattern match variables

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -871,6 +871,9 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
                 // No safety information found, likely a captured reference used within a lambda or anonymous class.
                 safety = getCapturedLocalVariableSafety(node);
             }
+            ReadableUpdates updates = new ReadableUpdates();
+            updates.set(node, safety);
+            return updateRegularStore(safety, input, updates);
         }
         return noStoreChanges(safety, input);
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1067,6 +1067,39 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    @Timeout(2)
+    public void testSwitchExpressionPatternMatching() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  sealed interface Parent {}",
+                        "  record Child1() implements Parent {}",
+                        "  record Child2() implements Parent {}",
+                        "  record Child3() implements Parent {}",
+                        "  record Child4() implements Parent {}",
+                        "  record Child5() implements Parent {}",
+                        "  record Child6() implements Parent {}",
+                        "  record Child7() implements Parent {}",
+                        "  record Child8() implements Parent {}",
+                        "  void f(Parent parent) {",
+                        "    fun(switch (parent) {",
+                        "      case Child1 child1 -> child1;",
+                        "      case Child2 child2 -> child2;",
+                        "      case Child3 child3 -> child3;",
+                        "      case Child4 child4 -> child4;",
+                        "      case Child5 child5 -> child5;",
+                        "      case Child6 child6 -> child6;",
+                        "      case Child7 child7 -> child7;",
+                        "      case Child8 child8 -> child8;",
+                        "    });",
+                        "  }",
+                        "  private static void fun(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testPreconditionsPassthrough() {
         helper().addSourceLines(
                         "Test.java",

--- a/changelog/@unreleased/pr-2851.v2.yml
+++ b/changelog/@unreleased/pr-2851.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix slow compilation for large pattern matching switch
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2851


### PR DESCRIPTION
Fixes #2850 

```
  return switch (parent) {
      case Child1 child -> child.id();
      case Child2 child -> child.id();
  };
```
In a pattern matching switch, we never seem to add the pattern-matched variables (`child`) to the `AccessPathStore`. For example, for the pattern-matching instance of, we update the store [here](https://github.com/palantir/gradle-baseline/blob/bcd9d2ef8b93e873dfdb38bc9f01add92a9b259b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java#L1159). (It might be possible to update `visitSwitchExpressionNode` in a similar way, but I think that requires Java 17+ compiler APIs.)

This means that when we visit `child.id()`, we don't have a safety value for `child` and we enter [this code path](https://github.com/palantir/gradle-baseline/blob/bcd9d2ef8b93e873dfdb38bc9f01add92a9b259b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java#L872C26-L872C56),  triggering a recursive analysis.

## After this PR

In this PR, every time we need to lazily compute a safety value in `visitLocalVariable`, we also add it to the store so downstream nodes don't need to recompute it. The first time we visit `child`, it's in the pattern binding (`case Child1 child`) and we compute the safety quickly [here](https://github.com/palantir/gradle-baseline/blob/bcd9d2ef8b93e873dfdb38bc9f01add92a9b259b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java#L869). The subsequent times we visit `child` (`child.id()`), we now get the safety from the store instead of triggering a recursive analysis.

==COMMIT_MSG==
Fix slow compilation for large pattern matching switch
==COMMIT_MSG==

## Possible downsides?

It's probably weird to add a safety value to the store in `visitLocalVariable`, since semantically it should be added higher up (e.g. for instance of, it's correctly added in `visitInstanceOf`. But I think the entire `if (safety == null) { ... }` block in `visitLocalVariable` is intended to handle these weird cases where we didn't properly add a safety value to the store, so this change at least feels consistent.