### PR TITLE
Preserve "Can Resolve" Settings When Cloning Implementation

### DIFF
--- a/changelog/@unreleased/pr-2860.v2.yml
+++ b/changelog/@unreleased/pr-2860.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Preserve "Can Resolve" Settings When Cloning Implementation
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2860

--- a/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -150,7 +150,14 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         // We therefore want to look at only the dependencies _directly_ declared in the implementation and compile
         // configurations (belonging to our source set)
         project.afterEvaluate(p -> {
-            Configuration implCopy = implementation.get().copy();
+            Configuration implConfig = implementation.get();
+            Configuration implCopy = implConfig.copy();
+
+            // Preserves the configuration role behavior from Gradle 7, Gradle 8 fails to
+            // preserve these values when copying a configuration
+            implCopy.setCanBeResolved(implConfig.isCanBeResolved());
+            implCopy.setCanBeConsumed(implConfig.isCanBeConsumed());
+
             // Without these, explicitCompile will successfully resolve 0 files and you'll waste 1 hour trying
             // to figure out why.
             project.getConfigurations().add(implCopy);


### PR DESCRIPTION
## Before this PR
[Gradle 8 changed the behavior of copying a configuration to where it no longer preserves the resolvability](https://github.com/gradle/gradle/blob/v8.5.0/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java#L1251). This causes code that relies on this to possibly resolve a clone of an unresolvable configuration.

## After this PR
Simply carry-forward the resolvability.

## Possible downsides?
Its possible that we implicitly started relying on resolving `implementationCopy` directly, but I seriously doubt it given we aren't fully migrated to 

