### PR TITLE
Test case: missed BUG for captured lambda parameter type's safety annotation

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1528,6 +1528,25 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testSafeArgOfUnsafeAnnotatedClassAs_noRecommendation() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import com.palantir.logsafe.exceptions.*;",
+                        "import java.util.*;",
+                        "class Test {",
+                        "  @Unsafe static class UnsafeClass {}",
+                        "  void f(UnsafeClass unsafeParam) {",
+                        "    Optional.empty().orElseThrow(() -> ",
+                        "        // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+                        "        new SafeIllegalArgumentException(\"message\", SafeArg.of(\"unsafe\", unsafeParam)));",
+//                        "        new SafeIllegalArgumentException(\"message\", SafeArg.of(\"unsafe\", new UnsafeClass())));",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testUnsafeArgumentForSafeParameter_noRecommendation() {
         refactoringHelper()
                 .addInputLines(


### PR DESCRIPTION
I would expect the test to pass as written. I can get it to pass by swapping to the commented-out line, which has `new UnsafeClass()` directly instead of as a parameter.