### PR TITLE
Disable some new Google provided errorprone checks

### DIFF
--- a/changelog/@unreleased/pr-3123.v2.yml
+++ b/changelog/@unreleased/pr-3123.v2.yml
@@ -1,0 +1,10 @@
+type: fix
+fix:
+  description: |-
+    Disable some new low-value Google provided errorprone checks:
+    * `AndroidJdkLibsChecker`
+    * `IdentifierName`
+    * `Java8ApiChecker`
+    * `Var`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3123

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -93,12 +93,19 @@ public final class BaselineErrorProne implements Plugin<Project> {
     private static void configureErrorProneOptions(ErrorProneOptions errorProneOptions) {
 
         errorProneOptions.disable(
+                // We don't use the Android SDK, so this check is unnecessary.
+                "AndroidJdkLibsChecker",
                 "AutoCloseableMustBeClosed",
                 "CatchSpecificity",
                 "CanIgnoreReturnValueSuggester",
                 // https://github.com/google/error-prone/issues/4544
                 "DistinctVarargsChecker",
+                // This does not allow underscore prefixed variables, which we use heavily.
+                // We have our checks for naming.
+                "IdentifierName",
                 "InlineMeSuggester",
+                // We are so far beyond needing to support Java 8 at Palantir. In fact we can't run it as it's EOL
+                "Java8ApiChecker",
                 // LambdaMethodReference is incredibly expensive, see #2997. We leave it
                 // here to employ as a cleanup, but don't execute it in most compilations.
                 "LambdaMethodReference",
@@ -107,6 +114,8 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "PreferImmutableStreamExCollections",
                 "UnnecessaryTestMethodPrefix",
                 "UnusedVariable",
+                // Var seems low value. Forcing devs to add a dep for annotations is too much.
+                "Var",
                 // See VarUsage: The var keyword results in illegible code in most cases and should not be used.
                 "Varifier",
                 // Yoda style should not block baseline upgrades.


### PR DESCRIPTION
## Before this PR
When we upgraded errorprone in #3121, it brought in a load of new checks. Some of these are not valuable or relevant with how we write code at Palantir.

## After this PR
==COMMIT_MSG==
Disable some new low-value Google provided errorprone checks:
* `AndroidJdkLibsChecker`
* `IdentifierName`
* `Java8ApiChecker`
* `Var`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

