### PR TITLE
Use JUnit Platform by default

### DIFF
--- a/changelog/@unreleased/pr-3053.v2.yml
+++ b/changelog/@unreleased/pr-3053.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: '`BaselineTesting` now configures tests to run using JUnit Platform
+    by default. Tests are configured using the test suites API, which ensures that
+    test framework dependencies are added automatically.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3053

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
@@ -69,6 +69,9 @@ public final class BaselineTesting implements Plugin<Project> {
                 task.dependsOn(checkJUnitDependencies);
             });
 
+            // For backwards compatibility reasons, Gradle uses the legacy JUnit4 test toolchain for the default
+            // test suite and the JUnit Platform test toolchain for everything else.
+            // We want to use junit jupiter by default for the default test suite.
             testingExtension
                     .getSuites()
                     .named(
@@ -76,11 +79,16 @@ public final class BaselineTesting implements Plugin<Project> {
                             JvmTestSuite.class,
                             JvmTestSuite::useJUnitJupiter);
 
+            // Gradle <8 does not automatically add junit toolchain deps. When the test-sets plugin is used instead
+            // of jvm-test-suites, these deps are not added either. We make sure that we lazily add these deps to
+            // the correct configurations if required. Note: we can't lazily configure test tasks or test suite then
+            // add the dependencies in that configuration action, as the Configurations may be resolved before the
+            // tasks/suites are realised, hence we have to work from the Configurations directly.
+            // See https://github.com/gradle/gradle/pull/26369
             project.getConfigurations().configureEach(configuration -> {
                 configuration.getDependencies().addAllLater(project.provider(() -> {
                     return testSourceSetsWhereJunitToolchainDepsHaveNotBeenAutomaticallyAdded(project)
                             .flatMap(sourceSet -> {
-                                // See https://github.com/gradle/gradle/pull/26369
                                 if (configuration.getName().equals(sourceSet.getImplementationConfigurationName())) {
                                     return Stream.of(project.getDependencies().create(JUNIT_JUPITER));
                                 }
@@ -109,28 +117,6 @@ public final class BaselineTesting implements Plugin<Project> {
         });
     }
 
-    private static Stream<SourceSet> testSourceSetsWhereJunitToolchainDepsHaveNotBeenAutomaticallyAdded(
-            Project project) {
-
-        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
-        TestingExtension testingExtension = project.getExtensions().getByType(TestingExtension.class);
-
-        // Gradle <8 does not automatically add junit toolchain deps - see https://github.com/gradle/gradle/pull/21919
-        boolean gradleVersionLessThan8 = GradleVersion.current().compareTo(GRADLE_8) < 0;
-
-        return project.getTasks().withType(Test.class).getNames().stream().flatMap(testTaskName -> {
-            if (gradleVersionLessThan8 || testTaskNotCreatedByJvmTestSuites(testingExtension, testTaskName)) {
-                return Stream.of(sourceSets.getByName(testTaskName));
-            }
-
-            return Stream.empty();
-        });
-    }
-
-    private static boolean testTaskNotCreatedByJvmTestSuites(TestingExtension testingExtension, String testTaskName) {
-        return !testingExtension.getSuites().getNames().contains(testTaskName);
-    }
-
     private void configureTestTask(Test task) {
         task.systemProperty("junit.platform.output.capture.stdout", "true");
         task.systemProperty("junit.platform.output.capture.stderr", "true");
@@ -153,5 +139,27 @@ public final class BaselineTesting implements Plugin<Project> {
                     .getEvents()
                     .addAll(Set.of(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED));
         }
+    }
+
+    private static Stream<SourceSet> testSourceSetsWhereJunitToolchainDepsHaveNotBeenAutomaticallyAdded(
+            Project project) {
+
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        TestingExtension testingExtension = project.getExtensions().getByType(TestingExtension.class);
+
+        // Gradle <8 does not automatically add junit toolchain deps - see https://github.com/gradle/gradle/pull/21919
+        boolean gradleVersionLessThan8 = GradleVersion.current().compareTo(GRADLE_8) < 0;
+
+        return project.getTasks().withType(Test.class).getNames().stream().flatMap(testTaskName -> {
+            if (gradleVersionLessThan8 || testTaskNotCreatedByJvmTestSuites(testingExtension, testTaskName)) {
+                return Stream.of(sourceSets.getByName(testTaskName));
+            }
+
+            return Stream.empty();
+        });
+    }
+
+    private static boolean testTaskNotCreatedByJvmTestSuites(TestingExtension testingExtension, String testTaskName) {
+        return !testingExtension.getSuites().getNames().contains(testTaskName);
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
@@ -19,13 +19,13 @@ package com.palantir.baseline.plugins;
 import com.palantir.baseline.tasks.CheckJUnitDependencies;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.JvmTestSuitePlugin;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.logging.TestLogEvent;
@@ -60,7 +60,6 @@ public final class BaselineTesting implements Plugin<Project> {
         });
 
         project.getPluginManager().withPlugin("java", unusedPlugin -> {
-            JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
             TestingExtension testingExtension = project.getExtensions().getByType(TestingExtension.class);
 
             TaskProvider<CheckJUnitDependencies> checkJUnitDependencies =
@@ -72,44 +71,64 @@ public final class BaselineTesting implements Plugin<Project> {
 
             testingExtension
                     .getSuites()
-                    .named(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME, JvmTestSuite.class, testSuite -> {
-                        testSuite.useJUnitJupiter();
-                    });
+                    .named(
+                            JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME,
+                            JvmTestSuite.class,
+                            JvmTestSuite::useJUnitJupiter);
 
-            javaPluginExtension.getSourceSets().configureEach(sourceSet -> {
-                TaskCollection<Test> testTasks = project.getTasks()
-                        .withType(Test.class)
-                        .matching(task -> task.getName().equals(sourceSet.getName()));
+            project.getConfigurations().configureEach(configuration -> {
+                configuration.getDependencies().addAllLater(project.provider(() -> {
+                    return testSourceSetsWhereJunitToolchainDepsHaveNotBeenAutomaticallyAdded(project)
+                            .flatMap(sourceSet -> {
+                                // See https://github.com/gradle/gradle/pull/26369
+                                if (configuration.getName().equals(sourceSet.getImplementationConfigurationName())) {
+                                    return Stream.of(project.getDependencies().create(JUNIT_JUPITER));
+                                }
 
-                // We must eagerly create the test task in order to add the junit-platform-launcher dependency.
-                // Otherwise the dependencies will already have been resolved by the time we create the test task.
-                testTasks.all(task -> {
-                    // See https://github.com/gradle/gradle/pull/21919
-                    if (GradleVersion.current().compareTo(GRADLE_8) < 0) {
-                        addJUnitJupiterTestToolchainDependencies(project, sourceSet);
-                    }
+                                if (configuration.getName().equals(sourceSet.getRuntimeOnlyConfigurationName())) {
+                                    return Stream.of(project.getDependencies().create(JUNIT_PLATFORM_LAUNCHER));
+                                }
 
-                    // For test tasks not created using test suites, we must explicitly the test to use JUnit Platform
-                    // and add the junit-platform-launcher dependency.
-                    if (testingExtension.getSuites().findByName(sourceSet.getName()) == null) {
-                        task.useJUnitPlatform();
-                        addJUnitJupiterTestToolchainDependencies(project, sourceSet);
-                    }
-                });
+                                return Stream.empty();
+                            })
+                            .toList();
+                }));
+            });
 
-                testTasks.configureEach(task -> {
-                    configureTestTask(task);
+            project.getTasks().withType(Test.class).configureEach(task -> {
+                configureTestTask(task);
 
-                    task.dependsOn(checkJUnitDependencies);
-                });
+                task.dependsOn(checkJUnitDependencies);
+
+                // For test tasks not created using test suites (ie using the old unbroken dome test-suites plugin),
+                // we must explicitly use the JUnit Platform
+                if (testTaskNotCreatedByJvmTestSuites(testingExtension, task.getName())) {
+                    task.useJUnitPlatform();
+                }
             });
         });
     }
 
-    private void addJUnitJupiterTestToolchainDependencies(Project project, SourceSet sourceSet) {
-        // See https://github.com/gradle/gradle/pull/26369
-        project.getDependencies().add(sourceSet.getImplementationConfigurationName(), JUNIT_JUPITER);
-        project.getDependencies().add(sourceSet.getRuntimeOnlyConfigurationName(), JUNIT_PLATFORM_LAUNCHER);
+    private static Stream<SourceSet> testSourceSetsWhereJunitToolchainDepsHaveNotBeenAutomaticallyAdded(
+            Project project) {
+
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        TestingExtension testingExtension = project.getExtensions().getByType(TestingExtension.class);
+
+        // Gradle <8 does not automatically add junit toolchain deps - see https://github.com/gradle/gradle/pull/21919
+        boolean gradleVersionLessThan8 = GradleVersion.current().compareTo(GRADLE_8) < 0;
+
+        return project.getTasks().withType(Test.class).getNames().stream().flatMap(testTaskName -> {
+            if (gradleVersionLessThan8 || testTaskNotCreatedByJvmTestSuites(testingExtension, testTaskName)) {
+                return Stream.of(sourceSets.getByName(testTaskName));
+            }
+
+            return Stream.empty();
+        });
+    }
+
+    private static boolean testTaskNotCreatedByJvmTestSuites(TestingExtension testingExtension, String testTaskName) {
+        return !testingExtension.getSuites().getNames().contains(testTaskName);
     }
 
     private void configureTestTask(Test task) {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
@@ -100,8 +100,6 @@ public final class BaselineTesting implements Plugin<Project> {
             project.getTasks().withType(Test.class).configureEach(task -> {
                 configureTestTask(task);
 
-                task.dependsOn(checkJUnitDependencies);
-
                 // For test tasks not created using test suites (ie using the old unbroken dome test-suites plugin),
                 // we must explicitly use the JUnit Platform
                 if (testTaskNotCreatedByJvmTestSuites(testingExtension, task.getName())) {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
@@ -16,34 +16,29 @@
 
 package com.palantir.baseline.plugins;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableSet;
 import com.palantir.baseline.tasks.CheckJUnitDependencies;
-import com.palantir.baseline.util.VersionUtils;
-import java.lang.reflect.Method;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.provider.Property;
+import org.gradle.api.plugins.JvmTestSuitePlugin;
+import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.api.tasks.testing.TestFrameworkOptions;
-import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
 import org.gradle.api.tasks.testing.logging.TestLogEvent;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.testing.base.TestingExtension;
 import org.gradle.util.GradleVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class BaselineTesting implements Plugin<Project> {
 
-    private static final Logger log = LoggerFactory.getLogger(BaselineTesting.class);
+    private static final GradleVersion GRADLE_8 = GradleVersion.version("8.0");
+
+    private static final String JUNIT_JUPITER = "org.junit.jupiter:junit-jupiter";
+    private static final String JUNIT_PLATFORM_LAUNCHER = "org.junit.platform:junit-platform-launcher";
 
     @Override
     public void apply(Project project) {
@@ -64,88 +59,60 @@ public final class BaselineTesting implements Plugin<Project> {
             }
         });
 
-        project.getPluginManager().withPlugin("java-base", unusedPlugin -> {
+        project.getPluginManager().withPlugin("java", unusedPlugin -> {
+            JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+            TestingExtension testingExtension = project.getExtensions().getByType(TestingExtension.class);
+
             TaskProvider<CheckJUnitDependencies> checkJUnitDependencies =
                     project.getTasks().register("checkJUnitDependencies", CheckJUnitDependencies.class);
 
-            project.getExtensions()
-                    .getByType(JavaPluginExtension.class)
-                    .getSourceSets()
-                    .configureEach(sourceSet -> {
-                        getTestTaskForSourceSet(project, sourceSet).ifPresent(testTask -> {
-                            testTask.dependsOn(checkJUnitDependencies);
-                        });
+            project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(task -> {
+                task.dependsOn(checkJUnitDependencies);
+            });
 
-                        ifHasResolvedCompileDependenciesMatching(
-                                project,
-                                sourceSet,
-                                BaselineTesting::requiresJunitPlatform,
-                                () -> fixSourceSet(project, sourceSet));
+            testingExtension
+                    .getSuites()
+                    .named(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME, JvmTestSuite.class, testSuite -> {
+                        testSuite.useJUnitJupiter();
                     });
+
+            javaPluginExtension.getSourceSets().configureEach(sourceSet -> {
+                TaskCollection<Test> testTasks = project.getTasks()
+                        .withType(Test.class)
+                        .matching(task -> task.getName().equals(sourceSet.getName()));
+
+                // We must eagerly create the test task in order to add the junit-platform-launcher dependency.
+                // Otherwise the dependencies will already have been resolved by the time we create the test task.
+                testTasks.all(task -> {
+                    // See https://github.com/gradle/gradle/pull/21919
+                    if (GradleVersion.current().compareTo(GRADLE_8) < 0) {
+                        addJUnitJupiterTestToolchainDependencies(project, sourceSet);
+                    }
+
+                    // For test tasks not created using test suites, we must explicitly the test to use JUnit Platform
+                    // and add the junit-platform-launcher dependency.
+                    if (testingExtension.getSuites().findByName(sourceSet.getName()) == null) {
+                        task.useJUnitPlatform();
+                        addJUnitJupiterTestToolchainDependencies(project, sourceSet);
+                    }
+                });
+
+                testTasks.configureEach(task -> {
+                    configureTestTask(task);
+
+                    task.dependsOn(checkJUnitDependencies);
+                });
+            });
         });
     }
 
-    private void fixSourceSet(Project project, SourceSet ss) {
-        Optional<Test> maybeTestTask = getTestTaskForSourceSet(project, ss);
-        if (!maybeTestTask.isPresent()) {
-            log.warn("Detected 'org:junit.jupiter:junit-jupiter', but unable to find test task");
-            return;
-        }
-        log.info(
-                "Detected 'org:junit.jupiter:junit-jupiter', enabling useJUnitPlatform() on {}",
-                maybeTestTask.get().getName());
-        enableJunit5ForTestTask(maybeTestTask.get());
+    private void addJUnitJupiterTestToolchainDependencies(Project project, SourceSet sourceSet) {
+        // See https://github.com/gradle/gradle/pull/26369
+        project.getDependencies().add(sourceSet.getImplementationConfigurationName(), JUNIT_JUPITER);
+        project.getDependencies().add(sourceSet.getRuntimeOnlyConfigurationName(), JUNIT_PLATFORM_LAUNCHER);
     }
 
-    public static Optional<Test> getTestTaskForSourceSet(Project proj, SourceSet ss) {
-        String testTaskName = ss.getTaskName(null, "test");
-
-        Task task1 = proj.getTasks().findByName(testTaskName);
-        if (task1 instanceof Test) {
-            return Optional.of((Test) task1);
-        }
-
-        // unbroken dome does this
-        Task task2 = proj.getTasks().findByName(ss.getName());
-        if (task2 instanceof Test) {
-            return Optional.of((Test) task2);
-        }
-        return Optional.empty();
-    }
-
-    private static void ifHasResolvedCompileDependenciesMatching(
-            Project project, SourceSet sourceSet, Predicate<ModuleComponentIdentifier> spec, Runnable runnable) {
-        project.getConfigurations()
-                .getByName(sourceSet.getRuntimeClasspathConfigurationName())
-                .getIncoming()
-                .afterResolve(deps -> {
-                    boolean anyMatch = deps.getResolutionResult().getAllComponents().stream()
-                            .map(ResolvedComponentResult::getId)
-                            .filter(ModuleComponentIdentifier.class::isInstance)
-                            .map(ModuleComponentIdentifier.class::cast)
-                            .anyMatch(spec);
-
-                    if (anyMatch) {
-                        runnable.run();
-                    }
-                });
-    }
-
-    private static boolean requiresJunitPlatform(ModuleComponentIdentifier dep) {
-        return isDep(dep, "org.junit.jupiter", "junit-jupiter")
-                || (isDep(dep, "org.spockframework", "spock-core")
-                        && VersionUtils.majorVersionNumber(dep.getVersion()) >= 2);
-    }
-
-    private static boolean isDep(ModuleComponentIdentifier dep, String group, String name) {
-        return group.equals(dep.getGroup()) && name.equals(dep.getModule());
-    }
-
-    private static void enableJunit5ForTestTask(Test task) {
-        if (!useJUnitPlatformEnabled(task)) {
-            task.useJUnitPlatform();
-        }
-
+    private void configureTestTask(Test task) {
         task.systemProperty("junit.platform.output.capture.stdout", "true");
         task.systemProperty("junit.platform.output.capture.stderr", "true");
 
@@ -162,76 +129,10 @@ public final class BaselineTesting implements Plugin<Project> {
         // circleci 10 min deadline if there are lots of tests. Don't do this locally to avoid spamming massive
         // amount of info for people running tests through the command line. Only for non unit test tasks as unit
         // test tasks tend to be fast and avoid this issue.
-        if (!task.getName().equals("test") && "true".equals(System.getenv("CI"))) {
+        if (!task.getName().equals(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME) && "true".equals(System.getenv("CI"))) {
             task.getTestLogging()
                     .getEvents()
-                    .addAll(ImmutableSet.of(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED));
-        }
-    }
-
-    @SuppressWarnings("IllegalImports")
-    public static boolean useJUnitPlatformEnabled(Test task) {
-        // Starting with Gradle 7.3, the test framework property is getting finalized and can't be set multiple times.
-        // Using getter such as 'Test#getOptions' will set a default test framework if it is not configured yet and
-        // finalize this value. This result in errors when trying to set the test framework at a later point.
-        // For Gradle 7.3, we can actually access the test framework as a property without finalizing its value which
-        // allows us to check if it's already configured.
-        // See: https: // github.com/palantir/gradle-baseline/pull/1974
-        if (GradleVersion.current().compareTo(GradleVersion.version("7.3")) < 0) {
-            return task.getOptions() instanceof JUnitPlatformOptions;
-        }
-        return getTestFrameworkWithReflection(task)
-                .map(org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework.class::isInstance)
-                .getOrElse(false);
-    }
-
-    @SuppressWarnings("IllegalImports")
-    public static Set<String> getJUnitPlatformEngines(Test task) {
-        // Starting with Gradle 7.3, the test framework property is getting finalized and can't be set multiple times.
-        // Using getter such as 'Test#getOptions' will set a default test framework if it is not configured yet and
-        // finalize this value. This result in errors when trying to set the test framework at a later point.
-        // For Gradle 7.3, we can actually access the test framework as a property without finalizing its value which
-        // allows us to check if it's already configured.
-        // See: https: // github.com/palantir/gradle-baseline/pull/1974
-        if (GradleVersion.current().compareTo(GradleVersion.version("7.3")) < 0) {
-            TestFrameworkOptions testOpts = task.getOptions();
-            if (testOpts instanceof JUnitPlatformOptions) {
-                JUnitPlatformOptions platformOptions = (JUnitPlatformOptions) testOpts;
-                return ImmutableSet.copyOf(platformOptions.getIncludeEngines());
-            } else {
-                return ImmutableSet.of();
-            }
-        }
-        return getTestFrameworkWithReflection(task)
-                .map(framework -> {
-                    if (framework
-                            instanceof org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework) {
-                        org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework
-                                platformFramework =
-                                        (org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework)
-                                                framework;
-                        return ImmutableSet.copyOf(
-                                platformFramework.getOptions().getIncludeEngines());
-                    }
-
-                    return ImmutableSet.<String>of();
-                })
-                .getOrElse(ImmutableSet.of());
-    }
-
-    @SuppressWarnings("IllegalImports")
-    private static Property<org.gradle.api.internal.tasks.testing.TestFramework> getTestFrameworkWithReflection(
-            Test task) {
-        try {
-            Method getTestFrameworkProperty = Test.class.getMethod("getTestFrameworkProperty");
-            return (Property<org.gradle.api.internal.tasks.testing.TestFramework>)
-                    getTestFrameworkProperty.invoke(task);
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(
-                    String.format(
-                            "Error calling Test#getTestFrameworkProperty reflectively on Gradle version %s",
-                            GradleVersion.current()),
-                    e);
+                    .addAll(Set.of(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED));
         }
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
@@ -91,7 +91,9 @@ public final class BaselineTesting implements Plugin<Project> {
 
                                 return Stream.empty();
                             })
-                            .toList();
+                            .findFirst()
+                            .map(Set::of)
+                            .orElseGet(Set::of);
                 }));
             });
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
@@ -105,19 +105,17 @@ public final class BaselineTesting implements Plugin<Project> {
                 }));
             });
 
-            project.getTasks().withType(Test.class).configureEach(task -> {
-                configureTestTask(task);
-
-                // For test tasks not created using test suites (ie using the old unbroken dome test-suites plugin),
-                // we must explicitly use the JUnit Platform
-                if (testTaskNotCreatedByJvmTestSuites(testingExtension, task.getName())) {
-                    task.useJUnitPlatform();
-                }
-            });
+            project.getTasks().withType(Test.class).configureEach(task -> configureTestTask(testingExtension, task));
         });
     }
 
-    private void configureTestTask(Test task) {
+    private void configureTestTask(TestingExtension testingExtension, Test task) {
+        // For test tasks not created using test suites (ie using the old unbroken dome test-suites plugin),
+        // we must explicitly use the JUnit Platform
+        if (testTaskNotCreatedByJvmTestSuites(testingExtension, task.getName())) {
+            task.useJUnitPlatform();
+        }
+
         task.systemProperty("junit.platform.output.capture.stdout", "true");
         task.systemProperty("junit.platform.output.capture.stderr", "true");
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -16,11 +16,12 @@
 
 package com.palantir.baseline.tasks;
 
-import static com.google.common.base.Preconditions.checkState;
-
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -28,22 +29,40 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.TestFrameworkOptions;
 import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
 
-public class CheckJUnitDependencies extends DefaultTask {
+public abstract class CheckJUnitDependencies extends DefaultTask {
+    @Input
+    public abstract ListProperty<String> getErrorMessages();
 
     public CheckJUnitDependencies() {
         setGroup("Verification");
         setDescription("Ensures the correct JUnit4/5 dependencies are present, otherwise tests may silently not run");
-        getOutputs().upToDateWhen(_task -> true);
+
+        getErrorMessages().set(getProject().provider(() -> validateDependencies()));
     }
 
     @TaskAction
-    public final void validateDependencies() {
+    public final void action() {
+        List<String> errorMessages = getErrorMessages().get();
+
+        if (errorMessages.isEmpty()) {
+            return;
+        }
+
+        throw new IllegalStateException(
+                "There were %s issues:\n\n".formatted(errorMessages.size()) + String.join("\n\n", errorMessages));
+    }
+
+    private List<String> validateDependencies() {
+        List<String> errorMessages = new ArrayList<>();
+
         getProject()
                 .getExtensions()
                 .getByType(JavaPluginExtension.class)
@@ -56,12 +75,18 @@ public class CheckJUnitDependencies extends DefaultTask {
 
                     getLogger().info("Analyzing source set {} with task {}", sourceSet.getName(), task.getName());
 
-                    validateSourceSet(sourceSet, task);
+                    try {
+                        validateSourceSet(sourceSet, task);
+                    } catch (IllegalStateException e) {
+                        errorMessages.add(e.getMessage());
+                    }
                 });
+
+        return errorMessages;
     }
 
     @SuppressWarnings("CyclomaticComplexity")
-    private void validateSourceSet(SourceSet sourceSet, Test task) {
+    private void validateSourceSet(SourceSet sourceSet, Test task) throws IllegalStateException {
         Set<ResolvedComponentResult> deps = getProject()
                 .getConfigurations()
                 .getByName(sourceSet.getRuntimeClasspathConfigurationName())
@@ -82,7 +107,7 @@ public class CheckJUnitDependencies extends DefaultTask {
 
         if (options instanceof JUnitPlatformOptions) {
             if (usesJUnit4) {
-                checkState(
+                Preconditions.checkState(
                         hasVintageEngine,
                         """
                         Some tests use JUnit4, but the '%s' task is not using the JUnit Vintage engine. \
@@ -96,7 +121,7 @@ public class CheckJUnitDependencies extends DefaultTask {
             }
 
             if (usesJUnit5) {
-                checkState(
+                Preconditions.checkState(
                         hasJunitJupiter,
                         """
                         Some tests use JUnit5, but the '%s' task is not using the JUnit Jupiter engine. \
@@ -110,7 +135,7 @@ public class CheckJUnitDependencies extends DefaultTask {
             }
 
             if (usesJqwik) {
-                checkState(
+                Preconditions.checkState(
                         hasJqwikEngine,
                         """
                         Some tests use Jqwik, but the '%s' task is not using the Jqwik engine. \

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -45,7 +45,7 @@ public abstract class CheckJUnitDependencies extends DefaultTask {
         setGroup("Verification");
         setDescription("Ensures the correct JUnit4/5 dependencies are present, otherwise tests may silently not run");
 
-        getErrorMessages().set(getProject().provider(() -> validateDependencies()));
+        getErrorMessages().set(getProject().provider(this::validateDependencies));
     }
 
     @TaskAction

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckJUnitDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckJUnitDependencies.java
@@ -16,28 +16,23 @@
 
 package com.palantir.baseline.tasks;
 
-import static java.util.stream.Collectors.toList;
+import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.base.Preconditions;
-import com.palantir.baseline.plugins.BaselineTesting;
-import com.palantir.baseline.util.VersionUtils;
-import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
-import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.TestFrameworkOptions;
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
 
 public class CheckJUnitDependencies extends DefaultTask {
 
@@ -49,178 +44,141 @@ public class CheckJUnitDependencies extends DefaultTask {
 
     @TaskAction
     public final void validateDependencies() {
-        getProbablyTestSourceSets().forEach(ss -> {
-            Optional<Test> maybeTestTask = BaselineTesting.getTestTaskForSourceSet(getProject(), ss);
-            if (!maybeTestTask.isPresent()) {
-                // source set doesn't have a test task, e.g. 'schema'
-                return;
-            }
-            Test task = maybeTestTask.get();
+        getProject()
+                .getExtensions()
+                .getByType(JavaPluginExtension.class)
+                .getSourceSets()
+                .forEach(sourceSet -> {
+                    Test task = getProject().getTasks().withType(Test.class).findByName(sourceSet.getName());
+                    if (task == null) {
+                        return;
+                    }
 
-            getProject().getLogger().info("Analyzing source set {} with task {}", ss.getName(), task.getName());
-            validateSourceSet(ss, task);
-        });
+                    getLogger().info("Analyzing source set {} with task {}", sourceSet.getName(), task.getName());
+
+                    validateSourceSet(sourceSet, task);
+                });
     }
 
-    @Classpath
-    public final Provider<List<Configuration>> getConfigurations() {
-        return getProject().provider(() -> getProbablyTestSourceSets()
-                .map(SourceSet::getRuntimeClasspathConfigurationName)
-                .map(getProject().getConfigurations()::getByName)
-                .collect(toList()));
-    }
-
-    private Stream<SourceSet> getProbablyTestSourceSets() {
-        return getProject().getExtensions().getByType(JavaPluginExtension.class).getSourceSets().stream()
-                .filter(ss -> !ss.getName().equals(SourceSet.MAIN_SOURCE_SET_NAME));
-    }
-
-    private void validateSourceSet(SourceSet ss, Test task) {
+    @SuppressWarnings("CyclomaticComplexity")
+    private void validateSourceSet(SourceSet sourceSet, Test task) {
         Set<ResolvedComponentResult> deps = getProject()
                 .getConfigurations()
-                .getByName(ss.getRuntimeClasspathConfigurationName())
+                .getByName(sourceSet.getRuntimeClasspathConfigurationName())
                 .getIncoming()
                 .getResolutionResult()
                 .getAllComponents();
-        boolean junitJupiterIsPresent = hasDep(deps, CheckJUnitDependencies::isJunitJupiter);
-        boolean vintageEngineExists = hasDep(deps, CheckJUnitDependencies::isVintageEngine);
-        boolean spock1Dependency = hasDep(deps, CheckJUnitDependencies::isSpock1);
-        boolean spock2OrGreaterDependency = hasDep(deps, CheckJUnitDependencies::isSpock2OrGreater);
-        String testRuntimeOnly = ss.getRuntimeOnlyConfigurationName();
-        boolean junitPlatformEnabled = BaselineTesting.useJUnitPlatformEnabled(task);
 
-        // If some testing library happens to provide the junit-jupiter-api, then users might start using the
-        // org.junit.jupiter.api.Test annotation, but as JUnit4 knows nothing about these, they'll silently not run
-        // unless the user has wired up the dependency correctly.
-        if (sourceSetMentionsJUnit5Api(ss)) {
-            String runtime = ss.getRuntimeClasspathConfigurationName();
-            Preconditions.checkState(
-                    junitPlatformEnabled,
-                    "Some tests mention JUnit5, but the '"
-                            + task.getName()
-                            + "' task does not have "
-                            + "useJUnitPlatform() enabled. This means tests may be silently not running! Please "
-                            + "add the following:\n\n"
-                            + "    "
-                            + runtime
-                            + " 'org.junit.jupiter:junit-jupiter'\n");
-        }
+        boolean usesJUnit4 = usesApi(sourceSet, CheckJUnitDependencies::isJUnit4);
+        boolean usesJUnit5 = usesApi(sourceSet, CheckJUnitDependencies::isJUnit5);
+        boolean usesJqwik = usesApi(sourceSet, CheckJUnitDependencies::isJqwik);
 
-        // When doing an incremental migration to JUnit5, a project may have some JUnit4 and some JUnit5 tests at the
-        // same time. It's crucial that they have the vintage engine set up correctly, otherwise tests may silently
-        // not run!
-        if (sourceSetMentionsJUnit4(ss)) {
-            if (junitPlatformEnabled) { // people might manually enable this
-                Preconditions.checkState(
-                        junitJupiterIsPresent,
-                        "Tests may be silently not running! Some tests still use JUnit4, but Gradle has "
-                                + "been set to use JUnit Platform. "
-                                + "To ensure your old JUnit4 tests still run, please add the following:\n\n"
-                                + "    "
-                                + testRuntimeOnly
-                                + " 'org.junit.jupiter:junit-jupiter'\n\n"
-                                + "Otherwise they will silently not run.");
+        boolean hasJunitJupiter = hasDep(deps, CheckJUnitDependencies::isJunitJupiter);
+        boolean hasVintageEngine = hasDep(deps, CheckJUnitDependencies::isVintageEngine);
+        boolean hasJqwikEngine = hasDep(deps, CheckJUnitDependencies::isJqwikEngine);
+        boolean hasSpock = hasDep(deps, CheckJUnitDependencies::isSpock);
 
-                Preconditions.checkState(
-                        vintageEngineExists,
-                        "Tests may be silently not running! Some tests still use JUnit4, but Gradle has "
-                                + "been set to use JUnit Platform. "
-                                + "To ensure your old JUnit4 tests still run, please add the following:\n\n"
-                                + "    "
-                                + testRuntimeOnly
-                                + " 'org.junit.vintage:junit-vintage-engine'\n\n"
-                                + "Otherwise they will silently not run.");
-            } else {
-                Preconditions.checkState(
-                        !junitJupiterIsPresent,
-                        "Tests may be silently not running! Please remove "
-                                + "'org.junit.jupiter:junit-jupiter' dependency "
-                                + "because tests use JUnit4 and useJUnitPlatform() is not enabled.");
+        TestFrameworkOptions options = task.getTestFramework().getOptions();
+
+        if (options instanceof JUnitPlatformOptions) {
+            if (usesJUnit4) {
+                checkState(
+                        hasVintageEngine,
+                        """
+                        Some tests use JUnit4, but the '%s' task is not using the JUnit Vintage engine. \
+                        To ensure your JUnit4 tests are run, add the following dependency:
+
+                        %s 'org.junit.vintage:junit-vintage-engine'
+
+                        """,
+                        task.getName(),
+                        sourceSet.getRuntimeOnlyConfigurationName());
             }
-        }
 
-        if (sourceSetMentionsJqwikApi(ss)) {
-            Preconditions.checkState(junitPlatformEnabled, "jqwik requires the junit platform");
-            String runtime = ss.getRuntimeClasspathConfigurationName();
-            Set<String> engines = BaselineTesting.getJUnitPlatformEngines(task);
-            if (!engines.contains("jqwik")) {
-                throw new IllegalStateException("Some tests mention jqwik, but the '"
-                        + task.getName()
-                        + "' task does not have the jqwik engine enabled. "
-                        + "This means tests may be silently not running! Please "
-                        + "add the following:\n\n"
-                        + "test {\n"
-                        + "    useJUnitPlatform {\n"
-                        + "        includeEngines 'jqwik', 'junit-jupiter'\n"
-                        + "    }\n"
-                        + "}\n\nAs well as a dependency on the engine:\n\n"
-                        + "    "
-                        + runtime
-                        + " 'net.jqwik:jqwik-engine'\n");
+            if (usesJUnit5) {
+                checkState(
+                        hasJunitJupiter,
+                        """
+                        Some tests use JUnit5, but the '%s' task is not using the JUnit Jupiter engine. \
+                        To ensure your JUnit5 tests are run, add the following dependency:
+
+                        %s 'org.junit.jupiter:junit-jupiter'
+
+                        """,
+                        task.getName(),
+                        sourceSet.getRuntimeOnlyConfigurationName());
             }
-            Preconditions.checkState(
-                    hasDep(deps, CheckJUnitDependencies::isJqwikEngine),
-                    "Some tests mention jqwik, but the '"
-                            + task.getName()
-                            + "' task does not depend on the jqwik engine. "
-                            + "This means tests may be silently not running! Please add the following:\n\n"
-                            + "    "
-                            + runtime
-                            + " 'net.jqwik:jqwik-engine'\n");
-        }
 
-        // spock uses JUnit4 under the hood, so the vintage engine is critical
-        if (spock1Dependency && junitPlatformEnabled) {
-            Preconditions.checkState(
-                    vintageEngineExists,
-                    "Tests may be silently not running! Spock 1.x dependency detected (which uses "
-                            + "a JUnit4 Runner under the hood). Please add the following:\n\n"
-                            + "    "
-                            + testRuntimeOnly
-                            + " 'org.junit.vintage:junit-vintage-engine'\n\n");
-        }
+            if (usesJqwik) {
+                checkState(
+                        hasJqwikEngine,
+                        """
+                        Some tests use Jqwik, but the '%s' task is not using the Jqwik engine. \
+                        To ensure your Jqwik tests are run, add the following dependency:
 
-        if (spock2OrGreaterDependency) {
-            Preconditions.checkState(
-                    junitPlatformEnabled,
-                    "Tests may silently be not running! Spock 2.x dependency "
-                            + "detected (which requires useJUnitPlatform() in order to run).");
+                        %s 'net.jqwik:jqwik-engine'
+
+                        """,
+                        task.getName(),
+                        sourceSet.getRuntimeOnlyConfigurationName());
+            }
+        } else {
+            if (usesJUnit5) {
+                throw new IllegalStateException(String.format(
+                        """
+                        Some tests use JUnit5, but the '%s' task is not using using the JUnit Platform test \
+                        framework.""",
+                        task.getName()));
+            }
+
+            if (usesJqwik) {
+                throw new IllegalStateException(String.format(
+                        """
+                        Some tests use Jqwik, but the '%s' task is not using using the JUnit Platform test \
+                        framework.""",
+                        task.getName()));
+            }
+
+            if (hasSpock) {
+                throw new IllegalStateException(String.format(
+                        """
+                        Some tests use Spock, but the '%s' task is not using using the JUnit Platform test \
+                        framework.""",
+                        task.getName()));
+            }
         }
     }
 
-    private boolean hasDep(Set<ResolvedComponentResult> deps, Predicate<ModuleVersionIdentifier> spec) {
-        return deps.stream().anyMatch(component -> spec.test(component.getModuleVersion()));
-    }
-
-    private boolean sourceSetMentionsJUnit4(SourceSet ss) {
+    private static boolean usesApi(SourceSet sourceSet, Predicate<String> condition) {
         // getAllJava() includes groovy sources too
-        return !ss.getAllJava()
-                .filter(file -> fileContainsSubstring(
-                        file,
-                        l -> l.contains("org.junit.Test")
-                                || l.contains("org.junit.runner")
-                                || l.contains("org.junit.ClassRule")))
+        return !sourceSet
+                .getAllJava()
+                .filter(file -> {
+                    try (Stream<String> lines = Files.lines(file.toPath())) {
+                        return lines.anyMatch(condition);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                })
                 .isEmpty();
     }
 
-    private boolean sourceSetMentionsJUnit5Api(SourceSet ss) {
-        return !ss.getAllJava()
-                .filter(file -> fileContainsSubstring(file, l -> l.contains("org.junit.jupiter.api.")))
-                .isEmpty();
+    private static boolean isJUnit4(String line) {
+        return line.contains("org.junit.Test")
+                || line.contains("org.junit.runner")
+                || line.contains("org.junit.ClassRule");
     }
 
-    private boolean sourceSetMentionsJqwikApi(SourceSet ss) {
-        return !ss.getAllJava()
-                .filter(file -> fileContainsSubstring(file, l -> l.contains("net.jqwik.api.")))
-                .isEmpty();
+    private static boolean isJUnit5(String line) {
+        return line.contains("org.junit.jupiter.api.");
     }
 
-    private boolean fileContainsSubstring(File file, Predicate<String> substring) {
-        try (Stream<String> lines = Files.lines(file.toPath())) {
-            return lines.anyMatch(substring);
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to check file for junit dependencies: " + file, e);
-        }
+    private static boolean isJqwik(String line) {
+        return line.contains("net.jqwik.api.");
+    }
+
+    private static boolean hasDep(Set<ResolvedComponentResult> deps, Predicate<ModuleVersionIdentifier> spec) {
+        return deps.stream().anyMatch(component -> spec.test(component.getModuleVersion()));
     }
 
     private static boolean isJunitJupiter(ModuleVersionIdentifier dep) {
@@ -231,19 +189,11 @@ public class CheckJUnitDependencies extends DefaultTask {
         return "org.junit.vintage".equals(dep.getGroup()) && "junit-vintage-engine".equals(dep.getName());
     }
 
-    private static boolean isSpock1(ModuleVersionIdentifier dep) {
-        return isSpock(dep) && VersionUtils.majorVersionNumber(dep.getVersion()) <= 1;
-    }
-
-    private static boolean isSpock2OrGreater(ModuleVersionIdentifier dep) {
-        return isSpock(dep) && VersionUtils.majorVersionNumber(dep.getVersion()) >= 2;
+    private static boolean isJqwikEngine(ModuleVersionIdentifier dep) {
+        return "net.jqwik".equals(dep.getGroup()) && "jqwik-engine".equals(dep.getName());
     }
 
     private static boolean isSpock(ModuleVersionIdentifier dep) {
         return "org.spockframework".equals(dep.getGroup()) && "spock-core".equals(dep.getName());
-    }
-
-    private static boolean isJqwikEngine(ModuleVersionIdentifier dep) {
-        return "net.jqwik".equals(dep.getGroup()) && "jqwik-engine".equals(dep.getName());
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -19,6 +19,7 @@ package com.palantir.baseline
 import com.palantir.gradle.plugintesting.GradleTestVersions
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
+import org.assertj.core.util.Throwables
 import spock.lang.Unroll
 
 @Unroll
@@ -82,7 +83,6 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
     def '#gradleVersionNumber: runs JUnit4 tests'() {
-        when:
         gradleVersion = gradleVersionNumber
 
         buildFile << standardBuildFile
@@ -95,9 +95,10 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
         file('src/test/java/test/JUnit4Test.java') << junit4Test
 
+        when:
+        runTasksSuccessfully('test')
+
         then:
-        ExecutionResult result = runTasksSuccessfully('test')
-        result.wasExecuted('checkJUnitDependencies')
         fileExists("build/reports/tests/test/classes/test.JUnit4Test.html")
 
         where:
@@ -105,15 +106,15 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
     }
 
     def '#gradleVersionNumber: runs JUnit5 tests'() {
-        when:
         gradleVersion = gradleVersionNumber
 
         buildFile << standardBuildFile
         file('src/test/java/test/JUnit5Test.java') << junit5Test
 
+        when:
+        runTasksSuccessfully('test')
+
         then:
-        ExecutionResult result = runTasksSuccessfully('test')
-        result.wasExecuted('checkJUnitDependencies')
         fileExists("build/reports/tests/test/classes/test.JUnit5Test.html")
 
         where:
@@ -136,8 +137,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         file('src/test/java/test/JUnit5Test.java') << junit5Test
 
         then:
-        ExecutionResult result = runTasksSuccessfully('test')
-        result.wasExecuted('checkJUnitDependencies')
+        runTasksSuccessfully('test')
         fileExists("build/reports/tests/test/classes/test.JUnit4Test.html")
         fileExists("build/reports/tests/test/classes/test.JUnit5Test.html")
 
@@ -146,7 +146,6 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
     }
 
     def '#gradleVersionNumber: runs Jqwik tests'() {
-        when:
         gradleVersion = gradleVersionNumber
 
         buildFile << standardBuildFile
@@ -157,9 +156,10 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
         file('src/test/java/test/JqwikTest.java') << jqwikTest
 
+        when:
+        runTasksSuccessfully('test')
+
         then:
-        ExecutionResult result = runTasksSuccessfully('test')
-        result.wasExecuted('checkJUnitDependencies')
         fileExists("build/reports/tests/test/classes/test.JqwikTest.html")
 
         where:
@@ -186,8 +186,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         then:
-        ExecutionResult result = runTasksSuccessfully('test')
-        result.wasExecuted('checkJUnitDependencies')
+        runTasksSuccessfully('test')
 
         where:
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
@@ -207,8 +206,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         file('src/integrationTest/java/test/JUnit5Test.java') << junit5Test
 
         then:
-        ExecutionResult result = runTasksSuccessfully('integrationTest')
-        result.wasExecuted('checkJUnitDependencies')
+        runTasksSuccessfully('integrationTest')
         fileExists("build/reports/tests/integrationTest/classes/test.JUnit5Test.html")
 
         where:
@@ -216,22 +214,22 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
     }
 
     def '#gradleVersionNumber: checkJUnitDependencies => JUnit4 without junit-vintage-engine'() {
-        when:
         gradleVersion = gradleVersionNumber
 
         buildFile << standardBuildFile
         file('src/test/java/test/JUnit4Test.java') << junit4Test
 
+        when:
+        String message = Throwables.getRootCause(runTasksWithFailure('checkJUnitDependencies').failure).message
+
         then:
-        ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')
-        result.failure.cause.cause.message.contains 'Some tests use JUnit4, but the \'test\' task is not using the JUnit Vintage engine.'
+        message.contains 'Some tests use JUnit4, but the \'test\' task is not using the JUnit Vintage engine.'
 
         where:
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
     def '#gradleVersionNumber: checkJUnitDependencies => JUnit5 without junit-jupiter'() {
-        when:
         gradleVersion = gradleVersionNumber
 
         buildFile << standardBuildFile
@@ -244,16 +242,17 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
         file('src/test/java/test/JUnit5Test.java') << junit5Test
 
+        when:
+        String message = Throwables.getRootCause(runTasksWithFailure('checkJUnitDependencies').failure).message
+
         then:
-        ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')
-        result.failure.cause.cause.message.contains 'Some tests use JUnit5, but the \'test\' task is not using the JUnit Jupiter engine.'
+        message.contains 'Some tests use JUnit5, but the \'test\' task is not using the JUnit Jupiter engine.'
 
         where:
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
     def '#gradleVersionNumber: checkJUnitDependencies => Jqwik without jqwik-engine'() {
-        when:
         gradleVersion = gradleVersionNumber
 
         buildFile << standardBuildFile
@@ -270,22 +269,25 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
         file('src/test/java/test/JqwikTest.java') << jqwikTest
 
+        when:
+        String message = Throwables.getRootCause(runTasksWithFailure('checkJUnitDependencies').failure).message
+
         then:
-        ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')
-        result.failure.cause.cause.message.contains 'Some tests use Jqwik, but the \'test\' task is not using the Jqwik engine.'
+        message.contains 'Some tests use Jqwik, but the \'test\' task is not using the Jqwik engine.'
 
         where:
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
     def '#gradleVersionNumber: checkJUnitDependencies => run as part of check'() {
-        when:
         gradleVersion = gradleVersionNumber
 
         buildFile << standardBuildFile
 
-        then:
+        when:
         ExecutionResult result = runTasksSuccessfully('check')
+
+        then:
         result.wasExecuted('checkJUnitDependencies')
 
         where:
@@ -293,21 +295,31 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
     }
 
     def 'running -Drecreate=true will re-run tests even if no code changes'() {
-        when:
         buildFile << standardBuildFile
         file('src/test/java/test/JUnit5Test.java') << junit5Test
 
-        then:
+        when:
         def result = runTasksSuccessfully('test')
+
+        then:
         result.wasExecuted(':test')
 
+        when:
         def result2 = runTasksSuccessfully('test')
+
+        then:
         result2.wasUpToDate(':test')
 
+        when:
         def result3 = runTasksSuccessfully('test', '-Drecreate=true')
+
+        then:
         result3.wasExecuted(':test')
 
+        when:
         def result4 = runTasksSuccessfully('test', '-Drecreate=true')
+
+        then:
         result4.wasExecuted(':test')
     }
 

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -17,13 +17,13 @@
 package com.palantir.baseline
 
 import com.palantir.gradle.plugintesting.GradleTestVersions
-
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.lang.Unroll
 
 @Unroll
 class BaselineTestingIntegrationTest extends IntegrationSpec {
+
     def standardBuildFile = '''
         plugins {
             id 'java-library'
@@ -35,8 +35,15 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
             mavenCentral()
         }
         
-        dependencies {
-            testImplementation 'junit:junit:4.12'
+        configurations.all {
+            resolutionStrategy {
+                force 'com.netflix.nebula:nebula-test:10.2.0'
+                force 'junit:junit:4.13.2'
+                force 'net.jqwik:jqwik:1.9.2'
+                force 'org.junit.jupiter:junit-jupiter:5.12.0'
+                force 'org.junit.platform:junit-platform-launcher:1.12.0'
+                force 'org.junit.vintage:junit-vintage-engine:5.12.0'
+            }
         }
     '''.stripIndent(true)
 
@@ -45,7 +52,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         
         import org.junit.Test;
         
-        public class TestClass4 { 
+        public class JUnit4Test { 
             @Test
             public void test() {}
         }
@@ -56,7 +63,7 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         
         import org.junit.jupiter.api.Test;
         
-        public class TestClass5 { 
+        public class JUnit5Test { 
             @Test
             public void test() {}
         }
@@ -68,66 +75,106 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         import net.jqwik.api.Property;
         import net.jqwik.api.ForAll;
         
-        class TestClass6 { 
+        class JqwikTest { 
             @Property
             void test(@ForAll byte value) {}
         }
         '''.stripIndent(true)
 
-    def '#gradleVersionNumber: capable of running both junit4 and junit5 tests'() {
+    def '#gradleVersionNumber: runs JUnit4 tests'() {
         when:
         gradleVersion = gradleVersionNumber
 
         buildFile << standardBuildFile
         buildFile << '''
         dependencies {
-            testImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
-            testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.4.2") {
-                because 'allows JUnit 3 and JUnit 4 tests to run\'
-            }
+            testImplementation 'junit:junit'
+
+            testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
         }
         '''.stripIndent(true)
-        file('src/test/java/test/TestClass4.java') << junit4Test
-        file('src/test/java/test/TestClass5.java') << junit5Test
+        file('src/test/java/test/JUnit4Test.java') << junit4Test
 
         then:
-        runTasksSuccessfully('test')
-        new File(projectDir, "build/reports/tests/test/classes/test.TestClass4.html").exists()
-        new File(projectDir, "build/reports/tests/test/classes/test.TestClass5.html").exists()
+        ExecutionResult result = runTasksSuccessfully('test')
+        result.wasExecuted('checkJUnitDependencies')
+        fileExists("build/reports/tests/test/classes/test.JUnit4Test.html")
 
         where:
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'runs integration tests with junit5'() {
+    def '#gradleVersionNumber: runs JUnit5 tests'() {
         when:
+        gradleVersion = gradleVersionNumber
+
         buildFile << standardBuildFile
-        buildFile << '''
-        apply plugin: 'org.unbroken-dome.test-sets'
-        testSets {
-            integrationTest
-        }
-        
-        dependencies {
-            integrationTestImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
-        }
-        '''.stripIndent(true)
-        file('src/integrationTest/java/test/TestClass5.java') << junit5Test
+        file('src/test/java/test/JUnit5Test.java') << junit5Test
 
         then:
-        // Explicitly testing broken state that needs fixing before gradle 8
-        runTasksSuccessfully('-DignoreDeprecations=true', 'integrationTest')
-        fileExists("build/reports/tests/integrationTest/classes/test.TestClass5.html")
+        ExecutionResult result = runTasksSuccessfully('test')
+        result.wasExecuted('checkJUnitDependencies')
+        fileExists("build/reports/tests/test/classes/test.JUnit5Test.html")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
-    
-    def 'runs nebula-test version 10+ tests that require junit platform'() {
+
+    def '#gradleVersionNumber: runs both JUnit4 and Junit5 tests'() {
         when:
+        gradleVersion = gradleVersionNumber
+
         buildFile << standardBuildFile
-        
+        buildFile << '''
+        dependencies {
+            testImplementation 'junit:junit'
+
+            testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+        }
+        '''.stripIndent(true)
+        file('src/test/java/test/JUnit4Test.java') << junit4Test
+        file('src/test/java/test/JUnit5Test.java') << junit5Test
+
+        then:
+        ExecutionResult result = runTasksSuccessfully('test')
+        result.wasExecuted('checkJUnitDependencies')
+        fileExists("build/reports/tests/test/classes/test.JUnit4Test.html")
+        fileExists("build/reports/tests/test/classes/test.JUnit5Test.html")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
+    }
+
+    def '#gradleVersionNumber: runs Jqwik tests'() {
+        when:
+        gradleVersion = gradleVersionNumber
+
+        buildFile << standardBuildFile
+        buildFile << '''
+        dependencies {
+            testImplementation 'net.jqwik:jqwik'
+        }
+        '''.stripIndent(true)
+        file('src/test/java/test/JqwikTest.java') << jqwikTest
+
+        then:
+        ExecutionResult result = runTasksSuccessfully('test')
+        result.wasExecuted('checkJUnitDependencies')
+        fileExists("build/reports/tests/test/classes/test.JqwikTest.html")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
+    }
+
+    def '#gradleVersionNumber: runs Nebula tests'() {
+        when:
+        gradleVersion = gradleVersionNumber
+
+        buildFile << standardBuildFile
         buildFile << '''
             apply plugin: 'groovy'
             dependencies {
-                testImplementation 'com.netflix.nebula:nebula-test:10.2.0'
+                testImplementation 'com.netflix.nebula:nebula-test'
             }
         '''.stripIndent(true)
 
@@ -139,126 +186,116 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         '''.stripIndent(true)
 
         then:
-        // Explicitly testing broken state that needs fixing before gradle 8
-        runTasksSuccessfully('-DignoreDeprecations=true', 'test')
+        ExecutionResult result = runTasksSuccessfully('test')
+        result.wasExecuted('checkJUnitDependencies')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'checkJUnitDependencies ensures mixture of junit4 and 5 tests => legacy must be present'() {
+    def '#gradleVersionNumber: runs test-sets tests'() {
         when:
+        gradleVersion = gradleVersionNumber
+
         buildFile << standardBuildFile
         buildFile << '''
         apply plugin: 'org.unbroken-dome.test-sets'
         testSets {
             integrationTest
         }
-
-        dependencies {
-            integrationTestImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
-        }
         '''.stripIndent(true)
-        file('src/integrationTest/java/test/TestClass2.java') << junit4Test
-        file('src/integrationTest/java/test/TestClass5.java') << junit5Test
+        file('src/integrationTest/java/test/JUnit5Test.java') << junit5Test
+
+        then:
+        ExecutionResult result = runTasksSuccessfully('integrationTest')
+        result.wasExecuted('checkJUnitDependencies')
+        fileExists("build/reports/tests/integrationTest/classes/test.JUnit5Test.html")
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
+    }
+
+    def '#gradleVersionNumber: checkJUnitDependencies => JUnit4 without junit-vintage-engine'() {
+        when:
+        gradleVersion = gradleVersionNumber
+
+        buildFile << standardBuildFile
+        file('src/test/java/test/JUnit4Test.java') << junit4Test
 
         then:
         ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')
-        result.failure.cause.cause.message.contains 'Some tests still use JUnit4, but Gradle has been set to use JUnit Platform'
+        result.failure.cause.cause.message.contains 'Some tests use JUnit4, but the \'test\' task is not using the JUnit Vintage engine.'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'checkJUnitDependencies ensures mixture of junit4 and 5 tests => new must be present'() {
+    def '#gradleVersionNumber: checkJUnitDependencies => JUnit5 without junit-jupiter'() {
         when:
+        gradleVersion = gradleVersionNumber
+
         buildFile << standardBuildFile
+        // The junit-jupiter dependency is added automatically by the jvm-test-suite plugin, so it is practically
+        // impossible for junit-jupiter to be absent. We manually exclude it here in order to test this case.
         buildFile << '''
-        dependencies {
-            testImplementation "junit:junit:4.12"
+        configurations {
+            testRuntimeClasspath.exclude group: 'org.junit.jupiter', module: 'junit-jupiter'
         }
         '''.stripIndent(true)
-        file('src/test/java/test/TestClass2.java') << junit4Test
-        file('src/test/java/test/TestClass5.java') << junit5Test
+        file('src/test/java/test/JUnit5Test.java') << junit5Test
 
         then:
         ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')
-        result.failure.cause.cause.message.contains 'Some tests mention JUnit5, but the \'test\' task does not have useJUnitPlatform() enabled'
+        result.failure.cause.cause.message.contains 'Some tests use JUnit5, but the \'test\' task is not using the JUnit Jupiter engine.'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'checkJUnitDependencies ensures nebula test => vintage must be present'() {
+    def '#gradleVersionNumber: checkJUnitDependencies => Jqwik without jqwik-engine'() {
         when:
+        gradleVersion = gradleVersionNumber
+
         buildFile << standardBuildFile
+        // jqwik depends on jqwik-engine, so it is practically impossible for jqwik-engine to be absent. We manually exclude it
+        // here in order to test this case.
         buildFile << '''
-        apply plugin: 'groovy'
-        dependencies {
-            testImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
-            testImplementation 'com.netflix.nebula:nebula-test:7.3.0'
+        dependencies { 
+            testImplementation 'net.jqwik:jqwik'
+        }
+        
+        configurations {
+            testRuntimeClasspath.exclude group: 'net.jqwik', module: 'jqwik-engine'
         }
         '''.stripIndent(true)
+        file('src/test/java/test/JqwikTest.java') << jqwikTest
 
         then:
         ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')
-        result.failure.cause.cause.message.contains 'Tests may be silently not running! Spock 1.x dependency detected'
+        result.failure.cause.cause.message.contains 'Some tests use Jqwik, but the \'test\' task is not using the Jqwik engine.'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'runs jqwik tests'() {
+    def '#gradleVersionNumber: checkJUnitDependencies => run as part of check'() {
         when:
+        gradleVersion = gradleVersionNumber
+
         buildFile << standardBuildFile
-        buildFile << '''
-        tasks.withType(Test) {
-            useJUnitPlatform {
-                includeEngines 'jqwik', 'junit-jupiter'
-            }
-        }
-        dependencies {
-            testImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
-            testImplementation "net.jqwik:jqwik:1.5.3"
-        }
-        '''.stripIndent(true)
-        file('src/test/java/test/TestClass6.java') << jqwikTest
 
         then:
-        runTasksSuccessfully('checkJUnitDependencies')
-        runTasksSuccessfully('test')
-        new File(projectDir, "build/reports/tests/test/classes/test.TestClass6.html").exists()
-    }
+        ExecutionResult result = runTasksSuccessfully('check')
+        result.wasExecuted('checkJUnitDependencies')
 
-    def 'checkJUnitDependencies fails when jqwik engine is not configured'() {
-        when:
-        buildFile << standardBuildFile
-        buildFile << '''
-        dependencies {
-            testImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
-            testImplementation "net.jqwik:jqwik:1.5.3"
-        }
-        '''.stripIndent(true)
-        file('src/test/java/test/TestClass6.java') << jqwikTest
-
-        then:
-        ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')
-        result.failure.cause.cause.message.contains 'task does not have the jqwik engine enabled'
-    }
-
-    def 'checkJUnitDependencies fails when jqwik engine is not on the classpath'() {
-        when:
-        buildFile << standardBuildFile
-        buildFile << '''
-        tasks.withType(Test) {
-            useJUnitPlatform {
-                includeEngines 'jqwik', 'junit-jupiter'
-            }
-        }
-        dependencies {
-            testImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
-            testImplementation "net.jqwik:jqwik-api:1.5.3"
-        }
-        '''.stripIndent(true)
-        file('src/test/java/test/TestClass6.java') << jqwikTest
-
-        then:
-        ExecutionResult result = runTasksWithFailure('checkJUnitDependencies')
-        result.failure.cause.cause.message.contains 'task does not depend on the jqwik engine'
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
     def 'running -Drecreate=true will re-run tests even if no code changes'() {
         when:
         buildFile << standardBuildFile
-        file('src/test/java/test/TestClass4.java') << junit4Test
+        file('src/test/java/test/JUnit5Test.java') << junit5Test
 
         then:
         def result = runTasksSuccessfully('test')


### PR DESCRIPTION
The JUnit 5.12.0 upgrade is causing test failures in all of our repos. See some prior discussion in https://github.com/junit-team/junit5/issues/4335.

```
Caused by: org.junit.platform.commons.JUnitException: TestEngine with ID 'junit-jupiter' failed to discover tests
        ...
Caused by: org.junit.platform.commons.JUnitException: OutputDirectoryProvider not available; probably due to unaligned versions of the junit-platform-engine and junit-platform-launcher jars on the classpath/module path.
        ...
```

The [Gradle documentation](https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#test_framework_implementation_dependencies) states that, in the absence of test suites, the necessary test framework dependencies (ex. `junit-platform-launcher`) must be explicitly declared. I think we've just gotten lucky that nothing in the JUnit implementation has actually required this dependency until now.

The best solution here is to migrate `BaselineTesting` to configure tests using the newer [`jvm-test-suites`](https://docs.gradle.org/8.12/userguide/jvm_test_suite_plugin.html) plugin, which is applied automatically by the [`java`](https://github.com/palantir/gradle-baseline/pull/3053) plugin and already used to configure the default `test` test suite. The test suites plugin will automatically add the necessary test framework dependencies, and consumers can use their existing version management tool (ex. [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions)) to ensure consistent versions of the JUnit dependencies.

Consumers will just need to add a `org.junit.platform:*` constraints in their `versions.props`. We can easily automate this (this is already done).

