### PR TITLE
baseline-java-versions: Remove setting sourceCompatibility in task action

### DIFF
--- a/changelog/@unreleased/pr-3060.v2.yml
+++ b/changelog/@unreleased/pr-3060.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: For baseline-java-versions (for Gradle >=8), do not explicitly set
+    the `sourceCompatibility` of Java compilations in a task action before the task
+    runs.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3060

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -119,15 +119,6 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             setJavaCompiler(
                     javaCompileTask, rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target);
             javaCompileTask.getOptions().getCompilerArgumentProviders().add(new EnablePreviewArgumentProvider(target));
-            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
-            javaCompileTask.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    ((JavaCompile) task)
-                            .setSourceCompatibility(
-                                    target.get().javaLanguageVersion().toString());
-                }
-            });
         });
 
         project.getTasks().withType(Javadoc.class).configureEach(javadocTask -> {
@@ -163,16 +154,6 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                     .getOptions()
                     .getCompilerArgumentProviders()
                     .add(new EnablePreviewArgumentProvider(target));
-
-            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
-            groovyCompileTask.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    ((GroovyCompile) task)
-                            .setSourceCompatibility(
-                                    target.get().javaLanguageVersion().toString());
-                }
-            });
         });
 
         project.getTasks().withType(ScalaCompile.class).configureEach(scalaCompileTask -> {
@@ -181,16 +162,6 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                     .set(getJavaLauncher(
                             rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target));
             scalaCompileTask.getOptions().getCompilerArgumentProviders().add(new EnablePreviewArgumentProvider(target));
-
-            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
-            scalaCompileTask.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    ((ScalaCompile) task)
-                            .setSourceCompatibility(
-                                    target.get().javaLanguageVersion().toString());
-                }
-            });
         });
 
         project.getTasks().withType(ScalaDoc.class).configureEach(scalaDoc -> scalaDoc.getJavaLauncher()

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -120,7 +120,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             setJavaCompiler(
                     javaCompileTask, rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target);
             javaCompileTask.getOptions().getCompilerArgumentProviders().add(new EnablePreviewArgumentProvider(target));
-            optOfReleaseFlagForGradle7(javaCompileTask, target);
+            optOutOfReleaseFlagForGradle7(javaCompileTask, target);
         });
 
         project.getTasks().withType(Javadoc.class).configureEach(javadocTask -> {
@@ -157,7 +157,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                     .getCompilerArgumentProviders()
                     .add(new EnablePreviewArgumentProvider(target));
 
-            optOfReleaseFlagForGradle7(groovyCompileTask, target);
+            optOutOfReleaseFlagForGradle7(groovyCompileTask, target);
         });
 
         project.getTasks().withType(ScalaCompile.class).configureEach(scalaCompileTask -> {
@@ -167,14 +167,14 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                             rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target));
             scalaCompileTask.getOptions().getCompilerArgumentProviders().add(new EnablePreviewArgumentProvider(target));
 
-            optOfReleaseFlagForGradle7(scalaCompileTask, target);
+            optOutOfReleaseFlagForGradle7(scalaCompileTask, target);
         });
 
         project.getTasks().withType(ScalaDoc.class).configureEach(scalaDoc -> scalaDoc.getJavaLauncher()
                 .set(getJavaLauncher(rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target)));
     }
 
-    private static void optOfReleaseFlagForGradle7(AbstractCompile compileTask, Provider<ChosenJavaVersion> target) {
+    private static void optOutOfReleaseFlagForGradle7(AbstractCompile compileTask, Provider<ChosenJavaVersion> target) {
         if (GradleVersion.current().compareTo(GradleVersion.version("8.0")) >= 0) {
             return;
         }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -119,15 +120,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             setJavaCompiler(
                     javaCompileTask, rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target);
             javaCompileTask.getOptions().getCompilerArgumentProviders().add(new EnablePreviewArgumentProvider(target));
-            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
-            javaCompileTask.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    ((JavaCompile) task)
-                            .setSourceCompatibility(
-                                    target.get().javaLanguageVersion().toString());
-                }
-            });
+            optOfReleaseFlagForGradle7(javaCompileTask, target);
         });
 
         project.getTasks().withType(Javadoc.class).configureEach(javadocTask -> {
@@ -164,15 +157,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                     .getCompilerArgumentProviders()
                     .add(new EnablePreviewArgumentProvider(target));
 
-            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
-            groovyCompileTask.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    ((GroovyCompile) task)
-                            .setSourceCompatibility(
-                                    target.get().javaLanguageVersion().toString());
-                }
-            });
+            optOfReleaseFlagForGradle7(groovyCompileTask, target);
         });
 
         project.getTasks().withType(ScalaCompile.class).configureEach(scalaCompileTask -> {
@@ -182,19 +167,28 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                             rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target));
             scalaCompileTask.getOptions().getCompilerArgumentProviders().add(new EnablePreviewArgumentProvider(target));
 
-            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
-            scalaCompileTask.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    ((ScalaCompile) task)
-                            .setSourceCompatibility(
-                                    target.get().javaLanguageVersion().toString());
-                }
-            });
+            optOfReleaseFlagForGradle7(scalaCompileTask, target);
         });
 
         project.getTasks().withType(ScalaDoc.class).configureEach(scalaDoc -> scalaDoc.getJavaLauncher()
                 .set(getJavaLauncher(rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target)));
+    }
+
+    private static void optOfReleaseFlagForGradle7(AbstractCompile compileTask, Provider<ChosenJavaVersion> target) {
+        if (GradleVersion.current().compareTo(GradleVersion.version("8.0")) >= 0) {
+            return;
+        }
+
+        // In Gradle <8, we need to set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
+        // https://github.com/gradle/gradle/issues/18824#issuecomment-1026909824
+        compileTask.doFirst(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                ((AbstractCompile) task)
+                        .setSourceCompatibility(
+                                target.get().javaLanguageVersion().toString());
+            }
+        });
     }
 
     private static void configureExecutionTasks(

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -119,6 +119,15 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             setJavaCompiler(
                     javaCompileTask, rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target);
             javaCompileTask.getOptions().getCompilerArgumentProviders().add(new EnablePreviewArgumentProvider(target));
+            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
+            javaCompileTask.doFirst(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    ((JavaCompile) task)
+                            .setSourceCompatibility(
+                                    target.get().javaLanguageVersion().toString());
+                }
+            });
         });
 
         project.getTasks().withType(Javadoc.class).configureEach(javadocTask -> {
@@ -154,6 +163,16 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                     .getOptions()
                     .getCompilerArgumentProviders()
                     .add(new EnablePreviewArgumentProvider(target));
+
+            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
+            groovyCompileTask.doFirst(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    ((GroovyCompile) task)
+                            .setSourceCompatibility(
+                                    target.get().javaLanguageVersion().toString());
+                }
+            });
         });
 
         project.getTasks().withType(ScalaCompile.class).configureEach(scalaCompileTask -> {
@@ -162,6 +181,16 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                     .set(getJavaLauncher(
                             rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target));
             scalaCompileTask.getOptions().getCompilerArgumentProviders().add(new EnablePreviewArgumentProvider(target));
+
+            // Set sourceCompatibility to opt out of '-release', allowing opens/exports to be used.
+            scalaCompileTask.doFirst(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    ((ScalaCompile) task)
+                            .setSourceCompatibility(
+                                    target.get().javaLanguageVersion().toString());
+                }
+            });
         });
 
         project.getTasks().withType(ScalaDoc.class).configureEach(scalaDoc -> scalaDoc.getJavaLauncher()

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package com.palantir.baseline
 
 import com.google.common.collect.MoreCollectors
+import com.palantir.gradle.plugintesting.GradleTestVersions
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
+import spock.lang.Unroll
 
 import java.util.jar.Attributes
 import java.util.jar.JarFile
@@ -26,8 +28,8 @@ import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
 import java.util.zip.ZipOutputStream
 
+@Unroll
 class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
-
     def standardBuildFile = '''
     plugins {
         id 'java-library'
@@ -51,7 +53,9 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         buildFile << standardBuildFile
     }
 
-    def 'Compiles with locally defined exports'() {
+    def '#gradleVersionNumber: Compiles with locally defined exports'() {
+        gradleVersion = gradleVersionNumber
+        
         when:
         buildFile << '''
         application {
@@ -72,9 +76,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
 
         then:
         runTasksSuccessfully('compileJava')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Compiles with locally defined opens'() {
+    def '#gradleVersionNumber: Compiles with locally defined opens'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         application {
@@ -95,9 +104,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
 
         then:
         runTasksSuccessfully('compileJava')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Builds javadoc with locally defined exports'() {
+    def '#gradleVersionNumber: Builds javadoc with locally defined exports'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         application {
@@ -122,9 +136,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
 
         then:
         runTasksSuccessfully('javadoc')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Builds javadoc with locally defined opens'() {
+    def '#gradleVersionNumber: Builds javadoc with locally defined opens'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         application {
@@ -149,9 +168,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
 
         then:
         runTasksSuccessfully('javadoc')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Runs with locally defined exports'() {
+    def '#gradleVersionNumber: Runs with locally defined exports'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         application {
@@ -178,9 +202,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
         // with an equals.
         result.standardOutput.contains('--add-exports=java.management/sun.management=ALL-UNNAMED')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Runs with locally defined exports with the release plugin, not toolchains'() {
+    def '#gradleVersionNumber: Runs with locally defined exports with the release plugin, not toolchains'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile.text = '''
         plugins {
@@ -216,9 +245,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
         // with an equals.
         result.standardOutput.contains('--add-exports=java.management/sun.management=ALL-UNNAMED')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Runs with locally defined opens'() {
+    def '#gradleVersionNumber: Runs with locally defined opens'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         application {
@@ -245,9 +279,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
         // with an equals.
         result.standardOutput.contains('--add-opens=java.management/sun.management=ALL-UNNAMED')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Adds locally defined exports to the jar manifest'() {
+    def '#gradleVersionNumber: Adds locally defined exports to the jar manifest'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         application {
@@ -279,9 +318,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         manifestValue == 'java.management/sun.management'
 
         !jarFile.getManifest().getMainAttributes().containsKey('Baseline-Enable-Preview')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Adds Baseline-Enable-Preview attribute to jar manifest'() {
+    def '#gradleVersionNumber: Adds Baseline-Enable-Preview attribute to jar manifest'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         javaVersions {
@@ -304,9 +348,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
                 .collect(MoreCollectors.onlyElement())
         String manifestValue = jarFile.getManifest().getMainAttributes().getValue('Baseline-Enable-Preview')
         manifestValue == '11'
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Executes with externally defined exports'() {
+    def '#gradleVersionNumber: Executes with externally defined exports'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         Manifest manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
@@ -339,9 +388,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
         // with an equals.
         result.standardOutput.contains('--add-exports=java.management/sun.management=ALL-UNNAMED')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Handles jars with no manifest'() {
+    def '#gradleVersionNumber: Handles jars with no manifest'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         File testJar = new File(getProjectDir(),"test.jar");
         testJar.withOutputStream { fos ->
@@ -369,9 +423,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         then:
         ExecutionResult result = runTasksSuccessfully('run')
         !result.standardOutput.contains('--add-exports')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Does not add externally defined exports to the jar manifest'() {
+    def '#gradleVersionNumber: Does not add externally defined exports to the jar manifest'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         Manifest manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
@@ -407,9 +466,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
                 .collect(MoreCollectors.onlyElement())
         String manifestValue = jarFile.getManifest().getMainAttributes().getValue('Add-Exports')
         manifestValue == null
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Validates exports'() {
+    def '#gradleVersionNumber: Validates exports'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         application {
@@ -424,9 +488,14 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         then:
         ExecutionResult result = runTasksWithFailure('jar')
         result.standardError.contains('separated by a single slash')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
-    def 'Task not up-to-date when extension value changes'() {
+    def '#gradleVersionNumber: Task not up-to-date when extension value changes'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << '''
         application {
@@ -467,5 +536,8 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         resultBeforeChange.wasExecuted('jar')
         !resultAfterChange.wasUpToDate('jar')
         resultAfterChange.wasExecuted('jar')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 }


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/gradle-baseline/pull/2136, we forced setting the source compatibility in a task action to work around [a bug](https://github.com/gradle/gradle/issues/18824#issuecomment-1026909824) in Gradle where it would add the `--release` flag unnecessarily, which meant we could not use `--add-exports` or `--add-opens`.

This has a couple of problems:
1. Since it access mutable task state inside a task action, it's not good Gradle:
    1. The task cannot be run in parallel with other tasks in the same project
    2. Not configuration cache compatible
2. It prevents people from setting their own `sourceCompatibility` and (`targetCompatibility` if it is less than the `sourceCompatibility`). I want to do this for palantir-java-format to support running in older compiler versions.

[This bug was fixed in Gradle 8](https://github.com/gradle/gradle/commit/03373e22e2de03602e3d08596e0f815d7d4fda89), so we don't need to do this any more.

## After this PR
==COMMIT_MSG==
For baseline-java-versions (for Gradle >=8), do not explicitly set the `sourceCompatibility` of Java compilations in a task action before the task runs. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

