### PR TITLE
Add `org.mockito.ArgumentMatchers.*` to `AvoidStaticImport` exclusions

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -77,7 +77,7 @@
         </module>
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
-            <property name="excludes" value="com.google.common.base.Preconditions.*, com.palantir.logsafe.Preconditions.*, java.util.Collections.*, java.util.stream.Collectors.*, org.apache.commons.lang3.Validate.*, org.assertj.core.api.Assertions.*, org.mockito.Mockito.*"/>
+            <property name="excludes" value="com.google.common.base.Preconditions.*, com.palantir.logsafe.Preconditions.*, java.util.Collections.*, java.util.stream.Collectors.*, org.apache.commons.lang3.Validate.*, org.assertj.core.api.Assertions.*, org.mockito.Mockito.*, org.mockito.ArgumentMatchers.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>


### PR DESCRIPTION
## Before this PR
- We did not permit `any()` or `eq(...)` static imports

## After this PR
- Add `org.mockito.ArgumentMatchers.*` to `AvoidStaticImport` exclusions
- Is in-line with the other suppressions here for Mockito and AssertJ

==COMMIT_MSG==
Add `org.mockito.ArgumentMatchers.*` to `AvoidStaticImport` exclusions
==COMMIT_MSG==


