### PR TITLE
safe-logging analysis correctly handles out-of-scope parameter references

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -870,14 +870,16 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
             // 4. Pattern matching (input instanceof String str)
 
             // Cast a wide net for all throwables (covers catch statements)
+            Safety treeSafety = SafetyAnnotations.getSafety(node.getTree(), state);
             if (THROWABLE_SUBTYPE.matches(node.getTree(), state)) {
-                safety = Safety.UNSAFE.leastUpperBound(SafetyAnnotations.getSafety(node.getTree(), state));
-            } else if (isElementKind(node, ElementKind.PARAMETER)
-                    || isElementKind(node, ElementKind.BINDING_VARIABLE)) {
-                safety = SafetyAnnotations.getSafety(node.getTree(), state);
-            } else {
+                safety = Safety.UNSAFE.leastUpperBound(treeSafety);
+            } else if (isElementKind(node, ElementKind.LOCAL_VARIABLE) && treeSafety == Safety.UNKNOWN) {
                 // No safety information found, likely a captured reference used within a lambda or anonymous class.
+                // If safety can be computed based on the symbol, use that, otherwise evaluate flow which is much
+                // more expensive.
                 safety = getCapturedLocalVariableSafety(node);
+            } else {
+                safety = treeSafety;
             }
             ReadableUpdates updates = new ReadableUpdates();
             updates.set(node, safety);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -71,6 +71,7 @@ import java.util.stream.BaseStream;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.errorprone.dataflow.analysis.Analysis;
@@ -871,7 +872,8 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
             // Cast a wide net for all throwables (covers catch statements)
             if (THROWABLE_SUBTYPE.matches(node.getTree(), state)) {
                 safety = Safety.UNSAFE.leastUpperBound(SafetyAnnotations.getSafety(node.getTree(), state));
-            } else if (isPatternBinding(node, state)) {
+            } else if (isElementKind(node, ElementKind.PARAMETER)
+                    || isElementKind(node, ElementKind.BINDING_VARIABLE)) {
                 safety = SafetyAnnotations.getSafety(node.getTree(), state);
             } else {
                 // No safety information found, likely a captured reference used within a lambda or anonymous class.
@@ -884,24 +886,9 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
         return noStoreChanges(safety, input);
     }
 
-    private static boolean isPatternBinding(LocalVariableNode node, VisitorState state) {
-        TreePath varPath = TreePath.getPath(state.getPath().getCompilationUnit(), node.getTree());
-        if (varPath == null) {
-            // Synthetic expression
-            return false;
-        }
-        TreePath parentPath = varPath.getParentPath();
-        if (parentPath == null) {
-            return false;
-        }
-        Tree enclosing = parentPath.getLeaf();
-        if (enclosing == null) {
-            return false;
-        }
-        // JCBindingPattern is newer than our compilation target, so we match strings to avoid
-        // complex build-system configurations.
-        String kindString = enclosing.getKind().name();
-        return "BINDING_PATTERN".equals(kindString);
+    private static boolean isElementKind(LocalVariableNode node, ElementKind elementKind) {
+        Symbol symbol = ASTHelpers.getSymbol(node.getTree());
+        return symbol != null && symbol.getKind() == elementKind;
     }
 
     private Safety getCapturedLocalVariableSafety(LocalVariableNode node) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -2121,6 +2121,51 @@ class IllegalSafeLoggingArgumentTest {
                 .doTest();
     }
 
+    @Test
+    public void testInterfaceDefaultMethodReturningRunnable() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "interface Test {",
+                        "  default Runnable f(@Unsafe Object value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    return () -> fun(value);",
+                        "  }",
+                        "  void fun(@Safe Object value);",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testStaticMethodReturningRunnable() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  static Runnable f(@Unsafe Object value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    return () -> fun(value);",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testStaticMethodContainingRunnable() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  static void f(@Unsafe Object value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "    Runnable ignored = () -> fun(value);",
+                        "  }",
+                        "  private static void fun(@Safe Object value) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -2122,21 +2122,6 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
-    public void testInterfaceDefaultMethodReturningRunnable() {
-        helper().addSourceLines(
-                        "Test.java",
-                        "import com.palantir.logsafe.*;",
-                        "interface Test {",
-                        "  default Runnable f(@Unsafe Object value) {",
-                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
-                        "    return () -> fun(value);",
-                        "  }",
-                        "  void fun(@Safe Object value);",
-                        "}")
-                .doTest();
-    }
-
-    @Test
     public void testStaticMethodReturningRunnable() {
         helper().addSourceLines(
                         "Test.java",
@@ -2145,21 +2130,6 @@ class IllegalSafeLoggingArgumentTest {
                         "  static Runnable f(@Unsafe Object value) {",
                         "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
                         "    return () -> fun(value);",
-                        "  }",
-                        "  private static void fun(@Safe Object value) {}",
-                        "}")
-                .doTest();
-    }
-
-    @Test
-    public void testStaticMethodContainingRunnable() {
-        helper().addSourceLines(
-                        "Test.java",
-                        "import com.palantir.logsafe.*;",
-                        "class Test {",
-                        "  static void f(@Unsafe Object value) {",
-                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
-                        "    Runnable ignored = () -> fun(value);",
                         "  }",
                         "  private static void fun(@Safe Object value) {}",
                         "}")

--- a/changelog/@unreleased/pr-2988.v2.yml
+++ b/changelog/@unreleased/pr-2988.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: safe-logging analysis correctly handles out-of-scope parameter references
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2988


### PR DESCRIPTION
Reported in #2984

==COMMIT_MSG==
safe-logging analysis correctly handles out-of-scope parameter references
==COMMIT_MSG==

Note that this has also been updated to improve the `isPatternBinding` check using java 17 target compatibility now that we've upgraded.
This should dramatically improve performance in areas which reference parameters in lambdas as well, as we can avoid an additional set of compilations :-)