### PR TITLE
[Safe-logging] Verify member reference type parameters when cast to functional interface

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -502,52 +502,85 @@ public final class IllegalSafeLoggingArgument extends BugChecker
 
     @Override
     public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
-        // This is the type the reference gets "cast" into, whether through assignment, return type, argument, etc
-        Type castType = state.getTypes().findDescriptorType(ASTHelpers.getType(tree));
-        // The reference will be used as the expected type. This means:
-        //   * the safety of the return type of the expected must be "lower" than the actual safety of the reference
-        //   * the safety of the arguments of the expected must be "higher" than the actual safety of the reference
-        // i.e. "Supplier<@Safe String> f = this::method" shouldn't be allowed, when method returns unsafe
-        // Similarly, "@Consumer<@Unsafe String> f = this::method" shouldn't be allowed, when method expects to take a
-        //   safe argument (since it might log it)
+        Type type = ASTHelpers.getType(tree);
+        if (type == null) {
+            return Description.NO_MATCH;
+        }
 
-        Safety castTypeReturnSafety = SafetyAnnotations.getSafety(castType.getReturnType(), state);
+        // This is the type the reference gets "cast" into, whether through assignment, return type, argument, etc
+        Type castType = state.getTypes().findDescriptorType(type);
+        if (castType == null) {
+            return Description.NO_MATCH;
+        }
 
         MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
+
+        // These methods rely on state.reportMatch to report all failures in one pass if multiple are found
+        handleMemberReferenceReturnType(tree, castType, methodSymbol, state);
+        handleMemberReferenceParameterTypes(tree, castType, methodSymbol, state);
+
+        return Description.NO_MATCH;
+    }
+
+    /**
+     * Verifies the return type of a method reference, when cast to a different type.
+     *
+     * This means that we expect the cast type's return type safety and will use it as such.
+     * If e.g. the cast type says it will return SAFE, but the reference returns UNSAFE, that's a problem.
+     * On the other hand, if the cast returns UNSAFE and the reference returns SAFE, that's fine.
+     */
+    private void handleMemberReferenceReturnType(
+            MemberReferenceTree tree, Type castType, MethodSymbol methodSymbol, VisitorState state) {
+        Safety castTypeReturnSafety = SafetyAnnotations.getSafety(castType.getReturnType(), state);
+
+        if (castTypeReturnSafety.allowsAll()) {
+            // Fast path - the type we're casting to allows all values (unknown or do-not-log), so we don't need to
+            //   check further
+            return;
+        }
+
         Safety referenceReturnSafety = Safety.mergeAssumingUnknownIsSame(
                 // This gets the combined safety annotations of the method and any of its supers
                 SafetyAnnotations.getSafety(methodSymbol, state),
                 SafetyAnnotations.getSafety(methodSymbol.getReturnType(), state));
 
-        // The reference will get used as the cast type
-        // This means that we expect the cast type's return type safety and will use it as such
-        // If e.g. the cast type says it will return SAFE, but the reference returns UNSAFE, that's a problem
-        // On the other hand, if the cast returns UNSAFE and the reference returns SAFE, that's fine
         if (!castTypeReturnSafety.allowsValueWith(referenceReturnSafety)) {
-            return buildDescription(tree)
+            state.reportMatch(buildDescription(tree)
                     .setMessage(String.format(
                             "Dangerous method reference: expected return type '%s' but the reference returns '%s'.",
                             castTypeReturnSafety, referenceReturnSafety))
-                    .build();
+                    .build());
         }
+    }
 
+    /**
+     * Verifies the parameter types of a method reference, when cast to a different type.
+     *
+     * This is similar to the return type check {@link #handleMemberReferenceReturnType}, but for each parameter.
+     * In this case, the requirement is reversed.
+     *
+     * If the cast type says it accepts an UNSAFE parameter, but the reference needs a SAFE one, then this should break.
+     * If the cast type accepts SAFE, and the reference needs UNSAFE, that's fine, since we're less permissive.
+     */
+    private void handleMemberReferenceParameterTypes(
+            MemberReferenceTree tree, Type castType, MethodSymbol methodSymbol, VisitorState state) {
         if (methodSymbol.getParameters().size() != castType.getParameterTypes().size()) {
             // This is unexpected, as the code should pass compilation - we don't know how to handle it, so just ignore
-            return Description.NO_MATCH;
+            return;
         }
 
-        // This is similar to the return type check, but for each parameter
-        // In this case, the requirement is reversed
-        // If the cast type says it accepts an UNSAFE parameter, but the reference needs a SAFE one,
-        //   then this should break
-        // If the cast type accepts SAFE, and the reference needs UNSAFE, that's fine, since we're less permissive
         for (int i = 0; i < methodSymbol.getParameters().size(); i++) {
-            Type expectedParameterType = castType.getParameterTypes().get(i);
-            Safety expectedParameterSafety = SafetyAnnotations.getSafety(expectedParameterType, state);
-
             VarSymbol parameter = methodSymbol.getParameters().get(i);
             Type referenceParameterType = parameter.type;
             Safety referenceParameterSafety = SafetyAnnotations.getSafety(referenceParameterType, state);
+            if (referenceParameterSafety.allowsAll()) {
+                // Fast path - the method reference allows all arguments for the parameter, so we don't need to check
+                //   further
+                continue;
+            }
+
+            Type expectedParameterType = castType.getParameterTypes().get(i);
+            Safety expectedParameterSafety = SafetyAnnotations.getSafety(expectedParameterType, state);
 
             if (!referenceParameterSafety.allowsValueWith(expectedParameterSafety)) {
                 // use state.reportMatch to report all failing arguments if multiple are invalid
@@ -559,7 +592,5 @@ public final class IllegalSafeLoggingArgument extends BugChecker
                         .build());
             }
         }
-
-        return Description.NO_MATCH;
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -35,6 +35,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
@@ -81,7 +82,8 @@ public final class IllegalSafeLoggingArgument extends BugChecker
                 BugChecker.VariableTreeMatcher,
                 BugChecker.NewClassTreeMatcher,
                 BugChecker.ClassTreeMatcher,
-                BugChecker.LambdaExpressionTreeMatcher {
+                BugChecker.LambdaExpressionTreeMatcher,
+                BugChecker.MemberReferenceTreeMatcher {
 
     private static final String UNSAFE_ARG = "com.palantir.logsafe.UnsafeArg";
     private static final Matcher<ExpressionTree> SAFE_ARG_OF_METHOD_MATCHER = MethodMatchers.staticMethod()
@@ -496,5 +498,60 @@ public final class IllegalSafeLoggingArgument extends BugChecker
             return Safety.UNKNOWN;
         }
         return SafetyAnnotations.getSafety(returnType.type(), state);
+    }
+
+    @Override
+    public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
+        Type expectedReferenceType = state.getTypes().findDescriptorType(ASTHelpers.getType(tree));
+        // The reference will be used as the expected type. This means:
+        //   * the safety of the return type of the expected must be "lower" than the actual safety of the reference
+        //   * the safety of the arguments of the expected must be "higher" than the actual safety of the reference
+        // i.e. "Supplier<@Safe String> f = this::method" shouldn't be allowed, when method returns unsafe
+        // Similarly, "@Consumer<@Unsafe String> f = this::method" shouldn't be allowed, when method expects to take a
+        //   safe argument (since it might log it)
+
+        Safety expectedReturnTypeSafety = SafetyAnnotations.getSafety(expectedReferenceType.getReturnType(), state);
+
+        // TODO: test method combined safety (super methods, class return type, etc)
+        MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
+        Safety referenceReturnTypeSafety = Safety.mergeAssumingUnknownIsSame(
+                SafetyAnnotations.getDirectSafety(methodSymbol, state),
+                SafetyAnnotations.getSafety(methodSymbol.getReturnType(), state));
+
+        if (!expectedReturnTypeSafety.allowsValueWith(referenceReturnTypeSafety)) {
+            return buildDescription(tree)
+                    .setMessage(String.format(
+                            "Dangerous method reference: expected return type '%s' but the reference returns '%s'.",
+                            expectedReturnTypeSafety, referenceReturnTypeSafety))
+                    .build();
+        }
+
+        if (methodSymbol.getParameters().size()
+                != expectedReferenceType.getParameterTypes().size()) {
+            // This is unexpected, as this should pass compilation - we don't know how to handle it, so just ignore
+            return Description.NO_MATCH;
+        }
+
+        // TODO: test multiple params
+        for (int i = 0; i < methodSymbol.getParameters().size(); i++) {
+            Type expectedParameterType =
+                    expectedReferenceType.getParameterTypes().get(i);
+            Safety expectedParameterSafety = SafetyAnnotations.getSafety(expectedParameterType, state);
+
+            VarSymbol parameter = methodSymbol.getParameters().get(i);
+            Type referenceParameterType = parameter.type;
+            Safety referenceParameterSafety = SafetyAnnotations.getSafety(referenceParameterType, state);
+
+            if (!referenceParameterSafety.allowsValueWith(expectedParameterSafety)) {
+                state.reportMatch(buildDescription(tree)
+                        .setMessage(String.format(
+                                "Dangerous method reference: method reference expects argument %d with safety '%s', "
+                                        + "but will be passed '%s'",
+                                i, referenceParameterSafety, expectedParameterSafety))
+                        .build());
+            }
+        }
+
+        return Description.NO_MATCH;
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -502,7 +502,8 @@ public final class IllegalSafeLoggingArgument extends BugChecker
 
     @Override
     public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
-        Type expectedReferenceType = state.getTypes().findDescriptorType(ASTHelpers.getType(tree));
+        // This is the type the reference gets "cast" into, whether through assignment, return type, argument, etc
+        Type castType = state.getTypes().findDescriptorType(ASTHelpers.getType(tree));
         // The reference will be used as the expected type. This means:
         //   * the safety of the return type of the expected must be "lower" than the actual safety of the reference
         //   * the safety of the arguments of the expected must be "higher" than the actual safety of the reference
@@ -510,31 +511,38 @@ public final class IllegalSafeLoggingArgument extends BugChecker
         // Similarly, "@Consumer<@Unsafe String> f = this::method" shouldn't be allowed, when method expects to take a
         //   safe argument (since it might log it)
 
-        Safety expectedReturnTypeSafety = SafetyAnnotations.getSafety(expectedReferenceType.getReturnType(), state);
+        Safety castTypeReturnSafety = SafetyAnnotations.getSafety(castType.getReturnType(), state);
 
         MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
-        Safety referenceReturnTypeSafety = Safety.mergeAssumingUnknownIsSame(
+        Safety referenceReturnSafety = Safety.mergeAssumingUnknownIsSame(
                 // This gets the combined safety annotations of the method and any of its supers
                 SafetyAnnotations.getSafety(methodSymbol, state),
                 SafetyAnnotations.getSafety(methodSymbol.getReturnType(), state));
 
-        if (!expectedReturnTypeSafety.allowsValueWith(referenceReturnTypeSafety)) {
+        // The reference will get used as the cast type
+        // This means that we expect the cast type's return type safety and will use it as such
+        // If e.g. the cast type says it will return SAFE, but the reference returns UNSAFE, that's a problem
+        // On the other hand, if the cast returns UNSAFE and the reference returns SAFE, that's fine
+        if (!castTypeReturnSafety.allowsValueWith(referenceReturnSafety)) {
             return buildDescription(tree)
                     .setMessage(String.format(
                             "Dangerous method reference: expected return type '%s' but the reference returns '%s'.",
-                            expectedReturnTypeSafety, referenceReturnTypeSafety))
+                            castTypeReturnSafety, referenceReturnSafety))
                     .build();
         }
 
-        if (methodSymbol.getParameters().size()
-                != expectedReferenceType.getParameterTypes().size()) {
-            // This is unexpected, as this should pass compilation - we don't know how to handle it, so just ignore
+        if (methodSymbol.getParameters().size() != castType.getParameterTypes().size()) {
+            // This is unexpected, as the code should pass compilation - we don't know how to handle it, so just ignore
             return Description.NO_MATCH;
         }
 
+        // This is similar to the return type check, but for each parameter
+        // In this case, the requirement is reversed
+        // If the cast type says it accepts an UNSAFE parameter, but the reference needs a SAFE one,
+        //   then this should break
+        // If the cast type accepts SAFE, and the reference needs UNSAFE, that's fine, since we're less permissive
         for (int i = 0; i < methodSymbol.getParameters().size(); i++) {
-            Type expectedParameterType =
-                    expectedReferenceType.getParameterTypes().get(i);
+            Type expectedParameterType = castType.getParameterTypes().get(i);
             Safety expectedParameterSafety = SafetyAnnotations.getSafety(expectedParameterType, state);
 
             VarSymbol parameter = methodSymbol.getParameters().get(i);
@@ -542,6 +550,7 @@ public final class IllegalSafeLoggingArgument extends BugChecker
             Safety referenceParameterSafety = SafetyAnnotations.getSafety(referenceParameterType, state);
 
             if (!referenceParameterSafety.allowsValueWith(expectedParameterSafety)) {
+                // use state.reportMatch to report all failing arguments if multiple are invalid
                 state.reportMatch(buildDescription(tree)
                         .setMessage(String.format(
                                 "Dangerous method reference: method reference expects argument %d with safety '%s', "

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgument.java
@@ -512,10 +512,10 @@ public final class IllegalSafeLoggingArgument extends BugChecker
 
         Safety expectedReturnTypeSafety = SafetyAnnotations.getSafety(expectedReferenceType.getReturnType(), state);
 
-        // TODO: test method combined safety (super methods, class return type, etc)
         MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
         Safety referenceReturnTypeSafety = Safety.mergeAssumingUnknownIsSame(
-                SafetyAnnotations.getDirectSafety(methodSymbol, state),
+                // This gets the combined safety annotations of the method and any of its supers
+                SafetyAnnotations.getSafety(methodSymbol, state),
                 SafetyAnnotations.getSafety(methodSymbol.getReturnType(), state));
 
         if (!expectedReturnTypeSafety.allowsValueWith(referenceReturnTypeSafety)) {
@@ -532,7 +532,6 @@ public final class IllegalSafeLoggingArgument extends BugChecker
             return Description.NO_MATCH;
         }
 
-        // TODO: test multiple params
         for (int i = 0; i < methodSymbol.getParameters().size(); i++) {
             Type expectedParameterType =
                     expectedReferenceType.getParameterTypes().get(i);

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -524,12 +524,19 @@ class IllegalSafeLoggingLambdaTest {
                         class MyObject {}
 
                         class Test {
-                          // BUG: Diagnostic contains: Dangerous method reference:
-                          // expected return type 'SAFE' but the reference returns 'UNSAFE'.
-                          Supplier<@Safe MyObject> func = this::fun;
-
                           MyObject fun() {
                             return new MyObject();
+                          }
+
+                          void f(@Safe Object o) {}
+
+                          void g() {
+                            // This passes the tests currently, but isn't a huge deal since the type itself is annotated
+                            // and the Safe annotation doesn't prevent us from catching the issue on usage below.
+                            Supplier<@Safe MyObject> func = this::fun;
+                            // BUG: Diagnostic contains: Dangerous argument value:
+                            // arg is 'UNSAFE' but the parameter requires 'SAFE'.
+                            f(func.get());
                           }
                         }
                         """)

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -396,7 +396,7 @@ class IllegalSafeLoggingLambdaTest {
     }
 
     @Test
-    void testLambdaConsumesSafetyAnnotatedType_reference() {
+    void testMemberReferenceParameterType() {
         helper().addSourceLines(
                         "Test.java",
                         // language=Java
@@ -416,7 +416,80 @@ class IllegalSafeLoggingLambdaTest {
     }
 
     @Test
-    void testLambdaProducesSafetyAnnotatedType_reference() {
+    void testMemberReferenceAsMethodReturn() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          void fun(@Safe Object ob) {}
+
+                          Consumer<@Unsafe String> getFunc() {
+                            // BUG: Diagnostic contains: Dangerous method reference:
+                            // method reference expects argument 0 with safety 'SAFE', but will be passed 'UNSAFE'
+                            return this::fun;
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    void testMemberReferenceAsMethodArgument() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          void fun(@Safe Object ob) {}
+
+                          void callFunc(Consumer<@Unsafe String> func) {}
+
+                          void f(@Unsafe Object value) {
+                            // BUG: Diagnostic contains: Dangerous method reference:
+                            // method reference expects argument 0 with safety 'SAFE', but will be passed 'UNSAFE'
+                            callFunc(this::fun);
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    void testMemberReferenceMultipleParameters() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          // BUG: Diagnostic contains: Dangerous method reference:
+                          // method reference expects argument 1 with safety 'SAFE', but will be passed 'UNSAFE'
+                          BiConsumer<@Unsafe String, @Unsafe String> func = this::fun;
+
+                          // BUG: Diagnostic contains: Dangerous method reference:
+                          // method reference expects argument 1 with safety 'SAFE', but will be passed 'UNSAFE'
+                          BiConsumer<@Safe String, @Unsafe String> func2 = this::fun;
+
+                          // This is fine
+                          BiConsumer<@Safe String, @Safe String> func3 = this::fun;
+
+                          void fun(@Unsafe Object ob, @Safe Object ob2) {}
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    void testMemberReferenceMethodAnnotation() {
         helper().addSourceLines(
                         "Test.java",
                         // language=Java
@@ -431,6 +504,95 @@ class IllegalSafeLoggingLambdaTest {
 
                           @Unsafe
                           String fun() {
+                            return "unsafe";
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    void testMemberReferenceReturnType() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        @Unsafe
+                        class MyObject {}
+
+                        class Test {
+                          // BUG: Diagnostic contains: Dangerous method reference:
+                          // expected return type 'SAFE' but the reference returns 'UNSAFE'.
+                          Supplier<@Safe MyObject> func = this::fun;
+
+                          MyObject fun() {
+                            return new MyObject();
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    void testMemberReferenceInheritedSafety() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        interface MyInterface {
+                          @Unsafe
+                          String fun();
+                        }
+
+                        class Test implements MyInterface {
+                          // BUG: Diagnostic contains: Dangerous method reference:
+                          // expected return type 'SAFE' but the reference returns 'UNSAFE'.
+                          Supplier<@Safe String> func = this::fun;
+
+                          public String fun() {
+                            return "unsafe";
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    void testMemberReferenceInheritedDiamondSafety() {
+        // Note: Diamond inheritance with conflicting safety types is prevented and covered
+        //   by IllegalSafeLoggingArgumentTest#testDiamondMethodSafetyInheritance
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        interface MyInterface {
+                          @Unsafe
+                          String fun();
+                        }
+
+                        interface MySafeInterface extends MyInterface {
+                          String fun();
+                        }
+
+                        interface MyUnsafeInterface extends MyInterface {
+                          String fun();
+                        }
+
+                        class Test implements MySafeInterface, MyUnsafeInterface {
+                          // BUG: Diagnostic contains: Dangerous method reference:
+                          // expected return type 'SAFE' but the reference returns 'UNSAFE'.
+                          Supplier<@Safe String> func = this::fun;
+
+                          public String fun() {
                             return "unsafe";
                           }
                         }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -395,6 +395,49 @@ class IllegalSafeLoggingLambdaTest {
                 .doTest();
     }
 
+    @Test
+    void testLambdaConsumesSafetyAnnotatedType_reference() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          // BUG: Diagnostic contains: Dangerous method reference:
+                          // method reference expects argument 0 with safety 'SAFE', but will be passed 'UNSAFE'
+                          Consumer<@Unsafe String> func = this::fun;
+
+                          void fun(@Safe Object ob) {}
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
+    void testLambdaProducesSafetyAnnotatedType_reference() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+
+                        class Test {
+                          // BUG: Diagnostic contains: Dangerous method reference:
+                          // expected return type 'SAFE' but the reference returns 'UNSAFE'.
+                          Supplier<@Safe String> func = this::fun;
+
+                          @Unsafe
+                          String fun() {
+                            return "unsafe";
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingLambdaTest.java
@@ -607,6 +607,29 @@ class IllegalSafeLoggingLambdaTest {
                 .doTest();
     }
 
+    @Test
+    public void testMemberReferenceUnsafeOptionalReturn() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+                        import java.util.*;
+
+                        class Test {
+                          // BUG: Diagnostic contains: Dangerous method reference:
+                          // expected return type 'SAFE' but the reference returns 'UNSAFE'.
+                          Supplier<Optional<@Safe String>> func = this::fun;
+
+                          public Optional<@Unsafe String> fun() {
+                            return Optional.of("unsafe");
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(IllegalSafeLoggingArgument.class, getClass());
     }

--- a/changelog/@unreleased/pr-3052.v2.yml
+++ b/changelog/@unreleased/pr-3052.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '[Safe-logging] Verify member reference type parameters when cast to
+    functional interface'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3052


### PR DESCRIPTION
## Before this PR
Passing a member reference as a lambda will currently not catch cases where the type it gets passed to has different requirements around safety of the return or parameter types.

## After this PR
==COMMIT_MSG==
[Safe-logging] Verify member reference type parameters when cast to functional interface
==COMMIT_MSG==

This is done by comparing the safety between the method reference and the functional interface it gets cast into, and verifying that:
- The interface's return type safety is _less safe_ than the method reference
  - This means you can do e.g. `Supplier<@Unsafe String> f = this::fun` when `fun` returns `@Safe`, but not `@Supplier<@Safe String> f = this::fun` when `fun` returns `@Unsafe`, as in the latter case, you would then start using the unsafe result from `fun` as safe when calling `f`
- The interface's argument's type safety is _more safe_ than the method reference
  - This means you can do e.g. `Consumer<@Safe String> f = this::fun` when `fun` takes an `@Unsafe`, but not `Consumer<@Unsafe String> f = this::fun` when `fun` takes a `@Safe`, as otherwise calling `f.accept(s)` would let you pass an unsafe string to `fun`

To summarize:
**Allowed**
```java
import com.palantir.logsafe.*;
import java.util.function.*;

class Test {
  Supplier<@Unsafe String> func = this::fun;

  @Safe
  String fun() {
    return "safe";
  }
}
```

```java
import com.palantir.logsafe.*;
import java.util.function.*;

class Test {
  Consumer<@Safe String> func = this::fun;

  void fun(@Unsafe Object ob) {}
}
```

**Forbidden**
```java
import com.palantir.logsafe.*;
import java.util.function.*;

class Test {
  Supplier<@Safe String> func = this::fun;

  @Unsafe
  String fun() {
    return "unsafe";
  }
}
```

```java
import com.palantir.logsafe.*;
import java.util.function.*;

class Test {
  Consumer<@Unsafe String> func = this::fun;

  void fun(@Safe Object ob) {}
}
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

