### PR TITLE
`Stream.mapMulti(Optional::ifPresent)` is more efficient than `Stream.flatMap(Optional::stream)`

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -35,6 +35,7 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
 import java.io.Serial;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -124,17 +125,11 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
 
         SuggestedFix.Builder fix = SuggestedFix.builder();
 
-        long receiverCount = args(ASTHelpers.getReceiverType(receiver)).count();
-        Stream<Type> args = args(ASTHelpers.getReceiverType(expressionTree));
-        long argCount = args.count();
-        boolean shouldQualifyType =
-                args(elementType).findAny().isPresent() || receiverCount > 1 || (receiverCount == 0 && argCount > 0);
-
         String qualifiedType = "";
-        if (shouldQualifyType) {
+        if (needsQualification(receiver, expressionTree, elementType)) {
             qualifiedType = qualifyType(state, fix, receiverType.getTypeArguments());
             if (qualifiedType.isEmpty()) {
-                qualifiedType = SuggestedFixes.qualifyType(state, fix, elementType);
+                qualifiedType = qualifyType(state, fix, Collections.singleton(elementType));
             }
         }
 
@@ -146,8 +141,19 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
                 .build();
     }
 
+    private static boolean needsQualification(
+            ExpressionTree receiver, ExpressionTree expressionTree, Type elementType) {
+        long receiverCount = args(ASTHelpers.getReceiverType(receiver)).count();
+        long treeArgCount = args(ASTHelpers.getReceiverType(expressionTree)).count();
+        return args(elementType).findAny().isPresent() || receiverCount > 1 || (receiverCount == 0 && treeArgCount > 0);
+    }
+
     private static String qualifyType(
             VisitorState state, SuggestedFix.Builder fix, Collection<Type> receiverTypeArguments) {
+        if (receiverTypeArguments.isEmpty()
+                || args(receiverTypeArguments).findAny().isEmpty()) {
+            return "";
+        }
         return args(receiverTypeArguments)
                 .map(type -> SuggestedFixes.qualifyType(state, fix, type))
                 .collect(Collectors.joining(", ", "<", ">"));
@@ -157,7 +163,7 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
         return args(type.getTypeArguments());
     }
 
-    private static Stream<Type> args(Collection<Type> types) {
-        return types.stream().flatMap(type -> type.getTypeArguments().stream());
+    static Stream<Type> args(Collection<Type> types) {
+        return types.stream().flatMap(t -> t.getTypeArguments().stream());
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.jspecify.annotations.Nullable;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -92,27 +91,22 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (STREAM_FLATMAP_OPTIONAL_STREAM.matches(tree, state)) {
-            ExpressionTree receiver = ASTHelpers.getReceiver(tree);
-            return fix(tree, state, receiver, receiver);
+            return fix(tree, state, tree);
         }
 
         if (STREAM_MAP_GET.matches(tree, state)) {
             ExpressionTree mapTree = ASTHelpers.getReceiver(tree);
             if (mapTree != null && STREAM_FILTER_IS_PRESENT.matches(mapTree, state)) {
-                ExpressionTree filterTree = ASTHelpers.getReceiver(mapTree);
-                return fix(tree, state, tree.getMethodSelect(), filterTree);
+                return fix(tree, state, mapTree);
             }
         }
 
         return Description.NO_MATCH;
     }
 
-    private Description fix(
-            MethodInvocationTree tree,
-            VisitorState state,
-            @Nullable ExpressionTree receiver,
-            @Nullable ExpressionTree expressionTree) {
-        if (receiver == null || expressionTree == null) {
+    private Description fix(MethodInvocationTree tree, VisitorState state, ExpressionTree expressionTree) {
+        ExpressionTree receiver = ASTHelpers.getReceiver(expressionTree);
+        if (receiver == null) {
             return Description.NO_MATCH;
         }
 
@@ -121,16 +115,10 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
             return Description.NO_MATCH;
         }
 
-        Type receiverType = ASTHelpers.getType(receiver);
-        if (receiverType == null) {
-            return Description.NO_MATCH;
-        }
-
         // try to elide the type arguments for mapMulti if it compiles, otherwise fallback on including qualified types
-        SuggestedFix fix = Optional.of(getSuggestedFix(SuggestedFix.builder(), tree, state, expressionTree, ""))
+        SuggestedFix fix = Optional.of(getSuggestedFix(SuggestedFix.builder(), tree, state, receiver, ""))
                 .filter(f -> SuggestedFixes.compilesWithFix(f, state))
-                .orElseGet(
-                        () -> getQualifiedSuggestedFix(tree, state, expressionTree, receiverType.getTypeArguments()));
+                .orElseGet(() -> getQualifiedSuggestedFix(tree, state, receiver, List.of(elementType)));
         return buildDescription(tree).addFix(fix).build();
     }
 
@@ -138,18 +126,18 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
             SuggestedFix.Builder fix,
             MethodInvocationTree tree,
             VisitorState state,
-            ExpressionTree expressionTree,
+            ExpressionTree receiver,
             String maybeQualifiedElementType) {
         String replacement = "." + maybeQualifiedElementType + "mapMulti("
                 + SuggestedFixes.qualifyType(state, fix, Optional.class.getCanonicalName()) + "::ifPresent)";
-        return fix.replace(state.getEndPosition(expressionTree), state.getEndPosition(tree), replacement)
+        return fix.replace(state.getEndPosition(receiver), state.getEndPosition(tree), replacement)
                 .build();
     }
 
     private static SuggestedFix getQualifiedSuggestedFix(
-            MethodInvocationTree tree, VisitorState state, ExpressionTree expressionTree, List<Type> args) {
+            MethodInvocationTree tree, VisitorState state, ExpressionTree receiver, List<Type> args) {
         SuggestedFix.Builder fix = SuggestedFix.builder();
-        return getSuggestedFix(fix, tree, state, expressionTree, qualifyType(state, fix, args));
+        return getSuggestedFix(fix, tree, state, receiver, qualifyType(state, fix, args));
     }
 
     private static String qualifyType(

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
@@ -93,13 +92,12 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (STREAM_FLATMAP_OPTIONAL_STREAM.matches(tree, state)) {
-            ExpressionTree methodSelect = tree.getMethodSelect();
-            ExpressionTree receiver = ASTHelpers.getReceiver(methodSelect);
+            ExpressionTree receiver = ASTHelpers.getReceiver(tree);
             return fix(tree, state, receiver, receiver);
         }
 
         if (STREAM_MAP_GET.matches(tree, state)) {
-            ExpressionTree mapTree = ASTHelpers.getReceiver(tree.getMethodSelect());
+            ExpressionTree mapTree = ASTHelpers.getReceiver(tree);
             if (mapTree != null && STREAM_FILTER_IS_PRESENT.matches(mapTree, state)) {
                 ExpressionTree filterTree = ASTHelpers.getReceiver(mapTree);
                 return fix(tree, state, tree.getMethodSelect(), filterTree);
@@ -128,19 +126,12 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
             return Description.NO_MATCH;
         }
 
-        return Stream.<Supplier<SuggestedFix>>of(
-                        () -> getSuggestedFix(SuggestedFix.builder(), tree, state, expressionTree, ""),
-                        () -> getQualifiedSuggestedFix(tree, state, expressionTree, receiverType.getTypeArguments()),
-                        () -> getQualifiedSuggestedFix(tree, state, expressionTree, List.of(elementType)))
-                .<SuggestedFix>mapMulti((f, consumer) -> {
-                    SuggestedFix fix = f.get();
-                    if (SuggestedFixes.compilesWithFix(fix, state)) {
-                        consumer.accept(fix);
-                    }
-                })
-                .findFirst()
-                .map(fix -> buildDescription(tree).addFix(fix).build())
-                .orElse(Description.NO_MATCH);
+        // try to elide the type arguments for mapMulti if it compiles, otherwise fallback on including qualified types
+        SuggestedFix fix = Optional.of(getSuggestedFix(SuggestedFix.builder(), tree, state, expressionTree, ""))
+                .filter(f -> SuggestedFixes.compilesWithFix(f, state))
+                .orElseGet(
+                        () -> getQualifiedSuggestedFix(tree, state, expressionTree, receiverType.getTypeArguments()));
+        return buildDescription(tree).addFix(fix).build();
     }
 
     private static SuggestedFix getSuggestedFix(

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -35,11 +35,11 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
 import java.io.Serial;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
@@ -128,10 +128,16 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
             return Description.NO_MATCH;
         }
 
-        return Stream.of(
-                        getSuggestedFix(SuggestedFix.builder(), tree, state, expressionTree, ""),
-                        getQualifiedSuggestedFix(tree, state, expressionTree, receiverType, elementType))
-                .filter(fix -> SuggestedFixes.compilesWithFix(fix, state))
+        return Stream.<Supplier<SuggestedFix>>of(
+                        () -> getSuggestedFix(SuggestedFix.builder(), tree, state, expressionTree, ""),
+                        () -> getQualifiedSuggestedFix(tree, state, expressionTree, receiverType.getTypeArguments()),
+                        () -> getQualifiedSuggestedFix(tree, state, expressionTree, List.of(elementType)))
+                .<SuggestedFix>mapMulti((f, consumer) -> {
+                    SuggestedFix fix = f.get();
+                    if (SuggestedFixes.compilesWithFix(fix, state)) {
+                        consumer.accept(fix);
+                    }
+                })
                 .findFirst()
                 .map(fix -> buildDescription(tree).addFix(fix).build())
                 .orElse(Description.NO_MATCH);
@@ -150,17 +156,9 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
     }
 
     private static SuggestedFix getQualifiedSuggestedFix(
-            MethodInvocationTree tree,
-            VisitorState state,
-            ExpressionTree expressionTree,
-            Type receiverType,
-            Type elementType) {
+            MethodInvocationTree tree, VisitorState state, ExpressionTree expressionTree, List<Type> args) {
         SuggestedFix.Builder fix = SuggestedFix.builder();
-        String qualifiedType = qualifyType(state, fix, receiverType.getTypeArguments());
-        if (qualifiedType.isEmpty()) {
-            qualifiedType = qualifyType(state, fix, Collections.singleton(elementType));
-        }
-        return getSuggestedFix(fix, tree, state, expressionTree, qualifiedType);
+        return getSuggestedFix(fix, tree, state, expressionTree, qualifyType(state, fix, args));
     }
 
     private static String qualifyType(

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = BugPattern.SeverityLevel.WARNING,
-        summary = "`Stream.filter(Optional::isPresent).map(Optional::get)` is more efficient than "
+        summary = "`Stream.filter(Optional::isPresent).map(Optional::orElseThrow)` is more efficient than "
                 + "`Stream.flatMap(Optional::stream)`")
 public final class StreamFlatMapOptional extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
     private static final long serialVersionUID = 1L;
@@ -67,7 +67,7 @@ public final class StreamFlatMapOptional extends BugChecker implements BugChecke
             if (receiver != null) {
                 SuggestedFix.Builder fix = SuggestedFix.builder();
                 String optionalType = SuggestedFixes.qualifyType(state, fix, Optional.class.getCanonicalName());
-                String replacement = ".filter(" + optionalType + "::isPresent).map(" + optionalType + "::get)";
+                String replacement = ".filter(" + optionalType + "::isPresent).map(" + optionalType + "::orElseThrow)";
                 return buildDescription(tree)
                         .addFix(fix.replace(state.getEndPosition(receiver), state.getEndPosition(tree), replacement)
                                 .build())

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -36,6 +36,7 @@ import com.sun.tools.javac.code.Type;
 import java.io.Serial;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -127,52 +128,52 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
             return Description.NO_MATCH;
         }
 
-        SuggestedFix.Builder fix = SuggestedFix.builder();
+        return Stream.of(
+                        getSuggestedFix(SuggestedFix.builder(), tree, state, expressionTree, ""),
+                        getQualifiedSuggestedFix(tree, state, expressionTree, receiverType, elementType))
+                .filter(fix -> SuggestedFixes.compilesWithFix(fix, state))
+                .findFirst()
+                .map(fix -> buildDescription(tree).addFix(fix).build())
+                .orElse(Description.NO_MATCH);
+    }
 
-        String qualifiedType = "";
-        if (needsQualification(receiver, expressionTree, elementType)) {
-            qualifiedType = qualifyType(state, fix, receiverType.getTypeArguments());
-            if (qualifiedType.isEmpty()) {
-                qualifiedType = qualifyType(state, fix, Collections.singleton(elementType));
-            }
-        }
-
-        String replacement = "." + qualifiedType + "mapMulti("
+    private static SuggestedFix getSuggestedFix(
+            SuggestedFix.Builder fix,
+            MethodInvocationTree tree,
+            VisitorState state,
+            ExpressionTree expressionTree,
+            String maybeQualifiedElementType) {
+        String replacement = "." + maybeQualifiedElementType + "mapMulti("
                 + SuggestedFixes.qualifyType(state, fix, Optional.class.getCanonicalName()) + "::ifPresent)";
-        return buildDescription(tree)
-                .addFix(fix.replace(state.getEndPosition(expressionTree), state.getEndPosition(tree), replacement)
-                        .build())
+        return fix.replace(state.getEndPosition(expressionTree), state.getEndPosition(tree), replacement)
                 .build();
     }
 
-    private static boolean needsQualification(
-            ExpressionTree receiver, ExpressionTree expressionTree, Type elementType) {
-        long receiverArgCount = args(ASTHelpers.getReceiverType(receiver)).count();
-        return args(elementType).findAny().isPresent()
-                || receiverArgCount > 1
-                || (receiverArgCount == 0
-                        && args(ASTHelpers.getReceiverType(expressionTree))
-                                .findAny()
-                                .isPresent())
-                || (receiverArgCount == 0 && !elementType.getTypeArguments().isEmpty());
+    private static SuggestedFix getQualifiedSuggestedFix(
+            MethodInvocationTree tree,
+            VisitorState state,
+            ExpressionTree expressionTree,
+            Type receiverType,
+            Type elementType) {
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        String qualifiedType = qualifyType(state, fix, receiverType.getTypeArguments());
+        if (qualifiedType.isEmpty()) {
+            qualifiedType = qualifyType(state, fix, Collections.singleton(elementType));
+        }
+        return getSuggestedFix(fix, tree, state, expressionTree, qualifiedType);
     }
 
     private static String qualifyType(
             VisitorState state, SuggestedFix.Builder fix, Collection<Type> receiverTypeArguments) {
-        if (receiverTypeArguments.isEmpty()
-                || args(receiverTypeArguments).findAny().isEmpty()) {
+        if (receiverTypeArguments.isEmpty() || args(receiverTypeArguments).isEmpty()) {
             return "";
         }
-        return args(receiverTypeArguments)
+        return args(receiverTypeArguments).stream()
                 .map(type -> SuggestedFixes.qualifyType(state, fix, type))
                 .collect(Collectors.joining(", ", "<", ">"));
     }
 
-    private static Stream<Type> args(Type type) {
-        return args(type.getTypeArguments());
-    }
-
-    static Stream<Type> args(Collection<Type> types) {
-        return types.stream().flatMap(t -> t.getTypeArguments().stream());
+    static List<Type> args(Collection<Type> types) {
+        return types.stream().flatMap(t -> t.getTypeArguments().stream()).toList();
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -108,8 +109,11 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
     }
 
     private Description fix(
-            MethodInvocationTree tree, VisitorState state, ExpressionTree receiver, ExpressionTree expressionTree) {
-        if (receiver == null) {
+            MethodInvocationTree tree,
+            VisitorState state,
+            @Nullable ExpressionTree receiver,
+            @Nullable ExpressionTree expressionTree) {
+        if (receiver == null || expressionTree == null) {
             return Description.NO_MATCH;
         }
 
@@ -143,9 +147,14 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
 
     private static boolean needsQualification(
             ExpressionTree receiver, ExpressionTree expressionTree, Type elementType) {
-        long receiverCount = args(ASTHelpers.getReceiverType(receiver)).count();
+        long receiverArgCount = args(ASTHelpers.getReceiverType(receiver)).count();
         long treeArgCount = args(ASTHelpers.getReceiverType(expressionTree)).count();
-        return args(elementType).findAny().isPresent() || receiverCount > 1 || (receiverCount == 0 && treeArgCount > 0);
+        int elementArgCount = elementType.getTypeArguments().size();
+        boolean q1 = args(elementType).findAny().isPresent();
+        boolean q2 = receiverArgCount > 1;
+        boolean q3 = receiverArgCount == 0 && treeArgCount > 0;
+        boolean q4 = receiverArgCount == 0 && elementArgCount > 0;
+        return q1 || q2 || q3 || q4;
     }
 
     private static String qualifyType(

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -18,8 +18,10 @@ package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.ChildMultiMatcher.MatchType;
@@ -30,50 +32,132 @@ import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Type;
+import java.io.Serial;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @AutoService(BugChecker.class)
 @BugPattern(
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = BugPattern.SeverityLevel.WARNING,
-        summary = "`Stream.filter(Optional::isPresent).map(Optional::orElseThrow)` is more efficient than "
-                + "`Stream.flatMap(Optional::stream)`")
-public final class StreamFlatMapOptional extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+        severity = SeverityLevel.SUGGESTION,
+        summary = "`Stream.mapMulti(Optional::ifPresent)` is more efficient than `Stream.flatMap(Optional::stream)`")
+public final class StreamFlatMapOptional extends BugChecker implements MethodInvocationTreeMatcher {
+    @Serial
     private static final long serialVersionUID = 1L;
 
-    private static final Matcher<ExpressionTree> STREAM_FLAT_MAP = MethodMatchers.instanceMethod()
-            .onDescendantOf(Stream.class.getName())
-            .namedAnyOf("flatMap")
-            .withParameters(Function.class.getName());
-
-    private static final Matcher<ExpressionTree> OPTIONAL_STREAM = MethodMatchers.instanceMethod()
-            .onDescendantOf(Optional.class.getName())
-            .named("stream")
-            .withNoParameters();
-
     private static final Matcher<ExpressionTree> STREAM_FLATMAP_OPTIONAL_STREAM = Matchers.methodInvocation(
-            STREAM_FLAT_MAP,
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(Stream.class.getCanonicalName())
+                    .namedAnyOf("flatMap")
+                    .withParameters(Function.class.getName()),
             // Any of the three MatchTypes are reasonable in this case, given a single arg
-            MatchType.LAST,
-            OPTIONAL_STREAM);
+            MatchType.AT_LEAST_ONE,
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(Optional.class.getCanonicalName())
+                    .named("stream")
+                    .withNoParameters());
+
+    private static final Matcher<ExpressionTree> STREAM_FILTER_IS_PRESENT = Matchers.methodInvocation(
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(Stream.class.getCanonicalName())
+                    .named("filter")
+                    .withParameters(Predicate.class.getName()),
+            // Any of the three MatchTypes are reasonable in this case, given a single arg
+            MatchType.AT_LEAST_ONE,
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(Optional.class.getCanonicalName())
+                    .named("isPresent")
+                    .withNoParameters());
+
+    private static final Matcher<ExpressionTree> STREAM_MAP_GET = Matchers.methodInvocation(
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(Stream.class.getCanonicalName())
+                    .named("map")
+                    .withParameters(Function.class.getName()),
+            // Any of the three MatchTypes are reasonable in this case, given a single arg
+            MatchType.AT_LEAST_ONE,
+            MethodMatchers.instanceMethod()
+                    .onDescendantOf(Optional.class.getCanonicalName())
+                    .namedAnyOf("get", "orElseThrow")
+                    .withNoParameters());
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (STREAM_FLATMAP_OPTIONAL_STREAM.matches(tree, state)) {
-            ExpressionTree receiver = ASTHelpers.getReceiver(tree.getMethodSelect());
-            if (receiver != null) {
-                SuggestedFix.Builder fix = SuggestedFix.builder();
-                String optionalType = SuggestedFixes.qualifyType(state, fix, Optional.class.getCanonicalName());
-                String replacement = ".filter(" + optionalType + "::isPresent).map(" + optionalType + "::orElseThrow)";
-                return buildDescription(tree)
-                        .addFix(fix.replace(state.getEndPosition(receiver), state.getEndPosition(tree), replacement)
-                                .build())
-                        .build();
+            ExpressionTree methodSelect = tree.getMethodSelect();
+            ExpressionTree receiver = ASTHelpers.getReceiver(methodSelect);
+            return fix(tree, state, receiver, receiver);
+        }
+
+        if (STREAM_MAP_GET.matches(tree, state)) {
+            ExpressionTree mapTree = ASTHelpers.getReceiver(tree.getMethodSelect());
+            if (mapTree != null && STREAM_FILTER_IS_PRESENT.matches(mapTree, state)) {
+                ExpressionTree filterTree = ASTHelpers.getReceiver(mapTree);
+                return fix(tree, state, tree.getMethodSelect(), filterTree);
             }
         }
+
         return Description.NO_MATCH;
+    }
+
+    private Description fix(
+            MethodInvocationTree tree, VisitorState state, ExpressionTree receiver, ExpressionTree expressionTree) {
+        if (receiver == null) {
+            return Description.NO_MATCH;
+        }
+
+        Type elementType = ASTHelpers.getType(tree);
+        if (elementType == null) {
+            return Description.NO_MATCH;
+        }
+
+        Type receiverType = ASTHelpers.getType(receiver);
+        if (receiverType == null) {
+            return Description.NO_MATCH;
+        }
+
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+
+        long receiverCount = args(ASTHelpers.getReceiverType(receiver)).count();
+        Stream<Type> args = args(ASTHelpers.getReceiverType(expressionTree));
+        long argCount = args.count();
+        boolean shouldQualifyType =
+                args(elementType).findAny().isPresent() || receiverCount > 1 || (receiverCount == 0 && argCount > 0);
+
+        String qualifiedType = "";
+        if (shouldQualifyType) {
+            qualifiedType = qualifyType(state, fix, receiverType.getTypeArguments());
+            if (qualifiedType.isEmpty()) {
+                qualifiedType = SuggestedFixes.qualifyType(state, fix, elementType);
+            }
+        }
+
+        String replacement = "." + qualifiedType + "mapMulti("
+                + SuggestedFixes.qualifyType(state, fix, Optional.class.getCanonicalName()) + "::ifPresent)";
+        return buildDescription(tree)
+                .addFix(fix.replace(state.getEndPosition(expressionTree), state.getEndPosition(tree), replacement)
+                        .build())
+                .build();
+    }
+
+    private static String qualifyType(
+            VisitorState state, SuggestedFix.Builder fix, Collection<Type> receiverTypeArguments) {
+        return args(receiverTypeArguments)
+                .map(type -> SuggestedFixes.qualifyType(state, fix, type))
+                .collect(Collectors.joining(", ", "<", ">"));
+    }
+
+    private static Stream<Type> args(Type type) {
+        return args(type.getTypeArguments());
+    }
+
+    private static Stream<Type> args(Collection<Type> types) {
+        return types.stream().flatMap(type -> type.getTypeArguments().stream());
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -148,13 +148,13 @@ public final class StreamFlatMapOptional extends BugChecker implements MethodInv
     private static boolean needsQualification(
             ExpressionTree receiver, ExpressionTree expressionTree, Type elementType) {
         long receiverArgCount = args(ASTHelpers.getReceiverType(receiver)).count();
-        long treeArgCount = args(ASTHelpers.getReceiverType(expressionTree)).count();
-        int elementArgCount = elementType.getTypeArguments().size();
-        boolean q1 = args(elementType).findAny().isPresent();
-        boolean q2 = receiverArgCount > 1;
-        boolean q3 = receiverArgCount == 0 && treeArgCount > 0;
-        boolean q4 = receiverArgCount == 0 && elementArgCount > 0;
-        return q1 || q2 || q3 || q4;
+        return args(elementType).findAny().isPresent()
+                || receiverArgCount > 1
+                || (receiverArgCount == 0
+                        && args(ASTHelpers.getReceiverType(expressionTree))
+                                .findAny()
+                                .isPresent())
+                || (receiverArgCount == 0 && !elementType.getTypeArguments().isEmpty());
     }
 
     private static String qualifyType(

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StreamFlatMapOptional.java
@@ -47,7 +47,7 @@ import org.jspecify.annotations.Nullable;
 @BugPattern(
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = SeverityLevel.SUGGESTION,
+        severity = SeverityLevel.WARNING,
         summary = "`Stream.mapMulti(Optional::ifPresent)` is more efficient than `Stream.flatMap(Optional::stream)`")
 public final class StreamFlatMapOptional extends BugChecker implements MethodInvocationTreeMatcher {
     @Serial

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
@@ -19,48 +19,99 @@ package com.palantir.baseline.errorprone;
 import org.junit.jupiter.api.Test;
 
 class StreamFlatmapOptionalTest {
+
     @Test
     public void test() {
         fix().addInputLines(
                         "Test.java",
                         "import java.util.Collection;",
+                        "import java.util.Map;",
                         "import java.util.Optional;",
                         "import java.util.stream.Stream;",
                         "public class Test {",
-                        "  Stream<String> f1(Stream<Collection<Optional<String>>> in) {",
+                        "  Stream<String> filter_empty(Stream<Optional<String>> in) {",
+                        "    return in.filter(Optional::isEmpty).map(o -> o.orElse(\"\"));",
+                        "  }",
+                        "  Stream<String> flatMap_simple(Stream<Optional<String>> in) {",
+                        "    return in.flatMap(Optional::stream);",
+                        "  }",
+                        "  Stream<String> filter_map_get(Stream<Optional<String>> in) {",
+                        "    return in.filter(Optional::isPresent).map(Optional::get);",
+                        "  }",
+                        "  Stream<Integer> filter_map_length(Stream<Optional<String>> in) {",
+                        "    return in.filter(Optional::isPresent).map(o -> o.get().length());",
+                        "  }",
+                        "  Stream<String> filter_orElseThrow(Stream<Optional<String>> in) {",
+                        "    return in.filter(Optional::isPresent).map(Optional::orElseThrow);",
+                        "  }",
+                        "  Stream<String> flatMap_collection(Stream<Collection<Optional<String>>> in) {",
                         "    return in.flatMap(Collection::stream).flatMap(Optional::stream);",
                         "  }",
-                        "  Stream<String> f2(Stream<Collection<Optional<String>>> in) {",
+                        "  Stream<String> flatMap_lambda_collection(Stream<Collection<Optional<String>>> in) {",
                         "    return in.flatMap(list -> list.stream().flatMap(Optional::stream));",
                         "  }",
-                        "  Stream<String> f3(Stream<Collection<Optional<String>>> in) {",
-                        "    return in.flatMap(list -> list.stream()).flatMap(Optional::stream);",
+                        "  Stream<String> flatMap_lambda_optional_collection("
+                                + "Stream<Optional<Collection<Optional<String>>>> in) {",
+                        "    return in.flatMap(o -> o.stream().flatMap(Collection::stream).flatMap(Optional::stream));",
                         "  }",
-                        "  Stream<String> f4(Stream<Optional<Optional<String>>> in) {",
-                        "      return in.flatMap(Optional::stream).flatMap(Optional::stream);",
+                        "  Stream<String> flatMap_simple_flatMap_collection(Stream<Optional<Collection<String>>> in) {",
+                        "    return in.flatMap(Optional::stream).flatMap(Collection::stream);",
+                        "  }",
+                        "  Stream<String> flatMap_optional_flatMap_optional(Stream<Optional<Optional<String>>> in) {",
+                        "    return in.flatMap(Optional::stream).flatMap(Optional::stream);",
+                        "  }",
+                        "  Collection<String> flatMap_optional_map_flatMap_optional_toList("
+                                + "Stream<Optional<Map.Entry<Integer, Optional<String>>>> in) {",
+                        "    return in.flatMap(Optional::stream).map(Map.Entry::getValue)"
+                                + ".flatMap(Optional::stream).toList();",
                         "  }",
                         "}")
                 .addOutputLines(
                         "Test.java",
                         "import java.util.Collection;",
+                        "import java.util.Map;",
                         "import java.util.Optional;",
                         "import java.util.stream.Stream;",
                         "public class Test {",
-                        "  Stream<String> f1(Stream<Collection<Optional<String>>> in) {",
-                        "    return in.flatMap(Collection::stream)"
-                                + ".filter(Optional::isPresent).map(Optional::orElseThrow);",
+                        "  Stream<String> filter_empty(Stream<Optional<String>> in) {",
+                        "    return in.filter(Optional::isEmpty).map(o -> o.orElse(\"\"));",
                         "  }",
-                        "  Stream<String> f2(Stream<Collection<Optional<String>>> in) {",
-                        "    return in.flatMap(list -> list.stream()"
-                                + ".filter(Optional::isPresent).map(Optional::orElseThrow));",
+                        "  Stream<String> flatMap_simple(Stream<Optional<String>> in) {",
+                        "    return in.mapMulti(Optional::ifPresent);",
                         "  }",
-                        "  Stream<String> f3(Stream<Collection<Optional<String>>> in) {",
-                        "    return in.flatMap(list -> list.stream())"
-                                + ".filter(Optional::isPresent).map(Optional::orElseThrow);",
+                        "  Stream<String> filter_map_get(Stream<Optional<String>> in) {",
+                        "    return in.mapMulti(Optional::ifPresent);",
                         "  }",
-                        "  Stream<String> f4(Stream<Optional<Optional<String>>> in) {",
-                        "      return in.filter(Optional::isPresent).map(Optional::orElseThrow)"
-                                + ".filter(Optional::isPresent).map(Optional::orElseThrow);",
+                        "  Stream<Integer> filter_map_length(Stream<Optional<String>> in) {",
+                        "    return in.filter(Optional::isPresent).map(o -> o.get().length());",
+                        "  }",
+                        "  Stream<String> filter_orElseThrow(Stream<Optional<String>> in) {",
+                        "    return in.mapMulti(Optional::ifPresent);",
+                        "  }",
+                        "  Stream<String> flatMap_collection(Stream<Collection<Optional<String>>> in) {",
+                        "    return in.flatMap(Collection::stream).mapMulti(Optional::ifPresent);",
+                        "  }",
+                        "  Stream<String> flatMap_lambda_collection(Stream<Collection<Optional<String>>> in) {",
+                        "    return in.flatMap(list -> list.stream().mapMulti(Optional::ifPresent));",
+                        "  }",
+                        "  Stream<String> flatMap_lambda_optional_collection("
+                                + "Stream<Optional<Collection<Optional<String>>>> in) {",
+                        "    return in.flatMap(o -> "
+                                + "o.stream().flatMap(Collection::stream).mapMulti(Optional::ifPresent));",
+                        "  }",
+                        "  Stream<String> flatMap_simple_flatMap_collection(Stream<Optional<Collection<String>>> in) {",
+                        "    return in.<Collection<String>>mapMulti(Optional::ifPresent).flatMap(Collection::stream);",
+                        "  }",
+                        "  Stream<String> flatMap_optional_flatMap_optional(Stream<Optional<Optional<String>>> in) {",
+                        "    return in.<Optional<String>>mapMulti(Optional::ifPresent)"
+                                + ".mapMulti(Optional::ifPresent);",
+                        "  }",
+                        "  Collection<String> flatMap_optional_map_flatMap_optional_toList("
+                                + "Stream<Optional<Map.Entry<Integer, Optional<String>>>> in) {",
+                        "    return in.<Map.Entry<Integer,Optional<String>>>mapMulti(Optional::ifPresent)"
+                                + ".map(Map.Entry::getValue)"
+                                + ".<String>mapMulti(Optional::ifPresent)"
+                                + ".toList();",
                         "  }",
                         "}")
                 .doTest();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
@@ -48,19 +48,19 @@ class StreamFlatmapOptionalTest {
                         "public class Test {",
                         "  Stream<String> f1(Stream<Collection<Optional<String>>> in) {",
                         "    return in.flatMap(Collection::stream)"
-                                + ".filter(Optional::isPresent).map(Optional::get);",
+                                + ".filter(Optional::isPresent).map(Optional::orElseThrow);",
                         "  }",
                         "  Stream<String> f2(Stream<Collection<Optional<String>>> in) {",
                         "    return in.flatMap(list -> list.stream()"
-                                + ".filter(Optional::isPresent).map(Optional::get));",
+                                + ".filter(Optional::isPresent).map(Optional::orElseThrow));",
                         "  }",
                         "  Stream<String> f3(Stream<Collection<Optional<String>>> in) {",
                         "    return in.flatMap(list -> list.stream())"
-                                + ".filter(Optional::isPresent).map(Optional::get);",
+                                + ".filter(Optional::isPresent).map(Optional::orElseThrow);",
                         "  }",
                         "  Stream<String> f4(Stream<Optional<Optional<String>>> in) {",
-                        "      return in.filter(Optional::isPresent).map(Optional::get)"
-                                + ".filter(Optional::isPresent).map(Optional::get);",
+                        "      return in.filter(Optional::isPresent).map(Optional::orElseThrow)"
+                                + ".filter(Optional::isPresent).map(Optional::orElseThrow);",
                         "  }",
                         "}")
                 .doTest();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
@@ -16,6 +16,11 @@
 
 package com.palantir.baseline.errorprone;
 
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 class StreamFlatmapOptionalTest {
@@ -27,6 +32,8 @@ class StreamFlatmapOptionalTest {
                         "import java.util.Collection;",
                         "import java.util.Map;",
                         "import java.util.Optional;",
+                        "import java.util.Set;",
+                        "import java.util.stream.Collectors;",
                         "import java.util.stream.Stream;",
                         "public class Test {",
                         "  Stream<String> filter_empty(Stream<Optional<String>> in) {",
@@ -65,16 +72,22 @@ class StreamFlatmapOptionalTest {
                         "    return in.flatMap(Optional::stream).map(Map.Entry::getValue)"
                                 + ".flatMap(Optional::stream).toList();",
                         "  }",
-                        "  Collection<String> chained_flatMap_maps(Stream<Optional<String>> in) {",
+                        "  Collection<String> chain_flatMap_maps(Stream<Optional<String>> in) {",
                         "    return in.flatMap(Optional::stream)",
-                        "      .map(Test::maybe)",
+                        "      .map(Optional::ofNullable)",
                         "      .flatMap(Optional::stream)",
-                        "      .map(Test::maybe)",
+                        "      .map(Optional::ofNullable)",
                         "      .flatMap(Optional::stream)",
                         "      .toList();",
                         "  }",
-                        "  static Optional<String> maybe(String in) {",
-                        "    return in.isEmpty() ? Optional.empty() : Optional.of(in);",
+                        "  Set<Integer> chain_flatMap_maps_toSet(Stream<Optional<Collection<Optional<String>>>> in) {",
+                        "    return in.flatMap(Optional::stream)",
+                        "      .map(Optional::ofNullable)",
+                        "      .flatMap(Optional::stream)",
+                        "      .flatMap(Collection::stream)",
+                        "      .flatMap(Optional::stream)",
+                        "      .map(String::length)",
+                        "      .collect(Collectors.toSet());",
                         "  }",
                         "}")
                 .addOutputLines(
@@ -82,13 +95,15 @@ class StreamFlatmapOptionalTest {
                         "import java.util.Collection;",
                         "import java.util.Map;",
                         "import java.util.Optional;",
+                        "import java.util.Set;",
+                        "import java.util.stream.Collectors;",
                         "import java.util.stream.Stream;",
                         "public class Test {",
                         "  Stream<String> filter_empty(Stream<Optional<String>> in) {",
                         "    return in.filter(Optional::isEmpty).map(o -> o.orElse(\"\"));",
                         "  }",
                         "  Stream<String> flatMap_simple(Stream<Optional<String>> in) {",
-                        "    return in.<String>mapMulti(Optional::ifPresent);",
+                        "    return in.mapMulti(Optional::ifPresent);",
                         "  }",
                         "  Stream<String> filter_map_get(Stream<Optional<String>> in) {",
                         "    return in.mapMulti(Optional::ifPresent);",
@@ -124,16 +139,22 @@ class StreamFlatmapOptionalTest {
                                 + ".<String>mapMulti(Optional::ifPresent)"
                                 + ".toList();",
                         "  }",
-                        "  Collection<String> chained_flatMap_maps(Stream<Optional<String>> in) {",
+                        "  Collection<String> chain_flatMap_maps(Stream<Optional<String>> in) {",
                         "    return in.<String>mapMulti(Optional::ifPresent)",
-                        "      .map(Test::maybe)",
+                        "      .map(Optional::ofNullable)",
                         "      .<String>mapMulti(Optional::ifPresent)",
-                        "      .map(Test::maybe)",
+                        "      .map(Optional::ofNullable)",
                         "      .<String>mapMulti(Optional::ifPresent)",
                         "      .toList();",
                         "  }",
-                        "  static Optional<String> maybe(String in) {",
-                        "    return in.isEmpty() ? Optional.empty() : Optional.of(in);",
+                        "  Set<Integer> chain_flatMap_maps_toSet(Stream<Optional<Collection<Optional<String>>>> in) {",
+                        "    return in.<Collection<Optional<String>>>mapMulti(Optional::ifPresent)",
+                        "      .map(Optional::ofNullable)",
+                        "      .<Collection<Optional<String>>>mapMulti(Optional::ifPresent)",
+                        "      .flatMap(Collection::stream)",
+                        "      .<String>mapMulti(Optional::ifPresent)",
+                        "      .map(String::length)",
+                        "      .collect(Collectors.toSet());",
                         "  }",
                         "}")
                 .doTest();
@@ -141,5 +162,17 @@ class StreamFlatmapOptionalTest {
 
     private RefactoringValidator fix() {
         return RefactoringValidator.of(StreamFlatMapOptional.class, getClass());
+    }
+
+    static class Foo {
+        Set<Integer> chain_flatMap_maps_toSet(Stream<Optional<Collection<Optional<String>>>> in) {
+            return in.<Collection<Optional<String>>>mapMulti(Optional::ifPresent)
+                    .map(Optional::ofNullable)
+                    .<Collection<Optional<String>>>mapMulti(Optional::ifPresent)
+                    .flatMap(Collection::stream)
+                    .<String>mapMulti(Optional::ifPresent)
+                    .map(String::length)
+                    .collect(Collectors.toSet());
+        }
     }
 }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
@@ -88,7 +88,7 @@ class StreamFlatmapOptionalTest {
                         "    return in.filter(Optional::isEmpty).map(o -> o.orElse(\"\"));",
                         "  }",
                         "  Stream<String> flatMap_simple(Stream<Optional<String>> in) {",
-                        "    return in.mapMulti(Optional::ifPresent);",
+                        "    return in.<String>mapMulti(Optional::ifPresent);",
                         "  }",
                         "  Stream<String> filter_map_get(Stream<Optional<String>> in) {",
                         "    return in.mapMulti(Optional::ifPresent);",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StreamFlatmapOptionalTest.java
@@ -65,6 +65,17 @@ class StreamFlatmapOptionalTest {
                         "    return in.flatMap(Optional::stream).map(Map.Entry::getValue)"
                                 + ".flatMap(Optional::stream).toList();",
                         "  }",
+                        "  Collection<String> chained_flatMap_maps(Stream<Optional<String>> in) {",
+                        "    return in.flatMap(Optional::stream)",
+                        "      .map(Test::maybe)",
+                        "      .flatMap(Optional::stream)",
+                        "      .map(Test::maybe)",
+                        "      .flatMap(Optional::stream)",
+                        "      .toList();",
+                        "  }",
+                        "  static Optional<String> maybe(String in) {",
+                        "    return in.isEmpty() ? Optional.empty() : Optional.of(in);",
+                        "  }",
                         "}")
                 .addOutputLines(
                         "Test.java",
@@ -112,6 +123,17 @@ class StreamFlatmapOptionalTest {
                                 + ".map(Map.Entry::getValue)"
                                 + ".<String>mapMulti(Optional::ifPresent)"
                                 + ".toList();",
+                        "  }",
+                        "  Collection<String> chained_flatMap_maps(Stream<Optional<String>> in) {",
+                        "    return in.<String>mapMulti(Optional::ifPresent)",
+                        "      .map(Test::maybe)",
+                        "      .<String>mapMulti(Optional::ifPresent)",
+                        "      .map(Test::maybe)",
+                        "      .<String>mapMulti(Optional::ifPresent)",
+                        "      .toList();",
+                        "  }",
+                        "  static Optional<String> maybe(String in) {",
+                        "    return in.isEmpty() ? Optional.empty() : Optional.of(in);",
                         "  }",
                         "}")
                 .doTest();

--- a/changelog/@unreleased/pr-2996.v2.yml
+++ b/changelog/@unreleased/pr-2996.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Stream.mapMulti(Optional::ifPresent)` is more efficient than `Stream.flatMap(Optional::stream)
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2996


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

https://github.com/palantir/gradle-baseline/pull/2946 added a check to convert `Stream.flatMap(Optional::stream)` to more efficient `Stream.filter(Optional::isPresent).map(Optional::get)`. There was discussion in https://github.com/palantir/gradle-baseline/pull/2950 whether the autofix should prefer `Optional::orElseThrow` over `Optional::get` and using [`Stream.mapMulti(Optional::ifPresent)` as a more concise and efficient alternative](https://github.com/palantir/gradle-baseline/pull/2946#issuecomment-2593654541).


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==

Converts `Stream.flatMap(Optional::stream)`, `Stream.filter(Optional::isPresent).map(Optional::get)`, and `filter(Optional::isPresent).map(Optional::orElseThrow)` to `Stream.mapMulti(Optional::ifPresent)`. 

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

