### PR TITLE
Move Slf4jLogsafeArgs to ERROR level

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jLogsafeArgs.java
@@ -44,7 +44,7 @@ import java.util.regex.Pattern;
 @BugPattern(
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
-        severity = SeverityLevel.WARNING,
+        severity = SeverityLevel.ERROR,
         summary = "Allow only com.palantir.logsafe.Arg types, or vararg arrays, as parameter inputs to slf4j log "
                 + "messages.")
 public final class Slf4jLogsafeArgs extends BugChecker implements MethodInvocationTreeMatcher {

--- a/changelog/@unreleased/pr-3092.v2.yml
+++ b/changelog/@unreleased/pr-3092.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Move Slf4jLogsafeArgs to ERROR level
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3092


### PR DESCRIPTION
## Before this PR
This check was presumably introduced as WARNING to allow its rollout without actually breaking builds. However, this also means that it will be ignored in a lot of cases.

With https://github.com/palantir/suppressible-error-prone now being a thing, and the new capability to remove the for-rollout suppressions to automatically open PRs to flag these, this means we can safely move this to ERROR level. Cases that will now be flagged as errors that weren't previously can be easily suppressed by suppressible-error-prone, and flagged in separate PRs for fixing.

## After this PR
==COMMIT_MSG==
Move Slf4jLogsafeArgs to ERROR level
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

