### PR TITLE
Allow violations of TimeInStaticInitializer rule in test code

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -281,7 +281,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "ReferenceEquality");
         // Relax some checks for test code
         if (errorProneOptions.getCompilingTestOnlyCode().get()) {
-            errorProneOptions.disable("UnnecessaryLambda");
+            errorProneOptions.disable("TimeInStaticInitializer", "UnnecessaryLambda");
         }
     }
 }


### PR DESCRIPTION
## Before this PR
The [TimeInStaticInitializer](https://errorprone.info/bugpattern/TimeInStaticInitializer) errorprone rule is enabled in both production and test code.

## After this PR
==COMMIT_MSG==
Allow violations of TimeInStaticInitializer rule in test code
==COMMIT_MSG==

While this rule is valuable for production code, initializing objects statically based on time is not unreasonable since test JVMs are short-lived anyway.

## Possible downsides?
🤷🏻‍♂️