### PR TITLE
Automatically fix  `PatternMatchingInstanceof `

### DIFF
--- a/changelog/@unreleased/pr-3114.v2.yml
+++ b/changelog/@unreleased/pr-3114.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Automatically fix  `PatternMatchingInstanceof `
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3114

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -91,6 +91,7 @@ public abstract class BaselineErrorProneExtension {
             "NarrowCalculation",
             "ObjectsHashCodePrimitive",
             "ProtectedMembersInFinalClass",
+            "PatternMatchingInstanceof",
             "UnnecessaryParentheses",
             "ZoneIdOfZ");
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Follow-up for the internal excavators that bump `distributionTarget = 21`. Most of the excavators are failing because of the `PatternMatchingInstanceof` warning (see internal link [here](https://pl.ntr/2tP)). Discussion about the addition [here](https://pl.ntr/2tO)

==COMMIT_MSG==
Automatically fix  `PatternMatchingInstanceof `
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

