### PR TITLE
baseline-java-versions: `explainJavaVersions` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,16 @@ The configurable fields of the `javaVersions` extension are:
 
 The configured Java versions are used as defaults for all projects.
 
+You can run the `explainJavaVersions` task to both show what the `target` and `runtime` versions are for each subproject, and explain why:
+
+```
+$ ./gradle explainJavaVersions
+> Task :subproject:explainJavaVersions
+target  = 11
+runtime = 17
+Reason: considered a distribution because it doesn't have any publishing extensions defined
+```
+
 If a sub-project should use `libraryTarget` but is not considered a library (for example, because it is not published), you can explicitly indicate that it is a library:
 
 ```gradle

--- a/changelog/@unreleased/pr-3079.v2.yml
+++ b/changelog/@unreleased/pr-3079.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: 'baseline-java-versions: Provide an `explainJavaVersions` task that
+    makes it easier to work out which `target` and `runtime` java versions have been
+    chosen by the plugin and why.'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3079

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -126,8 +126,8 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                                 + "distribution type is being published. The publications in this extensions are "
                                 + publishing.getPublications().getNames(),
                         String.format(
-                                "Despite not having any library publish plugins (%s), this is conservatively regarded as a "
-                                        + "library for safety.",
+                                "Despite not having any library publish plugins (%s), this is conservatively "
+                                        + "regarded as a library for safety.",
                                 LIBRARY_PLUGINS)));
     }
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -76,12 +76,16 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                     : rootExtension.distributionTarget().get();
         });
 
+        Property<ChosenJavaVersion> suggestedRuntime = rootExtension.runtime();
+
         projectVersions.target().convention(suggestedTarget);
-        projectVersions.runtime().convention(rootExtension.runtime());
+        projectVersions.runtime().convention(suggestedRuntime);
 
         project.getTasks().register("explainJavaVersions", ExplainJavaVersions.class, explainJavaVersions -> {
             explainJavaVersions.getTarget().set(projectVersions.target());
+            explainJavaVersions.getDefaultTarget().set(suggestedTarget);
             explainJavaVersions.getRuntime().set(projectVersions.runtime());
+            explainJavaVersions.getDefaultRuntime().set(suggestedRuntime);
             explainJavaVersions.getReasoning().set(project.provider(() -> isLibrary(project, projectVersions)
                     .toString()));
         });

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersions.java
@@ -59,59 +59,78 @@ public final class BaselineJavaVersions implements Plugin<Project> {
                 proj.getExtensions().create(EXTENSION_NAME, SubprojectBaselineJavaVersionsExtension.class, proj));
 
         project.allprojects(proj -> proj.getPluginManager().withPlugin("java", unused -> {
-            proj.getPluginManager().apply(BaselineJavaVersion.class);
-            BaselineJavaVersionExtension projectVersions =
-                    proj.getExtensions().getByType(BaselineJavaVersionExtension.class);
-
-            Provider<ChosenJavaVersion> suggestedTarget = proj.provider(() -> isLibrary(proj, projectVersions)
-                    ? ChosenJavaVersion.of(rootExtension.libraryTarget().get())
-                    : rootExtension.distributionTarget().get());
-
-            projectVersions.target().convention(suggestedTarget);
-            projectVersions.runtime().convention(rootExtension.runtime());
+            configureJavaProject(proj, rootExtension);
         }));
     }
 
-    private static boolean isLibrary(Project project, BaselineJavaVersionExtension projectVersions) {
+    private static void configureJavaProject(Project project, BaselineJavaVersionsExtension rootExtension) {
+        project.getPluginManager().apply(BaselineJavaVersion.class);
+        BaselineJavaVersionExtension projectVersions =
+                project.getExtensions().getByType(BaselineJavaVersionExtension.class);
+
+        Provider<ChosenJavaVersion> suggestedTarget = project.provider(() -> {
+            IsLibraryWithReason isLibraryWithReason = isLibrary(project, projectVersions);
+            log.info("{} is {}", project.getDisplayName(), isLibraryWithReason);
+            return isLibraryWithReason.isLibrary()
+                    ? ChosenJavaVersion.of(rootExtension.libraryTarget().get())
+                    : rootExtension.distributionTarget().get();
+        });
+
+        projectVersions.target().convention(suggestedTarget);
+        projectVersions.runtime().convention(rootExtension.runtime());
+
+        project.getTasks().register("explainJavaVersions", ExplainJavaVersions.class, explainJavaVersions -> {
+            explainJavaVersions.getTarget().set(projectVersions.target());
+            explainJavaVersions.getRuntime().set(projectVersions.runtime());
+            explainJavaVersions.getReasoning().set(project.provider(() -> isLibrary(project, projectVersions)
+                    .toString()));
+        });
+    }
+
+    private static IsLibraryWithReason isLibrary(Project project, BaselineJavaVersionExtension projectVersions) {
         Property<Boolean> libraryOverride = projectVersions.overrideLibraryAutoDetection();
         if (libraryOverride.isPresent()) {
-            log.debug(
-                    "Project '{}' is considered a library because it has been overridden with library = true",
-                    project.getDisplayName());
-            return libraryOverride.get();
+            return new IsLibraryWithReason(
+                    libraryOverride.get(), "has been overridden with `library = " + libraryOverride.get() + "`");
         }
 
         for (String plugin : LIBRARY_PLUGINS) {
             if (project.getPluginManager().hasPlugin(plugin)) {
-                log.debug(
-                        "Project '{}' is considered a library because the '{}' plugin is applied",
-                        project.getDisplayName(),
-                        plugin);
-                return true;
+                return new IsLibraryWithReason(true, String.format("has the '%s' plugin applied", plugin));
             }
         }
 
         for (String plugin : DISTRIBUTION_PLUGINS) {
             if (project.getPluginManager().hasPlugin(plugin)) {
-                log.debug(
-                        "Project '{}' is considered a distribution because the '{}' plugin is applied",
-                        project.getDisplayName(),
-                        plugin);
-                return false;
+                return new IsLibraryWithReason(false, String.format("has the '%s' plugin applied", plugin));
             }
         }
 
         PublishingExtension publishing = project.getExtensions().findByType(PublishingExtension.class);
         if (publishing == null) {
-            log.debug(
-                    "Project '{}' is considered a distribution, not a library, because "
-                            + "it doesn't define any publishing extensions",
-                    project.getDisplayName());
-            return false;
+            return new IsLibraryWithReason(false, "doesn't have any publishing extensions defined");
         }
 
         // Better to be conservative with the java version rather than release something that is too high to be used.
-        log.debug("Project '{}' is considered a library as no other conditions matched", project.getDisplayName());
-        return true;
+        return new IsLibraryWithReason(
+                true,
+                String.join(
+                        "\n",
+                        "didn't match any other conditions that would indicate it was a distribution:",
+                        "  * It did not have a distribution plugin: " + DISTRIBUTION_PLUGINS,
+                        "  * It had a publishing extension, indicating *something* that isn't a known "
+                                + "distribution type is being published. The publications in this extensions are "
+                                + publishing.getPublications().getNames(),
+                        String.format(
+                                "Despite not having any library publish plugins (%s), this is conservatively regarded as a "
+                                        + "library for safety.",
+                                LIBRARY_PLUGINS)));
+    }
+
+    private record IsLibraryWithReason(boolean isLibrary, String reason) {
+        @Override
+        public String toString() {
+            return String.format("considered a %s because it %s", isLibrary ? "library" : "distribution", reason);
+        }
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/ExplainJavaVersions.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/ExplainJavaVersions.java
@@ -26,15 +26,38 @@ public abstract class ExplainJavaVersions extends DefaultTask {
     public abstract Property<ChosenJavaVersion> getTarget();
 
     @Input
+    public abstract Property<ChosenJavaVersion> getDefaultTarget();
+
+    @Input
     public abstract Property<ChosenJavaVersion> getRuntime();
+
+    @Input
+    public abstract Property<ChosenJavaVersion> getDefaultRuntime();
 
     @Input
     public abstract Property<String> getReasoning();
 
     @TaskAction
     public final void action() {
-        getLogger().lifecycle("target  = {}", getTarget().get().toString());
-        getLogger().lifecycle("runtime = {}", getRuntime().get().toString());
+        getLogger()
+                .lifecycle(
+                        "target  = {} {}",
+                        getTarget().get().toString(),
+                        defaultValueChanged(getTarget(), getDefaultTarget()));
+
+        getLogger()
+                .lifecycle(
+                        "runtime = {} {}",
+                        getRuntime().get().toString(),
+                        defaultValueChanged(getRuntime(), getDefaultRuntime()));
+
         getLogger().lifecycle("Reason: {}", getReasoning().get());
+    }
+
+    private static String defaultValueChanged(
+            Property<ChosenJavaVersion> actualValue, Property<ChosenJavaVersion> defaultValue) {
+        return actualValue.get().equals(defaultValue.get())
+                ? "(default value)"
+                : String.format("(default value was %s - changed by a Gradle script or plugin)", defaultValue.get());
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/ExplainJavaVersions.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/ExplainJavaVersions.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.plugins.javaversions;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+
+public abstract class ExplainJavaVersions extends DefaultTask {
+    @Input
+    public abstract Property<ChosenJavaVersion> getTarget();
+
+    @Input
+    public abstract Property<ChosenJavaVersion> getRuntime();
+
+    @Input
+    public abstract Property<String> getReasoning();
+
+    @TaskAction
+    public final void action() {
+        getLogger().lifecycle("target  = {}", getTarget().get().toString());
+        getLogger().lifecycle("runtime = {}", getRuntime().get().toString());
+        getLogger().lifecycle("Reason: {}", getReasoning().get());
+    }
+}

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineJavaVersionIntegrationTest.groovy
@@ -690,6 +690,28 @@ class BaselineJavaVersionIntegrationTest extends IntegrationSpec {
         gradleVersionNumber << GRADLE_TEST_VERSIONS
     }
 
+
+    def '#gradleVersionNumber: explainJavaVersions prints the java version used'() {
+        fork = false
+        buildFile << '''
+            javaVersions {
+                libraryTarget = 11
+                runtime = 17
+            }
+        '''.stripIndent(true)
+
+        when:
+        def stdout = runTasksSuccessfully('explainJavaVersions').standardOutput
+
+        then:
+        stdout.contains('target  = 11')
+        stdout.contains('runtime = 17')
+        stdout.contains('Reason:')
+
+        where:
+        gradleVersionNumber << GRADLE_TEST_VERSIONS
+    }
+
     private static final int BYTECODE_IDENTIFIER = (int) 0xCAFEBABE
 
     // See http://illegalargumentexception.blogspot.com/2009/07/java-finding-class-versions.html


### PR DESCRIPTION
## Before this PR
It's hard to work out which versions baseline-java-versions has chosen for each project without looking at the logs or debugging.

## After this PR
==COMMIT_MSG==
baseline-java-versions: Provide an `explainJavaVersions` task that makes it easier to work out which `target` and `runtime` java versions have been chosen by the plugin and why.
==COMMIT_MSG==

Example output from a repo:

```
> Task :project-api:explainJavaVersions
target  = 21 (default value was 17 - changed by a Gradle script or plugin)
runtime = 21 (default value)
Reason: considered a library because it didn't match any other conditions that would indicate it was a distribution:
  * It did not have a distribution plugin: [com.palantir.external-publish-dist, com.palantir.publish-dist, com.palantir.sls-java-service-distribution]
  * It had a publishing extension, indicating *something* that isn't a known distribution type is being published. The publications in this extensions are [auditSchema, conjure]
Despite not having any library publish plugins ([com.palantir.external-publish-jar, com.palantir.publish-jar]), this is conservatively regarded as a library for safety.

> Task :project-adjudicator-provider:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-adjudicator-api:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-adjudicator-impl-installation:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-commons:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-adjudicator-impl-release-channel-promotion:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-internal-api:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a library because it didn't match any other conditions that would indicate it was a distribution:
  * It did not have a distribution plugin: [com.palantir.external-publish-dist, com.palantir.publish-dist, com.palantir.sls-java-service-distribution]
  * It had a publishing extension, indicating *something* that isn't a known distribution type is being published. The publications in this extensions are [auditSchema, conjure]
Despite not having any library publish plugins ([com.palantir.external-publish-jar, com.palantir.publish-jar]), this is conservatively regarded as a library for safety.

> Task :extras:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-api:project-api-objects:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a library because it has the 'com.palantir.publish-jar' plugin applied

> Task :project-api:project-api-typescript:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it has the 'com.palantir.publish-dist' plugin applied

> Task :project-api:project-api-undertow:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a library because it has the 'com.palantir.publish-jar' plugin applied

> Task :project-constraints:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-store-alta:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-internal-api:project-internal-api-objects:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-api:audited-project-api:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a library because it has the 'com.palantir.publish-jar' plugin applied

> Task :project-store-api:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a library because it didn't match any other conditions that would indicate it was a distribution:
  * It did not have a distribution plugin: [com.palantir.external-publish-dist, com.palantir.publish-dist, com.palantir.sls-java-service-distribution]
  * It had a publishing extension, indicating *something* that isn't a known distribution type is being published. The publications in this extensions are [auditSchema, conjure]
Despite not having any library publish plugins ([com.palantir.external-publish-jar, com.palantir.publish-jar]), this is conservatively regarded as a library for safety.

> Task :project-internal-api:audited-project-internal-api:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-store-api:audited-project-store-api:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :project-api:project-api-dialogue:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a library because it has the 'com.palantir.publish-jar' plugin applied

> Task :project-store-api:project-store-api-objects:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined

> Task :extras:test-common:explainJavaVersions
target  = 17 (default value)
runtime = 21 (default value)
Reason: considered a distribution because it doesn't have any publishing extensions defined
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

