### PR TITLE
Disallow duplicate files in archive tasks

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineReproducibility.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineReproducibility.java
@@ -20,7 +20,6 @@ import com.palantir.baseline.tasks.CheckExplicitSourceCompatibilityTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
@@ -34,7 +33,6 @@ public final class BaselineReproducibility implements Plugin<Project> {
         project.getTasks().withType(AbstractArchiveTask.class).configureEach(t -> {
             t.setPreserveFileTimestamps(false);
             t.setReproducibleFileOrder(true);
-            t.setDuplicatesStrategy(DuplicatesStrategy.WARN);
         });
 
         project.getPluginManager().withPlugin("nebula.info", plugin -> {


### PR DESCRIPTION
Gradle 7.0 changed the default duplicates strategy from `WARN` to fail if there are duplicates and an explicit duplicates strategy has not been set.

By explicitly setting a duplicates strategy here, we are opting in to less strict behavior than the Gradle defaults. We definitely do not want to allow duplicate files in archives in order to ensure reproducibility.

If existing repos produce duplicate files and cannot easily fix it, they can explicitly set the duplicate strategy to `WARN` or lower.