### PR TITLE
Fix missing space in error message

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -182,7 +182,7 @@ public class CheckClassUniquenessLockTask extends DefaultTask {
             throw new ExceptionWithSuggestion(
                     "baseline-class-uniqueness detected multiple jars containing identically named classes."
                             + " Please resolve these problems, or run `./gradlew checkClassUniqueness --fix`"
-                            + "to accept them:\n\n " + expected,
+                            + " to accept them:\n\n " + expected,
                     "./gradlew checkClassUniqueness --fix");
         }
 


### PR DESCRIPTION
## Before this PR
Error message is missing a space:
```
baseline-class-uniqueness detected multiple jars containing identically named classes. Please resolve these problems, or run `./gradlew checkClassUniqueness --fix`to accept them:
```

## After this PR
==COMMIT_MSG==
Fix missing space in error message
==COMMIT_MSG==

## Possible downsides?
None known