### PR TITLE
[Safe-logging] Verify safety of returns in lambda expressions

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -33,6 +34,7 @@ import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
@@ -53,6 +55,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import javax.lang.model.element.Modifier;
 
 /**
  * Ensures that safe-logging annotated elements are handled correctly by annotated method parameters.
@@ -78,7 +82,8 @@ public final class IllegalSafeLoggingArgument extends BugChecker
                 BugChecker.MethodTreeMatcher,
                 BugChecker.VariableTreeMatcher,
                 BugChecker.NewClassTreeMatcher,
-                BugChecker.ClassTreeMatcher {
+                BugChecker.ClassTreeMatcher,
+                BugChecker.LambdaExpressionTreeMatcher {
 
     private static final String UNSAFE_ARG = "com.palantir.logsafe.UnsafeArg";
     private static final Matcher<ExpressionTree> SAFE_ARG_OF_METHOD_MATCHER = MethodMatchers.staticMethod()
@@ -426,5 +431,87 @@ public final class IllegalSafeLoggingArgument extends BugChecker
                 .setMessage(String.format(
                         "Dangerous type: annotated '%s' but ancestors declare '%s'.", directSafety, ancestorSafety))
                 .build();
+    }
+
+    @Override
+    public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
+        TreePath path = state.getPath();
+        while (path != null && !(path.getLeaf() instanceof VariableTree)) {
+            path = path.getParentPath();
+        }
+        if (path == null) {
+            // The lambda isn't directly assigned to a variable, so we don't know how to analyze it (yet)
+            // TODO(aldexis): handle other ways that a lambda can be used, e.g. returned from a method
+            return Description.NO_MATCH;
+        }
+        VariableTree variable = (VariableTree) path.getLeaf();
+        Type variableType = ASTHelpers.getType(variable);
+
+        Type returnType = getFunctionalInterfaceReturnType(variableType, state);
+        if (returnType == null) {
+            return Description.NO_MATCH;
+        }
+        Safety requiredReturnSafety = SafetyAnnotations.getSafety(returnType, state);
+
+        if (requiredReturnSafety.allowsAll()) {
+            // Short-circuit if the return type allows all values
+            return Description.NO_MATCH;
+        }
+
+        Safety resultSafety = getLambdaReturnSafety(tree, state);
+
+        if (requiredReturnSafety.allowsValueWith(resultSafety)) {
+            return Description.NO_MATCH;
+        }
+
+        return buildDescription(tree)
+                .setMessage(String.format(
+                        "Dangerous return type in lambda function: expected return type is '%s' "
+                                + "but the lambda is returning '%s'.",
+                        requiredReturnSafety, resultSafety))
+                .build();
+    }
+
+    private Type getFunctionalInterfaceReturnType(Type variableType, VisitorState state) {
+        if (variableType == null) {
+            return null;
+        }
+
+        Iterable<Symbol> methods =
+                ASTHelpers.scope(variableType.tsym.members()).getSymbols(s -> s instanceof MethodSymbol);
+        List<MethodSymbol> abstractMethods = StreamSupport.stream(methods.spliterator(), false)
+                .map(MethodSymbol.class::cast)
+                .filter(m -> m.getModifiers().contains(Modifier.ABSTRACT))
+                .toList();
+        if (abstractMethods.size() != 1) {
+            // Functional interfaces should have exactly one abstract method
+            // Return nothing when we encounter something that isn't one
+            return null;
+        }
+        MethodSymbol method = Iterables.getOnlyElement(abstractMethods);
+        Type returnType = method.getReturnType();
+
+        com.sun.tools.javac.util.List<Type> classTypeArguments =
+                variableType.tsym.asType().getTypeArguments();
+
+        for (int i = 0; i < classTypeArguments.size(); i++) {
+            // TODO: check whether this is the correct way to compare the type arguments
+            if (ASTHelpers.isSameType(classTypeArguments.get(i), returnType, state)) {
+                return variableType.getTypeArguments().get(i);
+            }
+        }
+        return returnType;
+    }
+
+    private Safety getLambdaReturnSafety(LambdaExpressionTree tree, VisitorState state) {
+        LambdaExpressionTree.BodyKind bodyKind = tree.getBodyKind();
+        switch (bodyKind) {
+            case EXPRESSION:
+                return SafetyAnalysis.of(state.withPath(new TreePath(state.getPath(), tree.getBody())));
+            case STATEMENT:
+                // TODO(aldexis): Handle statement lambdas, by getting and analyzing all the return blocks
+                return Safety.UNKNOWN;
+        }
+        throw new IllegalStateException("Unexpected BodyKind: " + bodyKind);
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -17,7 +17,6 @@
 package com.palantir.baseline.errorprone;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -27,6 +26,7 @@ import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.ASTHelpers.TargetType;
 import com.palantir.baseline.errorprone.safety.Safety;
 import com.palantir.baseline.errorprone.safety.SafetyAnalysis;
 import com.palantir.baseline.errorprone.safety.SafetyAnnotations;
@@ -55,8 +55,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-import javax.lang.model.element.Modifier;
 
 /**
  * Ensures that safe-logging annotated elements are handled correctly by annotated method parameters.
@@ -265,11 +263,24 @@ public final class IllegalSafeLoggingArgument extends BugChecker
         while (path != null && path.getLeaf() instanceof StatementTree) {
             path = path.getParentPath();
         }
-        if (path == null || !(path.getLeaf() instanceof MethodTree)) {
+        if (path == null || !(path.getLeaf() instanceof MethodTree || path.getLeaf() instanceof LambdaExpressionTree)) {
             return Description.NO_MATCH;
         }
-        MethodTree method = (MethodTree) path.getLeaf();
+
+        if (path.getLeaf() instanceof MethodTree method) {
+            return handleMethodReturn(tree, method, state);
+        } else if (path.getLeaf() instanceof LambdaExpressionTree lambda) {
+            return handleLambdaReturn(tree, lambda, state);
+        } else {
+            // We verified just above that it should be either
+            throw new IllegalStateException(
+                    "Unexpected parent of return statement: " + state.getSourceForNode(path.getLeaf()));
+        }
+    }
+
+    private Description handleMethodReturn(ReturnTree tree, MethodTree method, VisitorState state) {
         Safety methodDeclaredSafety = SafetyAnnotations.getSafety(ASTHelpers.getSymbol(method), state);
+
         if (methodDeclaredSafety.allowsAll()) {
             // Fast path, all types are accepted, there's no reason to do further analysis.
             return Description.NO_MATCH;
@@ -283,6 +294,25 @@ public final class IllegalSafeLoggingArgument extends BugChecker
                 .setMessage(String.format(
                         "Dangerous return value: result is '%s' but the method is annotated '%s'.",
                         returnValueSafety, methodDeclaredSafety))
+                .build();
+    }
+
+    private Description handleLambdaReturn(ReturnTree tree, LambdaExpressionTree lambda, VisitorState state) {
+        Safety requiredSafety = getLambdaRequiredReturnSafety(lambda, state);
+
+        if (requiredSafety.allowsAll()) {
+            // Fast path, all types are accepted, there's no reason to do further analysis.
+            return Description.NO_MATCH;
+        }
+        Safety returnValueSafety =
+                SafetyAnalysis.of(state.withPath(new TreePath(state.getPath(), tree.getExpression())));
+        if (requiredSafety.allowsValueWith(returnValueSafety)) {
+            return Description.NO_MATCH;
+        }
+        return buildDescription(tree)
+                .setMessage(String.format(
+                        "Dangerous return value: result is '%s' but the lambda expects return '%s'.",
+                        returnValueSafety, requiredSafety))
                 .build();
     }
 
@@ -435,20 +465,23 @@ public final class IllegalSafeLoggingArgument extends BugChecker
 
     @Override
     public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
-        Type variableType = ASTHelpers.getType(tree);
-
-        Type returnType = getFunctionalInterfaceReturnType(variableType, state);
-        if (returnType == null) {
-            return Description.NO_MATCH;
-        }
-        Safety requiredReturnSafety = SafetyAnnotations.getSafety(returnType, state);
+        Safety requiredReturnSafety = getLambdaRequiredReturnSafety(tree, state);
 
         if (requiredReturnSafety.allowsAll()) {
             // Short-circuit if the return type allows all values
             return Description.NO_MATCH;
         }
 
-        Safety resultSafety = getLambdaReturnSafety(tree, state);
+        Safety resultSafety = Safety.UNKNOWN;
+        switch (tree.getBodyKind()) {
+            case EXPRESSION:
+                resultSafety = SafetyAnalysis.of(state.withPath(new TreePath(state.getPath(), tree.getBody())));
+                break;
+            case STATEMENT:
+                // Shortcut - statement lambdas get their return type checked in the return statement matcher
+                // This also allows us to indicate which return statement is bad (if any) rather than the lambda itself
+                return Description.NO_MATCH;
+        }
 
         if (requiredReturnSafety.allowsValueWith(resultSafety)) {
             return Description.NO_MATCH;
@@ -456,52 +489,16 @@ public final class IllegalSafeLoggingArgument extends BugChecker
 
         return buildDescription(tree)
                 .setMessage(String.format(
-                        "Dangerous return type in lambda function: expected return type is '%s' "
-                                + "but the lambda is returning '%s'.",
-                        requiredReturnSafety, resultSafety))
+                        "Dangerous return value: result is '%s' but the lambda expects return '%s'.",
+                        resultSafety, requiredReturnSafety))
                 .build();
     }
 
-    private Type getFunctionalInterfaceReturnType(Type variableType, VisitorState state) {
-        if (variableType == null) {
-            return null;
+    private Safety getLambdaRequiredReturnSafety(LambdaExpressionTree tree, VisitorState state) {
+        TargetType returnType = ASTHelpers.targetType(state.withPath(new TreePath(state.getPath(), tree)));
+        if (returnType == null) {
+            return Safety.UNKNOWN;
         }
-
-        Iterable<Symbol> methods =
-                ASTHelpers.scope(variableType.tsym.members()).getSymbols(s -> s instanceof MethodSymbol);
-        List<MethodSymbol> abstractMethods = StreamSupport.stream(methods.spliterator(), false)
-                .map(MethodSymbol.class::cast)
-                .filter(m -> m.getModifiers().contains(Modifier.ABSTRACT))
-                .toList();
-        if (abstractMethods.size() != 1) {
-            // Functional interfaces should have exactly one abstract method
-            // Return nothing when we encounter something that isn't one
-            return null;
-        }
-        MethodSymbol method = Iterables.getOnlyElement(abstractMethods);
-        Type returnType = method.getReturnType();
-
-        com.sun.tools.javac.util.List<Type> classTypeArguments =
-                variableType.tsym.asType().getTypeArguments();
-
-        for (int i = 0; i < classTypeArguments.size(); i++) {
-            // TODO: check whether this is the correct way to compare the type arguments
-            if (ASTHelpers.isSameType(classTypeArguments.get(i), returnType, state)) {
-                return variableType.getTypeArguments().get(i);
-            }
-        }
-        return returnType;
-    }
-
-    private Safety getLambdaReturnSafety(LambdaExpressionTree tree, VisitorState state) {
-        LambdaExpressionTree.BodyKind bodyKind = tree.getBodyKind();
-        switch (bodyKind) {
-            case EXPRESSION:
-                return SafetyAnalysis.of(state.withPath(new TreePath(state.getPath(), tree.getBody())));
-            case STATEMENT:
-                // TODO(aldexis): Handle statement lambdas, by getting and analyzing all the return blocks
-                return Safety.UNKNOWN;
-        }
-        throw new IllegalStateException("Unexpected BodyKind: " + bodyKind);
+        return SafetyAnnotations.getSafety(returnType.type(), state);
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -263,19 +263,15 @@ public final class IllegalSafeLoggingArgument extends BugChecker
         while (path != null && path.getLeaf() instanceof StatementTree) {
             path = path.getParentPath();
         }
-        if (path == null || !(path.getLeaf() instanceof MethodTree || path.getLeaf() instanceof LambdaExpressionTree)) {
-            return Description.NO_MATCH;
+        if (path != null) {
+            if (path.getLeaf() instanceof MethodTree method) {
+                return handleMethodReturn(tree, method, state);
+            } else if (path.getLeaf() instanceof LambdaExpressionTree lambda) {
+                return handleLambdaReturn(tree, lambda, state);
+            }
         }
 
-        if (path.getLeaf() instanceof MethodTree method) {
-            return handleMethodReturn(tree, method, state);
-        } else if (path.getLeaf() instanceof LambdaExpressionTree lambda) {
-            return handleLambdaReturn(tree, lambda, state);
-        } else {
-            // We verified just above that it should be either
-            throw new IllegalStateException(
-                    "Unexpected parent of return statement: " + state.getSourceForNode(path.getLeaf()));
-        }
+        return Description.NO_MATCH;
     }
 
     private Description handleMethodReturn(ReturnTree tree, MethodTree method, VisitorState state) {

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -435,17 +435,7 @@ public final class IllegalSafeLoggingArgument extends BugChecker
 
     @Override
     public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
-        TreePath path = state.getPath();
-        while (path != null && !(path.getLeaf() instanceof VariableTree)) {
-            path = path.getParentPath();
-        }
-        if (path == null) {
-            // The lambda isn't directly assigned to a variable, so we don't know how to analyze it (yet)
-            // TODO(aldexis): handle other ways that a lambda can be used, e.g. returned from a method
-            return Description.NO_MATCH;
-        }
-        VariableTree variable = (VariableTree) path.getLeaf();
-        Type variableType = ASTHelpers.getType(variable);
+        Type variableType = ASTHelpers.getType(tree);
 
         Type returnType = getFunctionalInterfaceReturnType(variableType, state);
         if (returnType == null) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -102,7 +102,6 @@ class IllegalSafeLoggingLambdaTest {
     //    }
 
     @Test
-    @SuppressWarnings("MisformattedTestData")
     public void testUnsafeExpressionLambdaSupplier() {
         helper().addSourceLines(
                         "Test.java",
@@ -110,6 +109,7 @@ class IllegalSafeLoggingLambdaTest {
                         """
                         import com.palantir.logsafe.*;
                         import java.util.function.*;
+
                         class Test {
                           static void f(@Unsafe Object value) {
                             // BUG: Diagnostic contains: Dangerous return type in lambda function:
@@ -122,7 +122,6 @@ class IllegalSafeLoggingLambdaTest {
     }
 
     @Test
-    @SuppressWarnings("MisformattedTestData")
     public void testFunctionalInterfaceWithVoidReturnType() {
         helper().addSourceLines(
                         "Test.java",
@@ -130,6 +129,7 @@ class IllegalSafeLoggingLambdaTest {
                         """
                         import com.palantir.logsafe.*;
                         import java.util.function.*;
+
                         class Test {
                           static void f() {
                             // void-returning lambdas should pass the checks fine
@@ -141,30 +141,76 @@ class IllegalSafeLoggingLambdaTest {
     }
 
     @Test
-    @SuppressWarnings("MisformattedTestData")
     public void testFunctionalInterfaceWithMultipleMethods() {
         helper().addSourceLines(
                         "Test.java",
                         // language=Java
                         """
                         import com.palantir.logsafe.*;
-                        import java.util.List;import java.util.function.*;
+                        import java.util.List;
+                        import java.util.function.*;
+
                         @FunctionalInterface
                         interface MultiMethod<T> {
-                            T get();
-                            default List<T> getMany() {
-                                return List.of(get());
-                            }
-                            static <T> MultiMethod<T> of(T value) {
-                                return () -> value;
-                            }
+                          T get();
+
+                          default List<T> getMany() {
+                            return List.of(get());
+                          }
+
+                          static <T> MultiMethod<T> of(T value) {
+                            return () -> value;
+                          }
                         }
+
                         class Test {
                           static void f(@Unsafe Object value) {
                             // BUG: Diagnostic contains: Dangerous return type in lambda function:
                             // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
                             MultiMethod<@Safe Object> supplier = () -> value;
                           }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    public void testUnsafeLambdaAsReturnType() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          static Supplier<@Safe Object> f(@Unsafe Object value) {
+                            // BUG: Diagnostic contains: Dangerous return type in lambda function:
+                            // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
+                            return () -> value;
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    public void testUnsafeLambdaAsMethodArgument() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          static void f(@Unsafe Object value) {
+                            // BUG: Diagnostic contains: Dangerous return type in lambda function:
+                            // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
+                            fun(() -> value);
+                          }
+
+                          static void fun(Supplier<@Safe Object> in) {}
                         }
                         """)
                 .doTest();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -275,6 +275,31 @@ class IllegalSafeLoggingLambdaTest {
                 .doTest();
     }
 
+    @Test
+    public void testUnsafeOptionalLambdaReturn() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+                        import java.util.*;
+
+                        interface MaybeSupplier<T> {
+                          Optional<T> get();
+                        }
+
+                        class Test {
+                          static MaybeSupplier<@Safe Object> f(@Unsafe Object value) {
+                            // BUG: Diagnostic contains: Dangerous return value:
+                            // result is 'UNSAFE' but the lambda expects return 'SAFE'.
+                            return () -> Optional.of(value);
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -86,23 +86,8 @@ class IllegalSafeLoggingLambdaTest {
                 .doTest();
     }
 
-    //    @Test
-    //    public void testUnsafeStatementLambdaSupplier() {
-    //        helper().addSourceLines(
-    //                        "Test.java",
-    //                        "import com.palantir.logsafe.*;",
-    //                        "import java.util.function.*;",
-    //                        "class Test {",
-    //                        "  static void f(@Unsafe Object value) {",
-    //                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
-    //                        "    Supplier<@Safe Object> supplier = () -> {return value;};",
-    //                        "  }",
-    //                        "}")
-    //                .doTest();
-    //    }
-
     @Test
-    public void testUnsafeExpressionLambdaSupplier() {
+    public void testUnsafeStatementLambda() {
         helper().addSourceLines(
                         "Test.java",
                         // language=Java
@@ -112,9 +97,83 @@ class IllegalSafeLoggingLambdaTest {
 
                         class Test {
                           static void f(@Unsafe Object value) {
-                            // BUG: Diagnostic contains: Dangerous return type in lambda function:
-                            // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
+                            Supplier<@Safe Object> supplier =
+                                () -> {
+                                  // BUG: Diagnostic contains: Dangerous return value:
+                                  // result is 'UNSAFE' but the lambda expects return 'SAFE'.
+                                  return value;
+                                };
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    public void testUnsafeStatementLambdaMultipleReturns() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          static void f(int i, @Safe Object safeValue, @Unsafe Object unsafeValue) {
+                            Supplier<@Safe Object> supplier =
+                                () -> {
+                                  if (i == 0) {
+                                    // BUG: Diagnostic contains: Dangerous return value:
+                                    // result is 'UNSAFE' but the lambda expects return 'SAFE'.
+                                    return unsafeValue;
+                                  } else if (i > 0) {
+                                    return safeValue;
+                                  } else {
+                                    // BUG: Diagnostic contains: Dangerous return value:
+                                    // result is 'UNSAFE' but the lambda expects return 'SAFE'.
+                                    return unsafeValue;
+                                  }
+                                };
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    public void testUnsafeExpressionLambdaIdentityResult() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          static void f(@Unsafe Object value) {
+                            // BUG: Diagnostic contains: Dangerous return value:
+                            // result is 'UNSAFE' but the lambda expects return 'SAFE'.
                             Supplier<@Safe Object> supplier = () -> value;
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    public void testUnsafeExpressionLambdaExpressionResult() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          static void f(@Unsafe String value) {
+                            // BUG: Diagnostic contains: Dangerous return value:
+                            // result is 'UNSAFE' but the lambda expects return 'SAFE'.
+                            Supplier<@Safe Object> supplier = () -> value + value;
                           }
                         }
                         """)
@@ -165,8 +224,8 @@ class IllegalSafeLoggingLambdaTest {
 
                         class Test {
                           static void f(@Unsafe Object value) {
-                            // BUG: Diagnostic contains: Dangerous return type in lambda function:
-                            // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
+                            // BUG: Diagnostic contains: Dangerous return value:
+                            // result is 'UNSAFE' but the lambda expects return 'SAFE'.
                             MultiMethod<@Safe Object> supplier = () -> value;
                           }
                         }
@@ -185,8 +244,8 @@ class IllegalSafeLoggingLambdaTest {
 
                         class Test {
                           static Supplier<@Safe Object> f(@Unsafe Object value) {
-                            // BUG: Diagnostic contains: Dangerous return type in lambda function:
-                            // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
+                            // BUG: Diagnostic contains: Dangerous return value:
+                            // result is 'UNSAFE' but the lambda expects return 'SAFE'.
                             return () -> value;
                           }
                         }
@@ -205,8 +264,8 @@ class IllegalSafeLoggingLambdaTest {
 
                         class Test {
                           static void f(@Unsafe Object value) {
-                            // BUG: Diagnostic contains: Dangerous return type in lambda function:
-                            // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
+                            // BUG: Diagnostic contains: Dangerous return value:
+                            // result is 'UNSAFE' but the lambda expects return 'SAFE'.
                             fun(() -> value);
                           }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -86,6 +86,90 @@ class IllegalSafeLoggingLambdaTest {
                 .doTest();
     }
 
+    //    @Test
+    //    public void testUnsafeStatementLambdaSupplier() {
+    //        helper().addSourceLines(
+    //                        "Test.java",
+    //                        "import com.palantir.logsafe.*;",
+    //                        "import java.util.function.*;",
+    //                        "class Test {",
+    //                        "  static void f(@Unsafe Object value) {",
+    //                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE'",
+    //                        "    Supplier<@Safe Object> supplier = () -> {return value;};",
+    //                        "  }",
+    //                        "}")
+    //                .doTest();
+    //    }
+
+    @Test
+    @SuppressWarnings("MisformattedTestData")
+    public void testUnsafeExpressionLambdaSupplier() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+                        class Test {
+                          static void f(@Unsafe Object value) {
+                            // BUG: Diagnostic contains: Dangerous return type in lambda function:
+                            // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
+                            Supplier<@Safe Object> supplier = () -> value;
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    @SuppressWarnings("MisformattedTestData")
+    public void testFunctionalInterfaceWithVoidReturnType() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+                        class Test {
+                          static void f() {
+                            // void-returning lambdas should pass the checks fine
+                            Consumer<@Safe Object> supplier = (value) -> {};
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    @SuppressWarnings("MisformattedTestData")
+    public void testFunctionalInterfaceWithMultipleMethods() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.List;import java.util.function.*;
+                        @FunctionalInterface
+                        interface MultiMethod<T> {
+                            T get();
+                            default List<T> getMany() {
+                                return List.of(get());
+                            }
+                            static <T> MultiMethod<T> of(T value) {
+                                return () -> value;
+                            }
+                        }
+                        class Test {
+                          static void f(@Unsafe Object value) {
+                            // BUG: Diagnostic contains: Dangerous return type in lambda function:
+                            // expected return type is 'SAFE' but the lambda is returning 'UNSAFE'
+                            MultiMethod<@Safe Object> supplier = () -> value;
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/changelog/@unreleased/pr-3048.v2.yml
+++ b/changelog/@unreleased/pr-3048.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[Safe-logging] Verify safety of returns in lambda expressions'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3048


### PR DESCRIPTION
## Before this PR
We wouldn't check correspondence between a functional interface's return type's declared safety and a lambda's actual return value, when that value's safety can be computed

## After this PR
==COMMIT_MSG==
[Safe-logging] Verify safety of returns in lambda expressions
==COMMIT_MSG==

~Note: This does not yet handle statement-base lambdas (need to do some more code-digging for this)~

I don't know much about Java compilation and static analysis primitives, so please tell me if there are better or simpler ways to do these things.