### PR TITLE
Improve logging and restore correct `--add-exports` handling in `BaselineModuleJvmArgs`

### DIFF
--- a/changelog/@unreleased/pr-3131.v2.yml
+++ b/changelog/@unreleased/pr-3131.v2.yml
@@ -1,8 +1,8 @@
 type: fix
 fix:
   description: |-
-    Fixes incorrect logging and restores correct handling of `--add-exports` and `--add-opens` in BaselineModuleJvmArgs
+    Fixes incorrect logging and restores correct handling of `--add-exports` and `--add-opens` in `BaselineModuleJvmArgs`
 
-    This change defers evaluation of the classpath to execution time, ensuring all relevant jars are included and their manifest entries are respected.
+    This change defers evaluation of the `classpath` to execution time, ensuring all relevant jars are included and their manifest entries are respected.
   links:
   - https://github.com/palantir/gradle-baseline/pull/3131

--- a/changelog/@unreleased/pr-3131.v2.yml
+++ b/changelog/@unreleased/pr-3131.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Fixes incorrect logging and restores correct handling of `--add-exports` and `--add-opens` in BaselineModuleJvmArgs
+
+    This change defers evaluation of the classpath to execution time, ensuring all relevant jars are included and their manifest entries are respected.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3131

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -99,7 +99,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                     ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
                             project,
                             extension,
-                            project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName()),
+                            project.files(project.getConfigurations()
+                                    .named(sourceSet.getAnnotationProcessorConfigurationName())),
                             javaCompile.getName());
                     provider.getBaselineJavaVersionEnabled()
                             .set(project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class)));
@@ -175,14 +176,20 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
             project.getTasks().withType(Test.class).configureEach(test -> {
                 ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                        project, extension, (Callable<FileCollection>) test::getClasspath, test.getName());
+                        project,
+                        extension,
+                        project.files((Callable<FileCollection>) test::getClasspath),
+                        test.getName());
                 test.getJvmArgumentProviders().add(provider);
                 setTaskInputsFromExtension(test, extension);
             });
 
             project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
                 ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                        project, extension, (Callable<FileCollection>) javaExec::getClasspath, javaExec.getName());
+                        project,
+                        extension,
+                        project.files((Callable<FileCollection>) javaExec::getClasspath),
+                        javaExec.getName());
                 javaExec.getJvmArgumentProviders().add(provider);
                 setTaskInputsFromExtension(javaExec, extension);
             });
@@ -234,7 +241,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     }
 
     private static ModuleJvmArgsArgumentProvider newModuleJvmArgsArgumentProvider(
-            Project project, BaselineModuleJvmArgsExtension extension, Object classpath, String taskName) {
+            Project project,
+            BaselineModuleJvmArgsExtension extension,
+            ConfigurableFileCollection classpath,
+            String taskName) {
         ModuleJvmArgsArgumentProvider provider = project.getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
         provider.getExports().set(extension.exports());
         provider.getOpens().set(extension.opens());
@@ -380,9 +390,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                     isCompilation ? compilationArgs(allExports, allOpens) : runtimeArgs(allExports, allOpens);
 
             log.debug(
-                    isCompilation
-                            ? "BaselineModuleJvmArgs compiling {} on project {} with exports: {}"
-                            : "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
+                    "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
                     getTaskName().getOrNull(),
                     getProjectPath().getOrNull(),
                     args);

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -98,8 +99,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                     ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
                             project,
                             extension,
-                            project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName()));
-
+                            project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName()),
+                            javaCompile.getName());
                     provider.getBaselineJavaVersionEnabled()
                             .set(project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class)));
 
@@ -122,10 +123,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                                 // The '--release' flag is set when BaselineJavaVersion is not used.
                                 if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
                                     log.debug(
-                                            "BaselineModuleJvmArgs not applying args to compilation task "
-                                                    + "{} on {} due to lack of BaselineJavaVersion",
+                                            "BaselineModuleJvmArgs not applying args to compilation task {} on {} "
+                                                    + "due to lack of BaselineJavaVersion",
                                             task.getName(),
-                                            project);
+                                            project.getPath());
                                     return;
                                 }
 
@@ -148,9 +149,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                                             .map(item -> item + "=ALL-UNNAMED")
                                             .collect(ImmutableList.toImmutableList());
                                     log.debug(
-                                            "BaselineModuleJvmArgs building {} on {} " + "with exports: {}",
+                                            "BaselineModuleJvmArgs building {} on {} with exports: {}",
                                             javadoc.getName(),
-                                            project,
+                                            project.getPath(),
                                             exportValues);
                                     if (!exportValues.isEmpty()) {
                                         coreOptions
@@ -173,15 +174,15 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             });
 
             project.getTasks().withType(Test.class).configureEach(test -> {
-                ModuleJvmArgsArgumentProvider provider =
-                        newModuleJvmArgsArgumentProvider(project, extension, test.getClasspath());
+                ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
+                        project, extension, (Callable<FileCollection>) test::getClasspath, test.getName());
                 test.getJvmArgumentProviders().add(provider);
                 setTaskInputsFromExtension(test, extension);
             });
 
             project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
-                ModuleJvmArgsArgumentProvider provider =
-                        newModuleJvmArgsArgumentProvider(project, extension, javaExec.getClasspath());
+                ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
+                        project, extension, (Callable<FileCollection>) javaExec::getClasspath, javaExec.getName());
                 javaExec.getJvmArgumentProviders().add(provider);
                 setTaskInputsFromExtension(javaExec, extension);
             });
@@ -233,13 +234,13 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     }
 
     private static ModuleJvmArgsArgumentProvider newModuleJvmArgsArgumentProvider(
-            Project project, BaselineModuleJvmArgsExtension extension, Object classpath) {
+            Project project, BaselineModuleJvmArgsExtension extension, Object classpath, String taskName) {
         ModuleJvmArgsArgumentProvider provider = project.getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
-
         provider.getExports().set(extension.exports());
         provider.getOpens().set(extension.opens());
         provider.getClasspath().from(classpath);
         provider.getProjectPath().set(project.getPath());
+        provider.getTaskName().set(taskName);
         return provider;
     }
 
@@ -351,6 +352,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         @Internal
         public abstract Property<Boolean> getBaselineJavaVersionEnabled();
 
+        @Internal
+        public abstract Property<String> getTaskName();
+
         @Override
         public final Iterable<String> asArguments() {
             boolean isCompilation = getBaselineJavaVersionEnabled().isPresent();
@@ -359,9 +363,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
             if (isCompilation && !isBaselineJavaVersionEnabled) {
                 log.debug(
-                        "BaselineModuleJvmArgs not applying args to compilation task on {} due to lack of "
+                        "BaselineModuleJvmArgs not applying args to compilation task {} on project {} due to lack of "
                                 + "BaselineJavaVersion",
-                        getProjectPath());
+                        getTaskName().getOrNull(),
+                        getProjectPath().getOrNull());
                 return ImmutableList.of();
             }
 
@@ -376,9 +381,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
             log.debug(
                     isCompilation
-                            ? "BaselineModuleJvmArgs compiling on {} with exports: {}"
-                            : "BaselineModuleJvmArgs executing task on project {} with exports: {}",
-                    getProjectPath(),
+                            ? "BaselineModuleJvmArgs compiling {} on project {} with exports: {}"
+                            : "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
+                    getTaskName().getOrNull(),
+                    getProjectPath().getOrNull(),
                     args);
             return args;
         }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -372,8 +372,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 log.debug(
                         "BaselineModuleJvmArgs not applying args to compilation task {} on project {} due to lack of "
                                 + "BaselineJavaVersion",
-                        getTaskName().getOrNull(),
-                        getProjectPath().getOrNull());
+                        getTaskName().get(),
+                        getProjectPath().get());
                 return ImmutableList.of();
             }
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -186,10 +186,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
             project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
                 ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                        project,
-                        extension,
-                        project.files((Callable<FileCollection>) javaExec::getClasspath),
-                        javaExec.getName());
+                        project, extension, project.files(javaExec.getClasspath()), javaExec.getName());
                 javaExec.getJvmArgumentProviders().add(provider);
                 setTaskInputsFromExtension(javaExec, extension);
             });

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
@@ -540,4 +540,52 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         where:
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
+
+    def '#gradleVersionNumber: Test task picks up Add-Exports from jars added to classpath after configuration'() {
+        buildFile << '''
+        dependencies {
+            testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+            testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+        }
+    '''.stripIndent(true)
+
+        writeJavaSourceFile('''
+            package com;
+            import org.junit.jupiter.api.Test;
+            public class ExampleTest {
+                @Test
+                public void test() {
+                    System.out.println(java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments());
+                }
+            }
+        '''.stripIndent(true), 'src/test/java/com/ExampleTest.java')
+
+        // Create a jar with Add-Exports in the manifest
+        Manifest manifest = new Manifest()
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
+        manifest.getMainAttributes().putValue('Add-Exports', 'java.management/sun.management')
+        File testJar = new File(getProjectDir(),"test.jar");
+        testJar.withOutputStream { fos ->
+            new JarOutputStream(fos, manifest).close()
+        }
+
+        // Mutate classpath after configuration
+        buildFile << """
+            tasks.named('test').configure {
+                classpath += files('test.jar')
+                useJUnitPlatform()
+                testLogging.showStandardStreams = true
+            }
+        """.stripIndent(true)
+
+        when:
+        def result = runTasksSuccessfully('test')
+
+        then:
+        // The test JVM should include the --add-exports argument from the manifest of test-addon.jar
+        result.standardOutput.contains('--add-exports=java.management/sun.management=ALL-UNNAMED')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
+    }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
@@ -30,6 +30,7 @@ import java.util.zip.ZipOutputStream
 
 @Unroll
 class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
+    // language=Gradle
     def standardBuildFile = '''
     plugins {
         id 'java-library'
@@ -40,8 +41,9 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
     apply plugin: 'com.palantir.baseline-module-jvm-args'
     
     javaVersions {
-        libraryTarget = 17
-        runtime = 21
+        // Use the same version at the current test runtime so that we definitely have a JDK of this
+        // version available for Gradle's built in java toolchains
+        libraryTarget = Runtime.version().version().get(0)
     }
 
     repositories {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
@@ -40,8 +40,8 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
     apply plugin: 'com.palantir.baseline-module-jvm-args'
     
     javaVersions {
-        libraryTarget = 11
-        runtime = 17
+        libraryTarget = 17
+        runtime = 21
     }
 
     repositories {


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/gradle-baseline/pull/3119 we fixed configuration cache for baseline but this has introduced and error where exports where not being correctly added and the logging was incorrect:

```
2025-06-20T09:09:39.332-0400 [DEBUG] [com.palantir.baseline.plugins.BaselineModuleJvmArgs$ModuleJvmArgsArgumentProvider] BaselineModuleJvmArgs executing task on project property 'projectPath' with exports: []
```

This appears to have been caused by eagerly calling `test.getClasspath()` which caused the `classpath` to be resolved at configuration time, before all dependencies (including those added later or via plugins) were present. As a result, any module `--add-exports` or `--add-opens` entries contributed by jars added after the initial configuration phase were missed. This led to missing JVM arguments for runtime tasks such as Test and JavaExec.

## After this PR
This PR defers evaluation of the `classpath` by wiring the provider with a Callable/Provider that resolves the `classpath` at execution time, ensuring that all jars (including those added late) are correctly included. This restores the expected behavior: all relevant `--add-exports` and `--add-opens` flags are present for runtime tasks, regardless of when dependencies are added. Logging is fixed to show the actual task and project names rather than property objects

This results in a restored fucntionallity:

```
2025-06-20T15:01:18.095+0100 [DEBUG] [com.palantir.baseline.plugins.BaselineModuleJvmArgs$ModuleJvmArgsArgumentProvider] BaselineModuleJvmArgs executing <redacted> on project <redacted> with exports: [--add-exports, java.base/jdk.internal.platform=ALL-UNNAMED, --add-exports, java.base/sun.net=ALL-UNNAMED, --add-exports, java.management/sun.management=ALL-UNNAMED, --add-exports, jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED, --add-exports, jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED, --add-exports, jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED, --add-exports, jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED, --add-exports, jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED, --add-exports, jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED, --add-exports, jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED, --add-exports, jdk.jfr/jdk.jfr.internal=ALL-UNNAMED, --add-opens, java.base/java.lang.invoke=ALL-UNNAMED, --add-opens, java.base/java.net=ALL-UNNAMED]
```

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes incorrect logging and restores correct handling of `--add-exports` and `--add-opens` in `BaselineModuleJvmArgs`

This change defers evaluation of the `classpath` to execution time, ensuring all relevant jars are included and their manifest entries are respected.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

