### PR TITLE
Disable expensive LambdaMethodReference by default

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LambdaMethodReference.java
@@ -52,7 +52,7 @@ import javax.annotation.Nullable;
 @BugPattern(
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = SeverityLevel.WARNING,
+        severity = SeverityLevel.SUGGESTION,
         summary = "Lambda should be a method reference")
 @SuppressWarnings("checkstyle:CyclomaticComplexity")
 public final class LambdaMethodReference extends BugChecker implements BugChecker.LambdaExpressionTreeMatcher {

--- a/changelog/@unreleased/pr-2999.v2.yml
+++ b/changelog/@unreleased/pr-2999.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable expensive LambdaMethodReference by default
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/2999

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -48,7 +48,6 @@ public abstract class BaselineErrorProneExtension {
             "ImplicitPublicBuilderConstructor",
             "JavaTimeDefaultTimeZone",
             "JavaTimeSystemDefaultTimeZone",
-            "LambdaMethodReference",
             "LoggerEnclosingClass",
             "LogsafeArgName",
             "ObjectsHashCodeUnnecessaryVarargs",

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -99,6 +99,9 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 // https://github.com/google/error-prone/issues/4544
                 "DistinctVarargsChecker",
                 "InlineMeSuggester",
+                // LambdaMethodReference is incredibly expensive, see #2997. We leave it
+                // here to employ as a cleanup, but don't execute it in most compilations.
+                "LambdaMethodReference",
                 // We often use javadoc comments without javadoc parameter information.
                 "NotJavadoc",
                 "PreferImmutableStreamExCollections",


### PR DESCRIPTION
See #2997

LambdaMethodReference is incredibly expensive, even compared to log safety flow analysis! It was originally added to clean up the results of other excavators, not to prevent runtime failures. We will apply the cleanup asynchronously via an excavator, rather than on a per-compilation basis, delayed fixups are a reasonable tradeoff here to dramatically improve compilation performance.

While we could move the code entirely into excavator instead of maintaining it here, however that has some risk for folks who explicitly configure/disable the `LambdaMethodReference` check (specifically, they would fail with:
`LambdaMethodReference not a valid checker name`)

==COMMIT_MSG==
Disable expensive LambdaMethodReference by default
==COMMIT_MSG==

