### PR TITLE
disable PreferSafeLogger and StrictUnusedVariable for intellij plugin development

### DIFF
--- a/changelog/@unreleased/pr-2878.v2.yml
+++ b/changelog/@unreleased/pr-2878.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: disable PreferSafeLogger and StrictUnusedVariable  for intellij
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2878

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -114,6 +114,18 @@ public final class BaselineErrorProne implements Plugin<Project> {
                         errorProneOptions.disable("Slf4jLogsafeArgs");
                     }));
         });
+
+        project.getPluginManager().withPlugin("org.jetbrains.intellij", appliedPlugin -> {
+            project.getTasks().withType(JavaCompile.class).configureEach(javaCompile -> ((ExtensionAware)
+                            javaCompile.getOptions())
+                    .getExtensions()
+                    .configure(ErrorProneOptions.class, errorProneOptions -> {
+                        errorProneOptions.disable("PreferSafeLogger");
+                        errorProneOptions.disable("PreferSafeLoggableExceptions");
+                        errorProneOptions.disable("PreferSafeLoggingPreconditions");
+                        errorProneOptions.disable("StrictUnusedVariable");
+                    }));
+        });
     }
 
     @SuppressWarnings("UnstableApiUsage")


### PR DESCRIPTION
## Before this PR
Inellij plugins had to manually disable error prone options

## After this PR
Now error prone options are auto disabled for intellij plugins 


