### PR TITLE
Revert "Restore error message"

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -43,7 +43,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExcludeRule;
-import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
@@ -301,7 +300,6 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     @ThreadSafe
     public static final class Indexes {
         private final Map<String, Set<ResolvedArtifact>> classToArtifacts = new ConcurrentHashMap<>();
-        private final Map<ResolvedArtifact, Set<String>> classesFromArtifact = new ConcurrentHashMap<>();
 
         public void populateIndexes(Set<ResolvedConfiguration> configurations) {
             configurations.stream()
@@ -312,7 +310,6 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             File jar = artifact.getFile();
                             Set<String> classesInArtifact =
                                     JAR_ANALYZER.analyze(jar.toURI().toURL());
-                            classesFromArtifact.put(artifact, classesInArtifact);
                             classesInArtifact.forEach(clazz -> classToArtifacts
                                     .computeIfAbsent(clazz, _ignored -> ConcurrentHashMap.newKeySet())
                                     .add(artifact));
@@ -325,23 +322,6 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         /** Given a class, what dependency brought it in. */
         public Stream<ResolvedArtifact> classToArtifacts(String clazz) {
             return classToArtifacts.getOrDefault(clazz, ImmutableSet.of()).stream();
-        }
-
-        /** Given an artifact, what classes does it contain. */
-        public Stream<String> classesFromArtifact(ResolvedArtifact resolvedArtifact) {
-            return Preconditions.checkNotNull(
-                    classesFromArtifact.get(resolvedArtifact), "Unable to find resolved artifact")
-                    .stream();
-        }
-
-        public ModuleIdentifier getArtifactModuleId(ResolvedArtifact resolvedArtifact) {
-            return resolvedArtifact.getModuleVersion().getId().getModule();
-        }
-
-        public Stream<ResolvedArtifact> findArtifactsWithSameModuleId(ResolvedArtifact artifact) {
-            ModuleIdentifier moduleId = getArtifactModuleId(artifact);
-            return classesFromArtifact.keySet().stream()
-                    .filter(otherArtifact -> getArtifactModuleId(otherArtifact).equals(moduleId));
         }
     }
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -102,34 +102,10 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
             // TODO(dfox): don't print warnings for jars that define service loaded classes (e.g. meta-inf)
             StringBuilder builder = new StringBuilder();
             builder.append(String.format(
-                    "Found %s dependencies unused during compilation, please delete them from '%s' or choose one of "
-                            + "the suggested fixes:\n",
+                    "Found %s dependencies unused during compilation, please delete them from '%s':",
                     unusedArtifacts.size(), buildFile()));
             for (ResolvedArtifact resolvedArtifact : unusedArtifacts) {
-                builder.append('\t')
-                        .append(BaselineExactDependencies.asDependencyStringWithName(resolvedArtifact))
-                        .append('\n');
-
-                // Suggest fixes by looking at all artifacts with the same module ID,
-                // filtering the ones we have declarations on, and mapping the remaining ones
-                // back to the jars they came from.
-                Set<ResolvedArtifact> didYouMean = BaselineExactDependencies.INDEXES
-                        .findArtifactsWithSameModuleId(resolvedArtifact)
-                        .flatMap(BaselineExactDependencies.INDEXES::classesFromArtifact)
-                        .filter(referencedClasses()::contains)
-                        .flatMap(BaselineExactDependencies.INDEXES::classToArtifacts)
-                        .filter(artifact -> !declaredArtifacts.contains(artifact))
-                        .collect(Collectors.toSet());
-
-                if (!didYouMean.isEmpty()) {
-                    builder.append("\t\tDid you mean:\n");
-                    didYouMean.stream()
-                            .map(BaselineExactDependencies::asDependencyStringWithoutName)
-                            .sorted()
-                            .forEach(dependencyString -> builder.append("\t\t\t")
-                                    .append(dependencyString)
-                                    .append("\n"));
-                }
+                builder.append("\n\t").append(BaselineExactDependencies.asDependencyStringWithName(resolvedArtifact));
             }
             throw new ExceptionWithSuggestion(builder.toString(), buildFile().toString());
         }
@@ -153,13 +129,6 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         String dependencyId = BaselineExactDependencies.asString(artifact);
         getLogger().info("Ignoring {} dependency: {}", config.getName(), dependencyId);
         ignore.add(dependencyId);
-    }
-
-    /** All classes which are mentioned in this project's source code. */
-    private Set<String> referencedClasses() {
-        return Streams.stream(sourceClasses.get().iterator())
-                .flatMap(BaselineExactDependencies::referencedClasses)
-                .collect(Collectors.toSet());
     }
 
     private Path buildFile() {


### PR DESCRIPTION
Reverts https://github.com/palantir/gradle-baseline/commit/5ae16f87cea5bec76a57ea4ac071a30aa3bdabcb from https://github.com/palantir/gradle-baseline/pull/3093.

This commit doesn't do what it purports to do. If we revert the test changes from that PR, then the test fails, meaning that we're not actually outputting any suggestions.

I'm happy to bring this back if we can find a way, but we should make sure to revert the test changes so we're actually validating that it works as it claims. 