### PR TITLE
Disable the `InjectOnConstructorOfAbstractClass` errorprone for gradle plugin projects

### DIFF
--- a/changelog/@unreleased/pr-2913.v2.yml
+++ b/changelog/@unreleased/pr-2913.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Disable the `InjectOnConstructorOfAbstractClass` errorprone for gradle
+    plugin projects
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2913

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -112,6 +112,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                         errorProneOptions.disable("PreferSafeLoggingPreconditions");
                         errorProneOptions.disable("Slf4jConstantLogMessage");
                         errorProneOptions.disable("Slf4jLogsafeArgs");
+                        errorProneOptions.disable("InjectOnConstructorOfAbstractClass");
                     }));
         });
 


### PR DESCRIPTION
## Before this PR
When writing a gradle plugin, if you want Gradle to instantiate your type for you, you would end up doing something like:

    getObjectFactory().newInstance(MyType.class);

If all the things you care about can be set as properties, you can do that and move forward with your life. Sometimes, you don't want something to be exposed as a property, you want it tied to the lifecycle of an instance of your type. You can then take in a constructor with whatever parameters you want. Here's how you would instantiate it:

    getObjectFactory().newInstance(MyType.class, arg1, arg2, arg3);

However, for this to work, you have to annotate your constructor with `@Inject`. This means things in different contexts, and there is an [errorprone rule](https://errorprone.info/bugpattern/InjectOnConstructorOfAbstractClass) for it:

> When dependency injection frameworks call constructors, they can only do so on constructors of concrete classes, which can delegate to superclass constructors. In the case of abstract classes, their constructors are only called by their concrete subclasses, not directly by injection frameworks, so the @Inject annotation has no effect.

That first statement is just not true for Gradle, so it's actually pretty safe to disable.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Disable the `InjectOnConstructorOfAbstractClass` errorprone for gradle plugin projects
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

