### PR TITLE
Test case: missed @DoNotLog enforcement

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1746,6 +1746,26 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testRecordStaticConstructor() {
+        helper().setArgs("--release", "17")
+                .addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  record MyRecord(@Unsafe String value) {",
+                        "    public static MyRecord of(String value) {",
+                        "      return new MyRecord(value);",
+                        "    }",
+                        "  }",
+                        "  void f(@DoNotLog String value) {",
+                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'DO_NOT_LOG'",
+                        "    MyRecord.of(value);",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testRecordComponentUsage() {
         helper().setArgs("--release", "17")
                 .addSourceLines(


### PR DESCRIPTION
This test case allows me to pass a `@DoNotLog String` into a `record MyRecord(@Unsafe String value)`, by using a static constructor that has no log safety annotations on it.

Shouldn't this be failing for some reason?  I kind of expect to be forced to add `@DoNotLog` to the `value` parameter of `public static MyRecord of(String value)`