### PR TITLE
Disable some more built in Google errorprones

### DIFF
--- a/changelog/@unreleased/pr-3124.v2.yml
+++ b/changelog/@unreleased/pr-3124.v2.yml
@@ -1,0 +1,13 @@
+type: fix
+fix:
+  description: |-
+    Disable some new low-value Google provided errorprone checks:
+    * `CatchingUnchecked`
+    * `DifferentNameButSame`
+    * `PreferredInterfaceType`
+    * `ThrowSpecificExceptions`
+    * `UnnecessaryFinal`
+    * `UnnecessaryFullyQualified`
+    * `UnnecessarilyVisible`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3124

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -97,7 +97,13 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "AndroidJdkLibsChecker",
                 "AutoCloseableMustBeClosed",
                 "CatchSpecificity",
+                // This might be worth re-evaluating later and auto-patching. But removing it for now to remove some
+                // auto-suppression noise.
+                "CatchingUnchecked",
                 "CanIgnoreReturnValueSuggester",
+                // This might be worth re-evaluating later - but removing it for now to remove some
+                // auto-suppression noise.
+                "DifferentNameButSame",
                 // https://github.com/google/error-prone/issues/4544
                 "DistinctVarargsChecker",
                 // This does not allow underscore prefixed variables, which we use heavily.
@@ -112,6 +118,22 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 // We often use javadoc comments without javadoc parameter information.
                 "NotJavadoc",
                 "PreferImmutableStreamExCollections",
+                "PreferImmutableCollection",
+                // We prefer to use List<...> instead of ImmutableList<...>. This way we don't expose the
+                // underlying implementation to the user.
+                "PreferredInterfaceType",
+                // This is so common we're not going to enforce it. Personally, I don't think it matters too much
+                // for RuntimeExceptions, as they are not supposed to be caught
+                "ThrowSpecificExceptions",
+                // This check is low value - an extra final doesn't really hurt anyone. It's very spammy when
+                // auto-suppressed though.
+                "UnnecessaryFinal",
+                // This forces Foo.Builder -> Builder, even when you may want to use Foo.Builder, apart from
+                // some allowlist. Let's leave it up to dev's discretion. Most people don't like fully qualified
+                // types anyway.
+                "UnnecessaryFullyQualified",
+                // This one isn't even correct for eg Gradle, which needs to be public.
+                "UnnecessarilyVisible",
                 "UnnecessaryTestMethodPrefix",
                 "UnusedVariable",
                 // Var seems low value. Forcing devs to add a dep for annotations is too much.

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -118,7 +118,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 // We often use javadoc comments without javadoc parameter information.
                 "NotJavadoc",
                 "PreferImmutableStreamExCollections",
-                "PreferImmutableCollection",
                 // We prefer to use List<...> instead of ImmutableList<...>. This way we don't expose the
                 // underlying implementation to the user.
                 "PreferredInterfaceType",

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -130,7 +130,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 // This forces Foo.Builder -> Builder, even when you may want to use Foo.Builder, apart from
                 // some allowlist. Let's leave it up to dev's discretion. Most people don't like fully qualified
                 // types anyway.
-                "UnnecessaryFullyQualified",
+                "UnnecessarilyFullyQualified",
                 // This one isn't even correct for eg Gradle, which needs to be public.
                 "UnnecessarilyVisible",
                 "UnnecessaryTestMethodPrefix",


### PR DESCRIPTION
## Before this PR
When we upgraded errorprone in https://github.com/palantir/gradle-baseline/pull/3121, it brought in a load of new checks. Some of these are not valuable or relevant with how we write code at Palantir.

We disabled some in https://github.com/palantir/gradle-baseline/pull/3123 already, but there are more.

## After this PR
==COMMIT_MSG==
Disable some new low-value Google provided errorprone checks:
* `CatchingUnchecked`
* `DifferentNameButSame`
* `PreferredInterfaceType`
* `ThrowSpecificExceptions`
* `UnnecessaryFinal`
* `UnnecessaryFullyQualified`
* `UnnecessarilyVisible`
==COMMIT_MSG==

## Possible downsides?
This is kinda a stop-gap measure until we fix suppressible-error-prone suppressing warnings.

