### PR TITLE
Handle safety analysis for `this` and `super` references

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -49,7 +49,9 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.RecordComponent;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import java.io.Closeable;
@@ -1058,25 +1060,40 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
     @Override
     public TransferResult<Safety, AccessPathStore<Safety>> visitImplicitThis(
             ImplicitThisNode node, TransferInput<Safety, AccessPathStore<Safety>> input) {
-        Symbol symbol = ASTHelpers.getSymbol(node.getTree());
-        Safety safety = symbol == null ? Safety.UNKNOWN : SafetyAnnotations.getSafety(symbol.owner, state);
-        return noStoreChanges(safety, input);
+        return visitThisOrSuper(node, input);
     }
 
     @Override
     public TransferResult<Safety, AccessPathStore<Safety>> visitExplicitThis(
             ExplicitThisNode node, TransferInput<Safety, AccessPathStore<Safety>> input) {
-        Symbol symbol = ASTHelpers.getSymbol(node.getTree());
-        Safety safety = symbol == null ? Safety.UNKNOWN : SafetyAnnotations.getSafety(symbol.owner, state);
-        return noStoreChanges(safety, input);
+        return visitThisOrSuper(node, input);
     }
 
     @Override
     public TransferResult<Safety, AccessPathStore<Safety>> visitSuper(
             SuperNode node, TransferInput<Safety, AccessPathStore<Safety>> input) {
+        return visitThisOrSuper(node, input);
+    }
+
+    public TransferResult<Safety, AccessPathStore<Safety>> visitThisOrSuper(
+            Node node, TransferInput<Safety, AccessPathStore<Safety>> input) {
+        Type nodeType = getTypeForThisOrSuper(node.getType());
         Symbol symbol = ASTHelpers.getSymbol(node.getTree());
-        Safety safety = symbol == null ? Safety.UNKNOWN : SafetyAnnotations.getSafety(symbol.owner, state);
-        return noStoreChanges(safety, input);
+        Safety treeSymbolSafety = symbol == null ? Safety.UNKNOWN : SafetyAnnotations.getSafety(symbol.owner, state);
+        Safety typeSymbolSafety = SafetyAnnotations.getSafety(nodeType, state);
+        Safety combined = Safety.mergeAssumingUnknownIsSame(treeSymbolSafety, typeSymbolSafety);
+        return noStoreChanges(combined, input);
+    }
+
+    @Nullable
+    private static Type getTypeForThisOrSuper(TypeMirror typeMirror) {
+        if (typeMirror instanceof ClassType classType) {
+            TypeSymbol typeSymbol = classType.tsym;
+            if (typeSymbol != null) {
+                return typeSymbol.type;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -1075,7 +1075,7 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
         return visitThisOrSuper(node, input);
     }
 
-    public TransferResult<Safety, AccessPathStore<Safety>> visitThisOrSuper(
+    private TransferResult<Safety, AccessPathStore<Safety>> visitThisOrSuper(
             Node node, TransferInput<Safety, AccessPathStore<Safety>> input) {
         Type nodeType = getTypeForThisOrSuper(node.getType());
         Symbol symbol = ASTHelpers.getSymbol(node.getTree());

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -994,6 +994,22 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testParameterizedTypeThisSafety() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.List;",
+                        "abstract class Test<@Unsafe T> implements List<T> {",
+                        "  public void f() {",
+                        "    // BUG: Diagnostic contains: arg is 'UNSAFE' but the parameter requires 'SAFE'",
+                        "    consume(this);",
+                        "  }",
+                        "  static void consume(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testThrowableSafeLoggable_thisGetMessageIsUnsafe() {
         helper().addSourceLines(
                         "TestThrowable.java",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -959,6 +959,81 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testThrowableSafeLoggable_superGetMessageIsUnsafe() {
+        helper().addSourceLines(
+                        "TestThrowable.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.List;",
+                        "class TestThrowable extends RuntimeException implements SafeLoggable {",
+                        "  @Override",
+                        "  public String getLogMessage() {",
+                        "    // BUG: Diagnostic contains: result is 'UNSAFE' but the method is annotated 'SAFE'",
+                        "    return super.getMessage();",
+                        "  }",
+                        "  @Override",
+                        "  public List<Arg<?>> getArgs() {",
+                        "    return List.of();",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testThrowableThisSafety() {
+        helper().addSourceLines(
+                        "TestThrowable.java",
+                        "import com.palantir.logsafe.*;",
+                        "class TestThrowable extends RuntimeException {",
+                        "  public void f() {",
+                        "    // BUG: Diagnostic contains: arg is 'UNSAFE' but the parameter requires 'SAFE'",
+                        "    consume(this);",
+                        "  }",
+                        "  static void consume(@Safe Object obj) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testThrowableSafeLoggable_thisGetMessageIsUnsafe() {
+        helper().addSourceLines(
+                        "TestThrowable.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.List;",
+                        "class TestThrowable extends RuntimeException implements SafeLoggable {",
+                        "  @Override",
+                        "  public String getLogMessage() {",
+                        "    // BUG: Diagnostic contains: result is 'UNSAFE' but the method is annotated 'SAFE'",
+                        "    return this.getMessage();",
+                        "  }",
+                        "  @Override",
+                        "  public List<Arg<?>> getArgs() {",
+                        "    return List.of();",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testThrowableSafeLoggable_getMessageIsUnsafe() {
+        helper().addSourceLines(
+                        "TestThrowable.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.List;",
+                        "class TestThrowable extends RuntimeException implements SafeLoggable {",
+                        "  @Override",
+                        "  public String getLogMessage() {",
+                        "    // BUG: Diagnostic contains: result is 'UNSAFE' but the method is annotated 'SAFE'",
+                        "    return getMessage();",
+                        "  }",
+                        "  @Override",
+                        "  public List<Arg<?>> getArgs() {",
+                        "    return List.of();",
+                        "  }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testStringFormat() {
         helper().addSourceLines(
                         "Test.java",

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/SafeLoggingPropagationTest.java
@@ -892,11 +892,30 @@ class SafeLoggingPropagationTest {
                         "Test.java",
                         "import com.palantir.logsafe.*;",
                         "class MyException extends RuntimeException {",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    void testThrowableGetMessageDelegatesToSuper() {
+        // We do, however, annotate the `getMessage` method if it delegates to super.
+        fix().addInputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class MyException extends RuntimeException {",
                         "  @Override public String getMessage() {",
                         "     return super.getMessage();",
                         "  }",
                         "}")
-                .expectUnchanged()
+                .addOutputLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "class MyException extends RuntimeException {",
+                        "  @Unsafe @Override public String getMessage() {",
+                        "     return super.getMessage();",
+                        "  }",
+                        "}")
                 .doTest();
     }
 

--- a/changelog/@unreleased/pr-3041.v2.yml
+++ b/changelog/@unreleased/pr-3041.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Handle safety analysis for `this` and `super` references
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3041


### PR DESCRIPTION
## Before this PR
Previously we failed to handle safety metadata for `this` and `super` references similarly to other variable references. See the new tests for examples. Most notably, this meant one could implement a `SafeLoggable` exception thusly without a warning:
```java
@Override
public String getLogMessage() {
    return getMessage(); // oh no! This is dangerous!
}
```
The danger is subtler than one might realize -- if such an exception is created with a known, safe message, it may be fine, however if it's constructed with a ctor that delegates to `public Throwable(Throwable cause)`, then `cause.toString()` will be used as the exception message, which is almost certainly unsafe, even (or especially!) if the cause implements `SafeLoggable` due to the following:
```java
public Throwable(Throwable cause) {
    fillInStackTrace();
    detailMessage = (cause==null ? null : cause.toString());
    this.cause = cause;
}
```

## After this PR
==COMMIT_MSG==
Handle safety analysis for `this` and `super` references
==COMMIT_MSG==
