### PR TITLE
Fix gradle 7 compat for checkClassUniquenessTask

### DIFF
--- a/changelog/@unreleased/pr-3090.v2.yml
+++ b/changelog/@unreleased/pr-3090.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix gradle 7 compat for checkClassUniquenessTask
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3090

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.Named;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.Property;
@@ -86,11 +87,13 @@ public class CheckClassUniquenessLockTask extends DefaultTask {
      */
     @Input
     public final Map<String, ImmutableList<String>> getContentsOfAllConfigurations() {
-        return configurations.get().stream().collect(Collectors.toMap(Configuration::getName, configuration -> {
-            return configuration.getIncoming().getResolutionResult().getAllComponents().stream()
-                    .map(resolvedComponentResult -> Objects.toString(resolvedComponentResult.getModuleVersion()))
-                    .collect(ImmutableList.toImmutableList()); // Gradle requires this to be Serializable
-        }));
+        return configurations.get().stream()
+                .collect(Collectors.toMap(CheckClassUniquenessLockTask::getConfigurationName, configuration -> {
+                    return configuration.getIncoming().getResolutionResult().getAllComponents().stream()
+                            .map(resolvedComponentResult ->
+                                    Objects.toString(resolvedComponentResult.getModuleVersion()))
+                            .collect(ImmutableList.toImmutableList()); // Gradle requires this to be Serializable
+                }));
     }
 
     @OutputFile
@@ -107,7 +110,9 @@ public class CheckClassUniquenessLockTask extends DefaultTask {
     public final void doIt() {
         ImmutableSortedMap<String, Optional<String>> resultsByConfiguration = configurations.get().stream()
                 .collect(ImmutableSortedMap.toImmutableSortedMap(
-                        Comparator.naturalOrder(), Configuration::getName, configuration -> {
+                        Comparator.naturalOrder(),
+                        CheckClassUniquenessLockTask::getConfigurationName,
+                        configuration -> {
                             ClassUniquenessAnalyzer analyzer = new ClassUniquenessAnalyzer(
                                     jarClassHasher.get(), getProject().getLogger());
                             analyzer.analyzeConfiguration(configuration);
@@ -225,5 +230,23 @@ public class CheckClassUniquenessLockTask extends DefaultTask {
                 throw new GradleException(lockFile + " should not exist (as no problems were found).");
             }
         }
+    }
+
+    /**
+     * Needed for gradle 7 -> 8 compatibility.  The Configuration interface directly had a getName() method in gradle 7.
+     * This was removed in gradle 8 and instead Configuration extends Named.  While the method signature is the same,
+     * code compiled against gradle 8 will have an incorrect reference to it in the class file when run under gradle 7.
+     *
+     * This method works around that by having the code check for what interfaces are implemented at runtime.  Could
+     * also use reflection to just find the getName method but this is a little more explicit as to why.
+     */
+    private static String getConfigurationName(Object config) {
+        if (config instanceof Named) {
+            return ((Named) config).getName();
+        } else if (config instanceof Configuration) {
+            return ((Configuration) config).getName();
+        }
+
+        throw new IllegalArgumentException("Unknown class for getting name: " + config.getClass());
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineClassUniquenessPluginIntegrationTest.groovy
@@ -16,6 +16,9 @@
 
 package com.palantir.baseline
 
+import com.palantir.gradle.plugintesting.GradleTestVersions
+import spock.lang.Unroll
+
 import java.nio.file.Files
 import java.util.stream.Stream
 import org.gradle.testkit.runner.BuildResult
@@ -37,7 +40,8 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
         }
     """.stripIndent()
 
-    def 'detect duplicates in two external jars, then --fix captures'() {
+    @Unroll
+    def '#gradleVersion: detect duplicates in two external jars, then --fix captures'() {
         File lockfile = new File(projectDir, 'baseline-class-uniqueness.lock')
 
         when:
@@ -48,7 +52,7 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
             api group: 'javax.servlet.jsp', name: 'jsp-api', version: '2.1'
         }
         """.stripIndent()
-        BuildResult result = with('check', '-s').buildAndFail()
+        BuildResult result = with('check', '-s').withGradleVersion(gradleVersion).buildAndFail()
 
         then:
         result.getOutput().contains("baseline-class-uniqueness detected multiple jars containing identically named classes.")
@@ -57,7 +61,7 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
         !lockfile.exists()
 
         when:
-        with("checkClassUniqueness", "--fix").build()
+        with("checkClassUniqueness", "--fix").withGradleVersion(gradleVersion).build()
 
         then:
         lockfile.exists()
@@ -66,6 +70,9 @@ class BaselineClassUniquenessPluginIntegrationTest extends AbstractPluginTest {
             GFileUtils.writeFile(lockfile.text, expected)
         }
         lockfile.text == expected.text
+
+        where:
+        gradleVersion << GradleTestVersions.gradleVersionsForTests
     }
 
     def 'detect duplicates in two external jars, then --write-locks captures'() {


### PR DESCRIPTION
## Before this PR
When run under gradle 7, the checkClassUniquenessTask gets this error:
LambdaConversionException: Invalid receiver type interface org.gradle.api.artifacts.Configuration; not a subtype of implementation type interface org.gradle.api.Named 

The problem comes in the multiple references to Configuration::getName in CheckClassUniquenessLockTask. The Configuration interface directly had a getName() method in gradle 7. This was removed in gradle 8 and instead Configuration extends Named.  While the method signature is the same, code compiled against gradle 8 will have an incorrect reference to it in the class file when run under gradle 7.

When compiling against the Gradle 7.6.4 API, the method that ends up in the class file is Configuration.getName.
When compiling against the Gradle 8.12.1 API, the method that ends up in the class file is Named.getName.
When you try to run the latter with Gradle 7.6.4, it fails because we attempt to invoke Named.getName on a Configuration object, but Configuration does not implement Named.

## After this PR
This method works around that by having the code check for what interfaces are implemented at runtime.  Could also use reflection to just find the getName method but this is a little more explicit as to why.
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

