### PR TITLE
Disable Google-authored errorprone checks that have been spuriously re-enabled by a bug in error-prone 2.37.0

### DIFF
--- a/changelog/@unreleased/pr-3126.v2.yml
+++ b/changelog/@unreleased/pr-3126.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Disable Google-authored errorprone checks that have been spuriously
+    re-enabled by a bug in error-prone 2.27.0
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3126

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -128,6 +128,10 @@ public final class BaselineErrorProne implements Plugin<Project> {
         // to be enabled by default. So we're disabling them here until error-prone is fixed, then these can all
         // be removed.
         // See https://github.com/google/error-prone/issues/4943
+        // Some of the checks in the original file:
+        // https://github.com/google/error-prone/blob/v2.38.0/core/src/main/java/
+        // com/google/errorprone/scanner/BuiltInCheckerSuppliers.java#L1168-L1307
+        // no longer exist and have been removed, so it's not the same.
         errorProneOptions.disable(
                 "AddNullMarkedToPackageInfo",
                 "AndroidJdkLibsChecker",
@@ -158,7 +162,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "DefaultLocale",
                 "DepAnn",
                 "DifferentNameButSame",
-                "EmptyIfStatement",
                 "EqualsBrokenForNull",
                 "EqualsMissingNullable",
                 "ExpectedExceptionChecker",
@@ -197,12 +200,10 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "MissingRuntimeRetention",
                 "MixedArrayDimensions",
                 "MockitoDoSetup",
-                "MoreThanOneQualifier",
                 "MultiVariableDeclaration",
                 "MultipleTopLevelClasses",
                 "MutableGuiceModule",
                 "NegativeBoolean",
-                "NoAllocationChecker",
                 "NonCanonicalStaticMemberImport",
                 "NonFinalStaticField",
                 "PackageLocation",
@@ -264,7 +265,6 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "UseCorrectAssertInTests",
                 "UseEnumSwitch",
                 "UsingJsr305CheckReturnValue",
-                "VarChecker",
                 "Varifier",
                 "VoidMissingNullable",
                 "WildcardImport",

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -89,7 +89,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
         });
     }
 
-    @SuppressWarnings("UnstableApiUsage")
+    @SuppressWarnings({"UnstableApiUsage", "checkstyle:MethodLength"})
     private static void configureErrorProneOptions(ErrorProneOptions errorProneOptions) {
 
         errorProneOptions.disable(

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -93,46 +93,18 @@ public final class BaselineErrorProne implements Plugin<Project> {
     private static void configureErrorProneOptions(ErrorProneOptions errorProneOptions) {
 
         errorProneOptions.disable(
-                // We don't use the Android SDK, so this check is unnecessary.
-                "AndroidJdkLibsChecker",
                 "AutoCloseableMustBeClosed",
                 "CatchSpecificity",
-                // This might be worth re-evaluating later and auto-patching. But removing it for now to remove some
-                // auto-suppression noise.
-                "CatchingUnchecked",
                 "CanIgnoreReturnValueSuggester",
-                // This might be worth re-evaluating later - but removing it for now to remove some
-                // auto-suppression noise.
-                "DifferentNameButSame",
                 // https://github.com/google/error-prone/issues/4544
                 "DistinctVarargsChecker",
-                // This does not allow underscore prefixed variables, which we use heavily.
-                // We have our checks for naming.
-                "IdentifierName",
                 "InlineMeSuggester",
-                // We are so far beyond needing to support Java 8 at Palantir. In fact we can't run it as it's EOL
-                "Java8ApiChecker",
                 // LambdaMethodReference is incredibly expensive, see #2997. We leave it
                 // here to employ as a cleanup, but don't execute it in most compilations.
                 "LambdaMethodReference",
                 // We often use javadoc comments without javadoc parameter information.
                 "NotJavadoc",
                 "PreferImmutableStreamExCollections",
-                // We prefer to use List<...> instead of ImmutableList<...>. This way we don't expose the
-                // underlying implementation to the user.
-                "PreferredInterfaceType",
-                // This is so common we're not going to enforce it. Personally, I don't think it matters too much
-                // for RuntimeExceptions, as they are not supposed to be caught
-                "ThrowSpecificExceptions",
-                // This check is low value - an extra final doesn't really hurt anyone. It's very spammy when
-                // auto-suppressed though.
-                "UnnecessaryFinal",
-                // This forces Foo.Builder -> Builder, even when you may want to use Foo.Builder, apart from
-                // some allowlist. Let's leave it up to dev's discretion. Most people don't like fully qualified
-                // types anyway.
-                "UnnecessarilyFullyQualified",
-                // This one isn't even correct for eg Gradle, which needs to be public.
-                "UnnecessarilyVisible",
                 "UnnecessaryTestMethodPrefix",
                 "UnusedVariable",
                 // Var seems low value. Forcing devs to add a dep for annotations is too much.
@@ -151,6 +123,152 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 // it we lose a bit of protection for the time being, but it's a small price to pay for
                 // seamless rollout.
                 "SuperCallToObjectMethod");
+
+        // These checks are default disabled in error-prone. However, in error-prone 2.37.0 a bug has caused them
+        // to be enabled by default. So we're disabling them here until error-prone is fixed, then these can all
+        // be removed.
+        // See https://github.com/google/error-prone/issues/4943
+        errorProneOptions.disable(
+                "AddNullMarkedToPackageInfo",
+                "AndroidJdkLibsChecker",
+                "AnnotationMirrorToString",
+                "AnnotationPosition",
+                "AnnotationValueToString",
+                "AssertFalse",
+                "AssistedInjectAndInjectOnConstructors",
+                "AutoFactoryAtInject",
+                "AvoidObjectArrays",
+                "BanClassLoader",
+                "BanSerializableRead",
+                "BinderIdentityRestoredDangerously",
+                "BindingToUnqualifiedCommonType",
+                "BooleanParameter",
+                "BuilderReturnThis",
+                "CanIgnoreReturnValueSuggester",
+                "CannotMockFinalClass",
+                "CannotMockMethod",
+                "CatchingUnchecked",
+                "CheckedExceptionNotThrown",
+                "ClassName",
+                "ClassNamedLikeTypeParameter",
+                "ComparisonContractViolated",
+                "ConstantField",
+                "ConstantPatternCompile",
+                "DeduplicateConstants",
+                "DefaultLocale",
+                "DepAnn",
+                "DifferentNameButSame",
+                "EmptyIfStatement",
+                "EqualsBrokenForNull",
+                "EqualsMissingNullable",
+                "ExpectedExceptionChecker",
+                "ExtendsAutoValue",
+                "FieldCanBeFinal",
+                "FieldCanBeLocal",
+                "FieldCanBeStatic",
+                "FieldMissingNullable",
+                "FloggerLogWithCause",
+                "FloggerMessageFormat",
+                "FloggerRedundantIsEnabled",
+                "FloggerRequiredModifiers",
+                "FloggerWithCause",
+                "FloggerWithoutCause",
+                "ForEachIterable",
+                "FunctionalInterfaceClash",
+                "HardCodedSdCardPath",
+                "IdentifierName",
+                "ImmutableMemberCollection",
+                "ImmutableRefactoring",
+                "ImmutableSetForContains",
+                "ImplementAssertionWithChaining",
+                "InconsistentOverloads",
+                "InitializeInline",
+                "InsecureCipherMode",
+                "InterfaceWithOnlyStatics",
+                "InterruptedExceptionSwallowed",
+                "Interruption",
+                "IterablePathParameter",
+                "Java8ApiChecker",
+                "LambdaFunctionalInterface",
+                "LongLiteralLowerCaseSuffix",
+                "MethodCanBeStatic",
+                "MissingBraces",
+                "MissingDefault",
+                "MissingRuntimeRetention",
+                "MixedArrayDimensions",
+                "MockitoDoSetup",
+                "MoreThanOneQualifier",
+                "MultiVariableDeclaration",
+                "MultipleTopLevelClasses",
+                "MutableGuiceModule",
+                "NegativeBoolean",
+                "NoAllocationChecker",
+                "NonCanonicalStaticMemberImport",
+                "NonFinalStaticField",
+                "PackageLocation",
+                "ParameterComment",
+                "ParameterMissingNullable",
+                "PreferJavaTimeOverload",
+                "PreferredInterfaceType",
+                "PrimitiveArrayPassedToVarargsMethod",
+                "PrivateConstructorForNoninstantiableModule",
+                "PrivateConstructorForUtilityClass",
+                "PublicApiNamedStreamShouldReturnStream",
+                "QualifierWithTypeUse",
+                "RedundantOverride",
+                "RedundantThrows",
+                "RefersToDaggerCodegen",
+                "RemoveUnusedImports",
+                "ReturnMissingNullable",
+                "ReturnsNullCollection",
+                "ScopeOnModule",
+                "StaticOrDefaultInterfaceMethod",
+                "StaticQualifiedUsingExpression",
+                "StringFormatWithLiteral",
+                "StronglyTypeByteString",
+                "StronglyTypeTime",
+                "SunApi",
+                "SuppressWarningsWithoutExplanation",
+                "SwitchDefault",
+                "SymbolToString",
+                "SystemExitOutsideMain",
+                "SystemOut",
+                "TestExceptionChecker",
+                "ThrowSpecificExceptions",
+                "ThrowsUncheckedException",
+                "TimeUnitMismatch",
+                "TooManyParameters",
+                "TransientMisuse",
+                "TruthContainsExactlyElementsInUsage",
+                "TryFailRefactoring",
+                "TryWithResourcesVariable",
+                "TypeParameterNaming",
+                "TypeToString",
+                "UnescapedEntity",
+                "UngroupedOverloads",
+                "UnnecessarilyFullyQualified",
+                "UnnecessarilyUsedValue",
+                "UnnecessarilyVisible",
+                "UnnecessaryAnonymousClass",
+                "UnnecessaryBoxedAssignment",
+                "UnnecessaryBoxedVariable",
+                "UnnecessaryDefaultInEnumSwitch",
+                "UnnecessaryFinal",
+                "UnnecessaryOptionalGet",
+                "UnnecessarySetDefault",
+                "UnnecessaryStaticImport",
+                "UnnecessaryTestMethodPrefix",
+                "UnsafeLocaleUsage",
+                "UnusedException",
+                "UrlInSee",
+                "UseCorrectAssertInTests",
+                "UseEnumSwitch",
+                "UsingJsr305CheckReturnValue",
+                "VarChecker",
+                "Varifier",
+                "VoidMissingNullable",
+                "WildcardImport",
+                "YodaCondition");
 
         errorProneOptions.error(
                 "EqualsHashCode",


### PR DESCRIPTION
## Before this PR
After upgrading to error-prone 2.38.0 in #3121, we started seeing a crazy number of "new" error-prone checks starting to be suppressed across our codebases:

<img width="952" alt="Screenshot 2025-06-13 at 16 37 09" src="https://github.com/user-attachments/assets/3b53f87d-202d-4a59-9c7a-3330977f8478" />

We attempted to disable a few in #3123 and #3124, but there are still loads lying around.

I spent today investigating deeper and found the real cause is a bug in error-prone, from this change: https://github.com/google/error-prone/pull/4699.

The issue is that on [this line of error-prone code](https://github.com/google/error-prone/blob/028246ba884a77849e6d6240073c2bb3af4c0862/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java#L91), it checks to see whether a check has been disabled in the user provided options, but the default disabled checks are not disabled via user given options.

There's actually already an issue for this: https://github.com/google/error-prone/issues/4943

## After this PR
==COMMIT_MSG==
Disable Google-authored errorprone checks that have been spuriously re-enabled by a bug in error-prone 2.27.0
==COMMIT_MSG==

I will follow up with an errorprone PR, and pray they merge it.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

