### PR TITLE
[Safe-logging] Infer lambda parameter safety from surrounding context

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -438,16 +438,44 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
     private final Set<VarSymbol> traversed = new HashSet<>();
 
     @Override
-    public AccessPathStore<Safety> initialStore(UnderlyingAST _underlyingAst, List<LocalVariableNode> parameters) {
+    public AccessPathStore<Safety> initialStore(UnderlyingAST underlyingAst, List<LocalVariableNode> parameters) {
         if (parameters == null) {
             return AccessPathStore.empty();
         }
         AccessPathStore.Builder<Safety> result = AccessPathStore.<Safety>empty().toBuilder();
 
-        for (LocalVariableNode param : parameters) {
-            Safety declared = SafetyAnnotations.getSafety(param.getTree(), state);
-            result.setInformation(AccessPath.fromLocalVariable(param), declared);
+        if (underlyingAst.getKind() == UnderlyingAST.Kind.LAMBDA) {
+            // Special-case lambda types as the parameter annotations are not propagated in
+            //   ForwardAnalysisImpl#getParameters, which is passed as the argument here
+            LambdaExpressionTree lambda = ((UnderlyingAST.CFGLambda) underlyingAst).getLambdaTree();
+
+            // We grab the inferred type of the lambda, then the argument types of the functional interface
+            //  and match them one by one with the actual parameters
+            com.sun.tools.javac.util.List<Type> parameterTypes = state.getTypes()
+                    .findDescriptorType(ASTHelpers.getType(lambda))
+                    .getParameterTypes();
+
+            // This is expected to be true, but let's be defensive here
+            if (parameterTypes.size() == parameters.size()) {
+                for (int i = 0; i < parameters.size(); i++) {
+                    Type type = parameterTypes.get(i);
+                    LocalVariableNode param = parameters.get(i);
+
+                    // If the lambda itself has a safety annotation, which doesn't match the expected one from the
+                    //   type it is used as, combine both
+                    Safety declared = SafetyAnnotations.getSafety(param.getTree(), state);
+                    Safety safety = SafetyAnnotations.getSafety(type, state);
+                    result.setInformation(
+                            AccessPath.fromLocalVariable(param), Safety.mergeAssumingUnknownIsSame(declared, safety));
+                }
+            }
+        } else {
+            for (LocalVariableNode param : parameters) {
+                Safety declared = SafetyAnnotations.getSafety(param.getTree(), state);
+                result.setInformation(AccessPath.fromLocalVariable(param), declared);
+            }
         }
+
         return result.build();
     }
 

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyPropagationTransfer.java
@@ -442,37 +442,45 @@ public final class SafetyPropagationTransfer implements ForwardTransferFunction<
         if (parameters == null) {
             return AccessPathStore.empty();
         }
-        AccessPathStore.Builder<Safety> result = AccessPathStore.<Safety>empty().toBuilder();
 
         if (underlyingAst.getKind() == UnderlyingAST.Kind.LAMBDA) {
             // Special-case lambda types as the parameter annotations are not propagated in
             //   ForwardAnalysisImpl#getParameters, which is passed as the argument here
-            LambdaExpressionTree lambda = ((UnderlyingAST.CFGLambda) underlyingAst).getLambdaTree();
-
-            // We grab the inferred type of the lambda, then the argument types of the functional interface
-            //  and match them one by one with the actual parameters
-            com.sun.tools.javac.util.List<Type> parameterTypes = state.getTypes()
-                    .findDescriptorType(ASTHelpers.getType(lambda))
-                    .getParameterTypes();
-
-            // This is expected to be true, but let's be defensive here
-            if (parameterTypes.size() == parameters.size()) {
-                for (int i = 0; i < parameters.size(); i++) {
-                    Type type = parameterTypes.get(i);
-                    LocalVariableNode param = parameters.get(i);
-
-                    // If the lambda itself has a safety annotation, which doesn't match the expected one from the
-                    //   type it is used as, combine both
-                    Safety declared = SafetyAnnotations.getSafety(param.getTree(), state);
-                    Safety safety = SafetyAnnotations.getSafety(type, state);
-                    result.setInformation(
-                            AccessPath.fromLocalVariable(param), Safety.mergeAssumingUnknownIsSame(declared, safety));
-                }
-            }
+            return initialStoreLambda(underlyingAst, parameters);
         } else {
+            AccessPathStore.Builder<Safety> result = AccessPathStore.<Safety>empty().toBuilder();
+
             for (LocalVariableNode param : parameters) {
                 Safety declared = SafetyAnnotations.getSafety(param.getTree(), state);
                 result.setInformation(AccessPath.fromLocalVariable(param), declared);
+            }
+
+            return result.build();
+        }
+    }
+
+    private AccessPathStore<Safety> initialStoreLambda(
+            UnderlyingAST underlyingAst, List<LocalVariableNode> parameters) {
+        AccessPathStore.Builder<Safety> result = AccessPathStore.<Safety>empty().toBuilder();
+        LambdaExpressionTree lambda = ((UnderlyingAST.CFGLambda) underlyingAst).getLambdaTree();
+
+        // We grab the inferred type of the lambda, then the argument types of the functional interface
+        //  and match them one by one with the actual parameters
+        com.sun.tools.javac.util.List<Type> parameterTypes =
+                state.getTypes().findDescriptorType(ASTHelpers.getType(lambda)).getParameterTypes();
+
+        // This is expected to be true, but let's be defensive here
+        if (parameterTypes.size() == parameters.size()) {
+            for (int i = 0; i < parameters.size(); i++) {
+                Type type = parameterTypes.get(i);
+                LocalVariableNode param = parameters.get(i);
+
+                // If the lambda itself has a safety annotation, which doesn't match the expected one from the
+                //   type it is used as, combine both
+                Safety declared = SafetyAnnotations.getSafety(param.getTree(), state);
+                Safety safety = SafetyAnnotations.getSafety(type, state);
+                result.setInformation(
+                        AccessPath.fromLocalVariable(param), Safety.mergeAssumingUnknownIsSame(declared, safety));
             }
         }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -315,8 +315,38 @@ class IllegalSafeLoggingLambdaTest {
                             // result is 'UNSAFE' but the lambda expects return 'SAFE'.
                             Function<@Unsafe String, @Safe String> func = in -> in;
                           }
+                        }
+                        """)
+                .doTest();
+    }
 
-                          static void fun(Supplier<@Safe Object> in) {}
+    @Test
+    void testFunctionalInterfaceSafeType() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        interface F<T, U, V> {
+                          V apply(T t, U u);
+                        }
+
+                        class Test {
+                          static void f(@Unsafe Object value) {
+                            F<@Unsafe String, @Safe String, @Safe String> func =
+                                (s1, s2) -> {
+                                  if (s1 == null) {
+                                    // This is safe
+                                    return s2;
+                                  } else {
+                                    // BUG: Diagnostic contains: Dangerous return value:
+                                    // result is 'UNSAFE' but the lambda expects return 'SAFE'.
+                                    return s1;
+                                  }
+                                };
+                          }
                         }
                         """)
                 .doTest();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -352,6 +352,34 @@ class IllegalSafeLoggingLambdaTest {
                 .doTest();
     }
 
+    @Test
+    void testLambdaConsumesSafetyAnnotatedType_expression() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.function.*;",
+                        "class Test {",
+                        "  // BUG: Diagnostic contains: Dangerous",
+                        "  Consumer<@Unsafe String> func = in -> fun(in);",
+                        "  void fun(@Safe Object ob) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testLambdaConsumesSafetyAnnotatedType_statement() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import com.palantir.logsafe.*;",
+                        "import java.util.function.*;",
+                        "class Test {",
+                        "  // BUG: Diagnostic contains: Dangerous",
+                        "  Consumer<@Unsafe String> func = in -> { fun(in); };",
+                        "  void fun(@Safe Object ob) {}",
+                        "}")
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -356,13 +356,19 @@ class IllegalSafeLoggingLambdaTest {
     void testLambdaConsumesSafetyAnnotatedType_expression() {
         helper().addSourceLines(
                         "Test.java",
-                        "import com.palantir.logsafe.*;",
-                        "import java.util.function.*;",
-                        "class Test {",
-                        "  // BUG: Diagnostic contains: Dangerous",
-                        "  Consumer<@Unsafe String> func = in -> fun(in);",
-                        "  void fun(@Safe Object ob) {}",
-                        "}")
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          // BUG: Diagnostic contains: Dangerous argument value:
+                          // arg is 'UNSAFE' but the parameter requires 'SAFE'.
+                          Consumer<@Unsafe String> func = in -> fun(in);
+
+                          void fun(@Safe Object ob) {}
+                        }
+                        """)
                 .doTest();
     }
 
@@ -370,13 +376,22 @@ class IllegalSafeLoggingLambdaTest {
     void testLambdaConsumesSafetyAnnotatedType_statement() {
         helper().addSourceLines(
                         "Test.java",
-                        "import com.palantir.logsafe.*;",
-                        "import java.util.function.*;",
-                        "class Test {",
-                        "  // BUG: Diagnostic contains: Dangerous",
-                        "  Consumer<@Unsafe String> func = in -> { fun(in); };",
-                        "  void fun(@Safe Object ob) {}",
-                        "}")
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          Consumer<@Unsafe String> func =
+                              in -> {
+                                // BUG: Diagnostic contains: Dangerous argument value:
+                                // arg is 'UNSAFE' but the parameter requires 'SAFE'.
+                                fun(in);
+                              };
+
+                          void fun(@Safe Object ob) {}
+                        }
+                        """)
                 .doTest();
     }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -300,6 +300,28 @@ class IllegalSafeLoggingLambdaTest {
                 .doTest();
     }
 
+    @Test
+    void testFunctionSafeType() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          static void f(@Unsafe Object value) {
+                            // BUG: Diagnostic contains: Dangerous return value:
+                            // result is 'UNSAFE' but the lambda expects return 'SAFE'.
+                            Function<@Unsafe String, @Safe String> func = in -> in;
+                          }
+
+                          static void fun(Supplier<@Safe Object> in) {}
+                        }
+                        """)
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/changelog/@unreleased/pr-3050.v2.yml
+++ b/changelog/@unreleased/pr-3050.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[Safe-logging] Infer lambda parameter safety from surrounding context'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3050


### PR DESCRIPTION
## Before this PR
Using a lambda's parameter as safe when we know it is unsafe isn't caught.

Unfortunately, the lambda parameter types passed in `SafetyPropagationTransfer#initialStore` from `ForwardAnalysisImpl#getParameters` don't seem to contain the type annotations. However, they are present in the `underlyingAst` argument which is also given, so we can instead recompute the argument safety from the expected lambda type.

## After this PR
Builds on top of https://github.com/palantir/gradle-baseline/pull/3048, which handles checking the returned values in a lambda

==COMMIT_MSG==
[Safe-logging] Infer lambda parameter safety from surrounding context
==COMMIT_MSG==

## Possible downsides?


