### PR TITLE
baseline-error-prone targets jdk-17+

### DIFF
--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 apply plugin: 'com.palantir.external-publish-jar'
 
 javaVersion {
-    target = 11
+    target = 17
     runtime = 21
 }
 

--- a/changelog/@unreleased/pr-2966.v2.yml
+++ b/changelog/@unreleased/pr-2966.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: baseline-error-prone targets jdk-17+
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2966


### PR DESCRIPTION
==COMMIT_MSG==
baseline-error-prone targets jdk-17+
==COMMIT_MSG==

Risk is that we lose errorprone support for projects targeting jdk11, where we use a jdk11 for compilation.
In those cases, failure modes range from silently ignoring error-prone to build failures. Given that we do not support jdk11 anymore, this is a reasonable risk.