### PR TITLE
Replace getAllModuleArtifacts with getModuleArtifacts

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.StringUtils;
@@ -46,7 +45,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.attributes.LibraryElements;
@@ -300,50 +299,29 @@ public final class BaselineExactDependencies implements Plugin<Project> {
 
     @ThreadSafe
     public static final class Indexes {
-        private final Map<String, Set<ResolvedArtifact>> classToDependency = new ConcurrentHashMap<>();
-        private final Map<ResolvedArtifact, Set<String>> classesFromArtifact = new ConcurrentHashMap<>();
-        private final Map<ResolvedArtifact, ResolvedDependency> artifactsFromDependency = new ConcurrentHashMap<>();
+        private final Map<String, Set<ResolvedArtifact>> classToArtifacts = new ConcurrentHashMap<>();
 
-        public void populateIndexes(Set<ResolvedDependency> declaredDependencies) {
-            Set<ResolvedArtifact> allArtifacts = declaredDependencies.stream()
-                    .flatMap(dependency -> dependency.getAllModuleArtifacts().stream())
-                    .filter(dependency -> VALID_ARTIFACT_EXTENSIONS.contains(dependency.getExtension()))
-                    .collect(Collectors.toSet());
-
-            allArtifacts.forEach(artifact -> {
-                try {
-                    File jar = artifact.getFile();
-                    Set<String> classesInArtifact =
-                            JAR_ANALYZER.analyze(jar.toURI().toURL());
-                    classesFromArtifact.put(artifact, classesInArtifact);
-                    classesInArtifact.forEach(clazz -> classToDependency
-                            .computeIfAbsent(clazz, _ignored -> ConcurrentHashMap.newKeySet())
-                            .add(artifact));
-                } catch (IOException e) {
-                    throw new RuntimeException("Unable to analyze artifact", e);
-                }
-            });
-
-            declaredDependencies.forEach(dependency -> dependency
-                    .getModuleArtifacts()
-                    .forEach(artifact -> artifactsFromDependency.put(artifact, dependency)));
+        public void populateIndexes(Set<ResolvedConfiguration> configurations) {
+            configurations.stream()
+                    .flatMap(configuration -> configuration.getResolvedArtifacts().stream())
+                    .filter(artifact -> VALID_ARTIFACT_EXTENSIONS.contains(artifact.getExtension()))
+                    .forEach(artifact -> {
+                        try {
+                            File jar = artifact.getFile();
+                            Set<String> classesInArtifact =
+                                    JAR_ANALYZER.analyze(jar.toURI().toURL());
+                            classesInArtifact.forEach(clazz -> classToArtifacts
+                                    .computeIfAbsent(clazz, _ignored -> ConcurrentHashMap.newKeySet())
+                                    .add(artifact));
+                        } catch (IOException e) {
+                            throw new RuntimeException("Unable to analyze artifact", e);
+                        }
+                    });
         }
 
         /** Given a class, what dependency brought it in. */
         public Stream<ResolvedArtifact> classToArtifacts(String clazz) {
-            return classToDependency.getOrDefault(clazz, ImmutableSet.of()).stream();
-        }
-
-        /** Given an artifact, what classes does it contain. */
-        public Stream<String> classesFromArtifact(ResolvedArtifact resolvedArtifact) {
-            return Preconditions.checkNotNull(
-                    classesFromArtifact.get(resolvedArtifact), "Unable to find resolved artifact")
-                    .stream();
-        }
-
-        public ResolvedDependency artifactsFromDependency(ResolvedArtifact resolvedArtifact) {
-            return Preconditions.checkNotNull(
-                    artifactsFromDependency.get(resolvedArtifact), "Unable to find resolved artifact");
+            return classToArtifacts.getOrDefault(clazz, ImmutableSet.of()).stream();
         }
     }
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -43,6 +43,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
@@ -300,6 +301,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     @ThreadSafe
     public static final class Indexes {
         private final Map<String, Set<ResolvedArtifact>> classToArtifacts = new ConcurrentHashMap<>();
+        private final Map<ResolvedArtifact, Set<String>> classesFromArtifact = new ConcurrentHashMap<>();
 
         public void populateIndexes(Set<ResolvedConfiguration> configurations) {
             configurations.stream()
@@ -310,6 +312,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             File jar = artifact.getFile();
                             Set<String> classesInArtifact =
                                     JAR_ANALYZER.analyze(jar.toURI().toURL());
+                            classesFromArtifact.put(artifact, classesInArtifact);
                             classesInArtifact.forEach(clazz -> classToArtifacts
                                     .computeIfAbsent(clazz, _ignored -> ConcurrentHashMap.newKeySet())
                                     .add(artifact));
@@ -322,6 +325,23 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         /** Given a class, what dependency brought it in. */
         public Stream<ResolvedArtifact> classToArtifacts(String clazz) {
             return classToArtifacts.getOrDefault(clazz, ImmutableSet.of()).stream();
+        }
+
+        /** Given an artifact, what classes does it contain. */
+        public Stream<String> classesFromArtifact(ResolvedArtifact resolvedArtifact) {
+            return Preconditions.checkNotNull(
+                    classesFromArtifact.get(resolvedArtifact), "Unable to find resolved artifact")
+                    .stream();
+        }
+
+        public ModuleIdentifier getArtifactModuleId(ResolvedArtifact resolvedArtifact) {
+            return resolvedArtifact.getModuleVersion().getId().getModule();
+        }
+
+        public Stream<ResolvedArtifact> findArtifactsWithSameModuleId(ResolvedArtifact artifact) {
+            ModuleIdentifier moduleId = getArtifactModuleId(artifact);
+            return classesFromArtifact.keySet().stream()
+                    .filter(otherArtifact -> getArtifactModuleId(otherArtifact).equals(moduleId));
         }
     }
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckImplicitDependenciesTask.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
@@ -63,17 +63,20 @@ public class CheckImplicitDependenciesTask extends DefaultTask {
 
     @TaskAction
     public final void checkImplicitDependencies() {
-        Set<ResolvedDependency> declaredDependencies = dependenciesConfigurations.get().stream()
+        Set<ResolvedConfiguration> resolvedConfigurations = dependenciesConfigurations.get().stream()
                 .map(Configuration::getResolvedConfiguration)
-                .flatMap(resolved -> resolved.getFirstLevelModuleDependencies().stream())
                 .collect(Collectors.toSet());
-        BaselineExactDependencies.INDEXES.populateIndexes(declaredDependencies);
+        BaselineExactDependencies.INDEXES.populateIndexes(resolvedConfigurations);
+
+        Set<ResolvedArtifact> declaredArtifacts = resolvedConfigurations.stream()
+                .flatMap(resolved -> resolved.getFirstLevelModuleDependencies().stream())
+                .flatMap(dependency -> dependency.getModuleArtifacts().stream())
+                .filter(dependency ->
+                        BaselineExactDependencies.VALID_ARTIFACT_EXTENSIONS.contains(dependency.getExtension()))
+                .collect(Collectors.toSet());
 
         Set<List<ResolvedArtifact>> necessaryArtifacts = referencedClasses().stream()
                 .map(c -> BaselineExactDependencies.INDEXES.classToArtifacts(c).collect(Collectors.toList()))
-                .collect(Collectors.toSet());
-        Set<ResolvedArtifact> declaredArtifacts = declaredDependencies.stream()
-                .flatMap(dependency -> dependency.getModuleArtifacts().stream())
                 .collect(Collectors.toSet());
 
         List<ResolvedArtifact> usedButUndeclared = necessaryArtifacts.stream()

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
@@ -62,13 +62,13 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
 
     @TaskAction
     public final void checkUnusedDependencies() {
-        Set<ResolvedDependency> declaredDependencies = dependenciesConfigurations.get().stream()
+        Set<ResolvedConfiguration> resolvedConfigurations = dependenciesConfigurations.get().stream()
                 .map(Configuration::getResolvedConfiguration)
-                .flatMap(resolved -> resolved.getFirstLevelModuleDependencies().stream())
                 .collect(Collectors.toSet());
-        BaselineExactDependencies.INDEXES.populateIndexes(declaredDependencies);
+        BaselineExactDependencies.INDEXES.populateIndexes(resolvedConfigurations);
 
-        Set<ResolvedArtifact> declaredArtifacts = declaredDependencies.stream()
+        Set<ResolvedArtifact> declaredArtifacts = resolvedConfigurations.stream()
+                .flatMap(resolved -> resolved.getFirstLevelModuleDependencies().stream())
                 .flatMap(dependency -> dependency.getModuleArtifacts().stream())
                 .filter(dependency ->
                         BaselineExactDependencies.VALID_ARTIFACT_EXTENSIONS.contains(dependency.getExtension()))
@@ -83,55 +83,29 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
                 .map(BaselineExactDependencies::asString)
                 .collect(Collectors.toSet());
 
-        Set<ResolvedArtifact> possiblyUnused = declaredArtifacts.stream()
+        Set<ResolvedArtifact> possiblyUnusedArtifacts = declaredArtifacts.stream()
                 .filter(artifact ->
                         !necessaryArtifactsDeclaration.contains(BaselineExactDependencies.asString(artifact)))
                 .collect(Collectors.toSet());
         getLogger()
                 .debug(
                         "Possibly unused dependencies: {}",
-                        possiblyUnused.stream()
+                        possiblyUnusedArtifacts.stream()
                                 .map(BaselineExactDependencies::asString)
                                 .sorted()
                                 .collect(Collectors.toList()));
-        List<ResolvedArtifact> declaredButUnused = possiblyUnused.stream()
+        List<ResolvedArtifact> unusedArtifacts = possiblyUnusedArtifacts.stream()
                 .filter(artifact -> !shouldIgnore(artifact))
                 .sorted(Comparator.comparing(BaselineExactDependencies::asString))
                 .collect(Collectors.toList());
-        if (!declaredButUnused.isEmpty()) {
+        if (!unusedArtifacts.isEmpty()) {
             // TODO(dfox): don't print warnings for jars that define service loaded classes (e.g. meta-inf)
             StringBuilder builder = new StringBuilder();
             builder.append(String.format(
-                    "Found %s dependencies unused during compilation, please delete them from '%s' or choose one of "
-                            + "the suggested fixes:\n",
-                    declaredButUnused.size(), buildFile()));
-            for (ResolvedArtifact resolvedArtifact : declaredButUnused) {
-                builder.append('\t')
-                        .append(BaselineExactDependencies.asDependencyStringWithName(resolvedArtifact))
-                        .append('\n');
-
-                // Suggest fixes by looking at all transitive classes, filtering the ones we have declarations on,
-                // and mapping the remaining ones back to the jars they came from.
-                ResolvedDependency dependency =
-                        BaselineExactDependencies.INDEXES.artifactsFromDependency(resolvedArtifact);
-                Set<ResolvedArtifact> didYouMean = dependency.getAllModuleArtifacts().stream()
-                        .filter(artifact ->
-                                BaselineExactDependencies.VALID_ARTIFACT_EXTENSIONS.contains(artifact.getExtension()))
-                        .flatMap(BaselineExactDependencies.INDEXES::classesFromArtifact)
-                        .filter(referencedClasses()::contains)
-                        .flatMap(BaselineExactDependencies.INDEXES::classToArtifacts)
-                        .filter(artifact -> !declaredArtifacts.contains(artifact))
-                        .collect(Collectors.toSet());
-
-                if (!didYouMean.isEmpty()) {
-                    builder.append("\t\tDid you mean:\n");
-                    didYouMean.stream()
-                            .map(BaselineExactDependencies::asDependencyStringWithoutName)
-                            .sorted()
-                            .forEach(dependencyString -> builder.append("\t\t\t")
-                                    .append(dependencyString)
-                                    .append("\n"));
-                }
+                    "Found %s dependencies unused during compilation, please delete them from '%s':",
+                    unusedArtifacts.size(), buildFile()));
+            for (ResolvedArtifact resolvedArtifact : unusedArtifacts) {
+                builder.append("\n\t").append(BaselineExactDependencies.asDependencyStringWithName(resolvedArtifact));
             }
             throw new ExceptionWithSuggestion(builder.toString(), buildFile().toString());
         }
@@ -155,13 +129,6 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         String dependencyId = BaselineExactDependencies.asString(artifact);
         getLogger().info("Ignoring {} dependency: {}", config.getName(), dependencyId);
         ignore.add(dependencyId);
-    }
-
-    /** All classes which are mentioned in this project's source code. */
-    private Set<String> referencedClasses() {
-        return Streams.stream(sourceClasses.get().iterator())
-                .flatMap(BaselineExactDependencies::referencedClasses)
-                .collect(Collectors.toSet());
     }
 
     private Path buildFile() {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -102,10 +102,34 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
             // TODO(dfox): don't print warnings for jars that define service loaded classes (e.g. meta-inf)
             StringBuilder builder = new StringBuilder();
             builder.append(String.format(
-                    "Found %s dependencies unused during compilation, please delete them from '%s':",
+                    "Found %s dependencies unused during compilation, please delete them from '%s' or choose one of "
+                            + "the suggested fixes:\n",
                     unusedArtifacts.size(), buildFile()));
             for (ResolvedArtifact resolvedArtifact : unusedArtifacts) {
-                builder.append("\n\t").append(BaselineExactDependencies.asDependencyStringWithName(resolvedArtifact));
+                builder.append('\t')
+                        .append(BaselineExactDependencies.asDependencyStringWithName(resolvedArtifact))
+                        .append('\n');
+
+                // Suggest fixes by looking at all artifacts with the same module ID,
+                // filtering the ones we have declarations on, and mapping the remaining ones
+                // back to the jars they came from.
+                Set<ResolvedArtifact> didYouMean = BaselineExactDependencies.INDEXES
+                        .findArtifactsWithSameModuleId(resolvedArtifact)
+                        .flatMap(BaselineExactDependencies.INDEXES::classesFromArtifact)
+                        .filter(referencedClasses()::contains)
+                        .flatMap(BaselineExactDependencies.INDEXES::classToArtifacts)
+                        .filter(artifact -> !declaredArtifacts.contains(artifact))
+                        .collect(Collectors.toSet());
+
+                if (!didYouMean.isEmpty()) {
+                    builder.append("\t\tDid you mean:\n");
+                    didYouMean.stream()
+                            .map(BaselineExactDependencies::asDependencyStringWithoutName)
+                            .sorted()
+                            .forEach(dependencyString -> builder.append("\t\t\t")
+                                    .append(dependencyString)
+                                    .append("\n"));
+                }
             }
             throw new ExceptionWithSuggestion(builder.toString(), buildFile().toString());
         }
@@ -129,6 +153,13 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         String dependencyId = BaselineExactDependencies.asString(artifact);
         getLogger().info("Ignoring {} dependency: {}", config.getName(), dependencyId);
         ignore.add(dependencyId);
+    }
+
+    /** All classes which are mentioned in this project's source code. */
+    private Set<String> referencedClasses() {
+        return Streams.stream(sourceClasses.get().iterator())
+                .flatMap(BaselineExactDependencies::referencedClasses)
+                .collect(Collectors.toSet());
     }
 
     private Path buildFile() {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/AbstractPluginTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/AbstractPluginTest.groovy
@@ -46,6 +46,8 @@ class AbstractPluginTest extends Specification {
             .withProjectDir(projectDir)
             .withArguments(tasks)
             .withPluginClasspath()
+            .withDebug(true)
+            .forwardOutput()
     }
 
     String exec(String task) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -311,7 +311,6 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
         then:
         BuildResult result = with(':checkUnusedDependencies', '--stacktrace').withDebug(true).buildAndFail()
         result.output.contains "project(':sub-project-with-deps') <-- main"
-        result.output.contains "project(':sub-project-no-deps')"
     }
 
     def 'plugin does not cause GCV checkUnusedConstraints to fail'() {


### PR DESCRIPTION
`getAllModuleArtifacts` does not correctly handle circular dependencies. See https://github.com/gradle/gradle/issues/22850.

We should not try to "resolve" dependencies ourselves using `getAllModuleArtifacts`. Instead we should always let Gradle resolve configurations and then use the artifacts from the resolved configuration.