### PR TITLE
Make DEFAULT_PATCH_CHECKS public

### DIFF
--- a/changelog/@unreleased/pr-2978.v2.yml
+++ b/changelog/@unreleased/pr-2978.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Make `BaselineErrorProne.DEFAULT_PATCH_CHECKS` public so other tools
+    can use it.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2978

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.extensions;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorProneExtension;
+import java.util.List;
 import org.gradle.api.provider.SetProperty;
 
 public abstract class BaselineErrorProneExtension {
@@ -26,7 +27,7 @@ public abstract class BaselineErrorProneExtension {
      * Do not add SUGGESTION checks here. Instead either increase the severity to WARNING or do not apply them by
      * default.
      */
-    public static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
+    public static final List<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
             "AssertNoArgs",
             "AvoidNewHashMapInt",

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -16,9 +16,8 @@
 
 package com.palantir.baseline.extensions;
 
-import com.google.common.collect.ImmutableList;
 import com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorProneExtension;
-import java.util.List;
+import java.util.Set;
 import org.gradle.api.provider.SetProperty;
 
 public abstract class BaselineErrorProneExtension {
@@ -27,7 +26,7 @@ public abstract class BaselineErrorProneExtension {
      * Do not add SUGGESTION checks here. Instead either increase the severity to WARNING or do not apply them by
      * default.
      */
-    public static final List<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
+    public static final Set<String> DEFAULT_PATCH_CHECKS = Set.of(
             // Baseline checks
             "AssertNoArgs",
             "AvoidNewHashMapInt",

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -26,7 +26,7 @@ public abstract class BaselineErrorProneExtension {
      * Do not add SUGGESTION checks here. Instead either increase the severity to WARNING or do not apply them by
      * default.
      */
-    private static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
+    public static final ImmutableList<String> DEFAULT_PATCH_CHECKS = ImmutableList.of(
             // Baseline checks
             "AssertNoArgs",
             "AvoidNewHashMapInt",
@@ -102,7 +102,7 @@ public abstract class BaselineErrorProneExtension {
      * @deprecated Interact with SuppressibleErrorProneExtension instead. This only provided for backcompat.
      */
     @Deprecated
-    public static final SetProperty<String> getPatchChecks() {
+    public final SetProperty<String> getPatchChecks() {
         return suppressibleErrorProneExtension.getPatchChecks();
     }
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -102,7 +102,7 @@ public abstract class BaselineErrorProneExtension {
      * @deprecated Interact with SuppressibleErrorProneExtension instead. This only provided for backcompat.
      */
     @Deprecated
-    public final SetProperty<String> getPatchChecks() {
+    public static final SetProperty<String> getPatchChecks() {
         return suppressibleErrorProneExtension.getPatchChecks();
     }
 


### PR DESCRIPTION
Makes DEFAULT_PATCH_CHECKS within `BaselineErrorProneExtension` public in order to access without needing to construct an instance.