### PR TITLE
baseline-java-versions: Regard projects as applicable for `libraryTarget` iff they have a jar publish plugin

### DIFF
--- a/changelog/@unreleased/pr-3066.v2.yml
+++ b/changelog/@unreleased/pr-3066.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: baseline-java-versions is now much less conservative about what it
+    regards for `libraryTarget` instead of `distributionTarget`. `libraryTarget` will
+    be used if and only if a jar is published using one of the Palantir jar publish
+    plugins.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3066

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -69,7 +69,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
     private static boolean isLibrary(Project project, BaselineJavaVersionExtension projectVersions) {
         Property<Boolean> libraryOverride = projectVersions.overrideLibraryAutoDetection();
         if (libraryOverride.isPresent()) {
-            log.warn(
+            log.info(
                     "{} is considered a library because it has been overridden with library = true",
                     project.getDisplayName());
             return libraryOverride.get();
@@ -77,7 +77,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
 
         for (String plugin : LIBRARY_PLUGINS) {
             if (project.getPluginManager().hasPlugin(plugin)) {
-                log.warn(
+                log.info(
                         "{} is considered a library because the '{}' plugin is applied",
                         project.getDisplayName(),
                         plugin);
@@ -85,12 +85,21 @@ public final class BaselineJavaVersions implements Plugin<Project> {
             }
         }
 
-        // The assumption here is that (at least for Palantir code):
-        //   1. Only individual published jars matter when we upgrade Java versions, as this is what will
-        //      spread to other projects
+        // The whole reason for having libraryTarget vs distributionTarget is so that we can allow distributions
+        // (ie Java code that isn't published and only used in that service) to use newer source features and
+        // class files, allowing everyone to support the newer compilation level *before* libraries they depend on
+        // start requiring the newer compilation level. We want to upgrade distributionTarget first, wait for every
+        // repo to support the new compilation level, then allow libraries to be published with the new level.
+        //
+        // So the assumptions here are that (at least for Palantir code):
+        //   1. Only individual published jars matter for spreading higher compilation level requirements between repos
+        //      when we upgrade Java versions:
         //        a) Jars inside dists/containers are not relevant as they will normally have JDK packaged with them.
-        //        b) Shaded jars will still need to be published to have any kind of affect.
+        //        b) Shaded/fat jars will still need to be published to have any kind of effect.
         //   2. The *only* way to publish an individual jar is to use one of the above library plugins.
+        //
+        // So if the project does not use one of these jar publish plugins, we should let it use distributionTarget
+        // source features.
         log.warn("{} is considered distribution code as it does not publish a jar", project.getDisplayName());
         return false;
     }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -18,13 +18,11 @@ package com.palantir.baseline.plugins.javaversions;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
-import java.util.Set;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.publish.PublishingExtension;
 import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,11 +36,6 @@ public final class BaselineJavaVersions implements Plugin<Project> {
 
     private static final ImmutableSet<String> LIBRARY_PLUGINS =
             ImmutableSet.of("com.palantir.external-publish-jar", "com.palantir.publish-jar");
-
-    private static final ImmutableSet<String> DISTRIBUTION_PLUGINS = ImmutableSet.of(
-            "com.palantir.external-publish-dist",
-            "com.palantir.publish-dist",
-            "com.palantir.sls-java-service-distribution");
 
     @Override
     public void apply(Project project) {
@@ -77,7 +70,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
         Property<Boolean> libraryOverride = projectVersions.overrideLibraryAutoDetection();
         if (libraryOverride.isPresent()) {
             log.warn(
-                    "Project '{}' is considered a library because it has been overridden with library = true",
+                    "{} is considered a library because it has been overridden with library = true",
                     project.getDisplayName());
             return libraryOverride.get();
         }
@@ -85,42 +78,20 @@ public final class BaselineJavaVersions implements Plugin<Project> {
         for (String plugin : LIBRARY_PLUGINS) {
             if (project.getPluginManager().hasPlugin(plugin)) {
                 log.warn(
-                        "Project '{}' is considered a library because the '{}' plugin is applied",
+                        "{} is considered a library because the '{}' plugin is applied",
                         project.getDisplayName(),
                         plugin);
                 return true;
             }
         }
 
-        for (String plugin : DISTRIBUTION_PLUGINS) {
-            if (project.getPluginManager().hasPlugin(plugin)) {
-                log.warn(
-                        "Project '{}' is considered a distribution because the '{}' plugin is applied",
-                        project.getDisplayName(),
-                        plugin);
-                return false;
-            }
-        }
-
-        PublishingExtension publishing = project.getExtensions().findByType(PublishingExtension.class);
-        if (publishing == null) {
-            log.warn(
-                    "Project '{}' is considered a distribution, not a library, because "
-                            + "it doesn't define any publishing extensions",
-                    project.getDisplayName());
-            return false;
-        }
-
-        if (publishing.getPublications().getNames().equals(Set.of("conjure"))) {
-            log.warn(
-                    "Project '{}' is considered a distribution, not a library, because "
-                            + "it only has a single 'conjure' publication",
-                    project.getDisplayName());
-            return false;
-        }
-
-        // Better to be conservative with the java version rather than release something that is too high to be used.
-        log.warn("Project '{}' is considered a library as no other conditions matched", project.getDisplayName());
-        return true;
+        // The assumption here is that (at least for Palantir code):
+        //   1. Only individual published jars matter when we upgrade Java versions, as this is what will
+        //      spread to other projects
+        //        a) Jars inside dists/containers are not relevant as they will normally have JDK packaged with them.
+        //        b) Shaded jars will still need to be published to have any kind of affect.
+        //   2. The *only* way to publish an individual jar is to use one of the above library plugins.
+        log.warn("{} is considered distribution code as it does not publish a jar", project.getDisplayName());
+        return false;
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -18,6 +18,7 @@ package com.palantir.baseline.plugins.javaversions;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
+import java.util.Set;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -75,7 +76,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
     private static boolean isLibrary(Project project, BaselineJavaVersionExtension projectVersions) {
         Property<Boolean> libraryOverride = projectVersions.overrideLibraryAutoDetection();
         if (libraryOverride.isPresent()) {
-            log.debug(
+            log.warn(
                     "Project '{}' is considered a library because it has been overridden with library = true",
                     project.getDisplayName());
             return libraryOverride.get();
@@ -83,7 +84,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
 
         for (String plugin : LIBRARY_PLUGINS) {
             if (project.getPluginManager().hasPlugin(plugin)) {
-                log.debug(
+                log.warn(
                         "Project '{}' is considered a library because the '{}' plugin is applied",
                         project.getDisplayName(),
                         plugin);
@@ -93,7 +94,7 @@ public final class BaselineJavaVersions implements Plugin<Project> {
 
         for (String plugin : DISTRIBUTION_PLUGINS) {
             if (project.getPluginManager().hasPlugin(plugin)) {
-                log.debug(
+                log.warn(
                         "Project '{}' is considered a distribution because the '{}' plugin is applied",
                         project.getDisplayName(),
                         plugin);
@@ -103,15 +104,23 @@ public final class BaselineJavaVersions implements Plugin<Project> {
 
         PublishingExtension publishing = project.getExtensions().findByType(PublishingExtension.class);
         if (publishing == null) {
-            log.debug(
+            log.warn(
                     "Project '{}' is considered a distribution, not a library, because "
                             + "it doesn't define any publishing extensions",
                     project.getDisplayName());
             return false;
         }
 
+        if (publishing.getPublications().getNames().equals(Set.of("conjure"))) {
+            log.warn(
+                    "Project '{}' is considered a distribution, not a library, because "
+                            + "it only has a single 'conjure' publication",
+                    project.getDisplayName());
+            return false;
+        }
+
         // Better to be conservative with the java version rather than release something that is too high to be used.
-        log.debug("Project '{}' is considered a library as no other conditions matched", project.getDisplayName());
+        log.warn("Project '{}' is considered a library as no other conditions matched", project.getDisplayName());
         return true;
     }
 }


### PR DESCRIPTION
## Before this PR
Currently we are _very_ conservative with what we choose to be "published library" vs "distribution only" code in baseline-java-versions. If there is any hint of publishing, even if there are no publications, we regard the project as a published library.

Internally, lots of repos have Gradle projects that are internal only (no jar is published) but happen to publish some non-jar resource (eg `conjure` or `audit-schema`). baseline-java-versions currently regards these as `libraryTarget` despite being internal only. People have started to use the hidden `override...` property to fix it, which is less than ideal: it should just do the right thing.

## After this PR
==COMMIT_MSG==
baseline-java-versions is now much less conservative about what it regards for `libraryTarget` instead of `distributionTarget`. `libraryTarget` will be used if and only if a jar is published using one of the Palantir jar publish plugins.
==COMMIT_MSG==

## Possible downsides?
* What about Gradle plugins etc bundled into maven-bundles? Is this going to now make them `distributionTarget`? Similar question for other jar based stuff packaged into maven bundles and run in prod (flink? magritte?)

---

I think baseline-java-versions needs a complete overhaul. This PR is a patch more than anything and the plugin still has some deep problems:

* It's very much in a "working by accident" state, as now Gradle requires the JDK levels very early on in the build, which just happens to be after the `publish-jar` plugin is applied. If it were just a bit earlier, it would not work.
* The providers to work out the target/runtime versions are called many times throughout the build and produce different values depending on the time they are called. Finalising them on read breaks everything at it finalises a calculation that's too early.
* It's very hard to work out _why_ a project is a certain runtime/target without running with extra logging.
* Some situations it's just wrong (eg libraryTarget test code depends on testing library project that is now marked as distributionTarget). Ideally it needs to take into account all the dependents for each project.

All of these could probably be solved by having lock files in each project. Then we can work out library vs distribution target later in the build ie at task input property calculation time rather than super early on in configuration time - then we could actually look at publications and inter-project dependencies etc safely

