### PR TITLE
Allow test tasks without corresponding source set

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineTesting.java
@@ -141,7 +141,6 @@ public final class BaselineTesting implements Plugin<Project> {
 
     private static Stream<SourceSet> testSourceSetsWhereJunitToolchainDepsHaveNotBeenAutomaticallyAdded(
             Project project) {
-
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         TestingExtension testingExtension = project.getExtensions().getByType(TestingExtension.class);
 
@@ -150,7 +149,7 @@ public final class BaselineTesting implements Plugin<Project> {
 
         return project.getTasks().withType(Test.class).getNames().stream().flatMap(testTaskName -> {
             if (gradleVersionLessThan8 || testTaskNotCreatedByJvmTestSuites(testingExtension, testTaskName)) {
-                return Stream.of(sourceSets.getByName(testTaskName));
+                return Stream.ofNullable(sourceSets.findByName(testTaskName));
             }
 
             return Stream.empty();

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTestingIntegrationTest.groovy
@@ -294,6 +294,23 @@ class BaselineTestingIntegrationTest extends IntegrationSpec {
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
 
+    def '#gradleVersionNumber: test task without source set'() {
+        when:
+        gradleVersion = gradleVersionNumber
+
+        buildFile << standardBuildFile
+        buildFile << '''
+            tasks.register('otherTest', Test.class)
+        '''.stripIndent(true)
+
+        then:
+        // Run a task that will attempt to resolve dependencies
+        runTasksSuccessfully('compileJava')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
+    }
+
     def 'running -Drecreate=true will re-run tests even if no code changes'() {
         buildFile << standardBuildFile
         file('src/test/java/test/JUnit5Test.java') << junit5Test


### PR DESCRIPTION
The refactor in https://github.com/palantir/gradle-baseline/commit/34b446190f04f74e7d6ba8f3bf7a1d1bd9890aed from in https://github.com/palantir/gradle-baseline/pull/3053 unintentionally introduced a requirement that all `Test` tasks must have a corresponding source set.

This PR simply replaces `getByName` with `findByName`. If there is no source set for a given test task, then there's nothing for us to do (there's no configuration to which to add dependencies).