### PR TITLE
failing testcases for safe-logging check when using Runnables/Suppliers/etc

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -2121,6 +2121,51 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testInterfaceDefaultMethodReturningRunnable() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "interface Test {",
+                        "  default Runnable f(@Unsafe Object value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    return () -> fun(value);",
+                        "  }",
+                        "  void fun(@Safe Object value);",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testStaticMethodReturningRunnable() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  static Runnable f(@Unsafe Object value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    return () -> fun(value);",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testStaticMethodContainingRunnable() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  static void f(@Unsafe Object value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    Runnable ignored = () -> fun(value);",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

I tried to see if I could fix this myself, but I lack the knowledge of this meta-java stuff. I did see in debugger that at [this line](https://github.com/palantir/gradle-baseline/blob/2270796a5160f4a1b61d8b3690a323fdb3cfe8ec/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java#L168), the `parameterSafety` is correctly `SAFE`, and the `argument` is an `@Unsafe Object value`, but then the SafetyAnalysis returns as `UNKNOWN` leading to the check below passing. But not sure if this is even the correct place to catch it, or if it should rather be caught somewhere else.

Also my `//` asserts in the test cases might be wrong, but if you remove them, the tests will pass with no errors - which they shouldn't, I think.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

