### PR TITLE
Implement Error Prone `GradleExceptionUsage` to discourage throwing `GradleException`s in production code

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `InvocationTargetExceptionGetTargetException`: InvocationTargetException.getTargetException() predates the general-purpose exception chaining facility. The Throwable.getCause() method is now the preferred means of obtaining this information. [(source)](https://docs.oracle.com/en/java/javase/17/docs/api//java.base/java/lang/reflect/InvocationTargetException.html#getTargetException())
 - `PreferInputStreamTransferTo`: Prefer JDK `InputStream.transferTo(OutputStream)` over utility methods such as `com.google.common.io.ByteStreams.copy(InputStream, OutputStream)`, `org.apache.commons.io.IOUtils.copy(InputStream, OutputStream)`, `org.apache.commons.io.IOUtils.copyLong(InputStream, OutputStream)`.
 - `ConjureEndpointDeprecatedForRemoval`: Conjure endpoints marked with Deprecated and `forRemoval = true` should not be used as they are scheduled to be removed.
+- `GradleExceptionUsage`: Avoid throwing GradleException, which should only be thrown by Gradle internal code. 
 
 ### Programmatic Application
 

--- a/baseline-error-prone/build.gradle
+++ b/baseline-error-prone/build.gradle
@@ -7,6 +7,7 @@ javaVersion {
 }
 
 dependencies {
+    implementation gradleApi()
     implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.google.errorprone:error_prone_core'
     // Ensure a new enough version of dataflow-errorprone is available

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleExceptionUsage.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/GradleExceptionUsage.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.ThrowTree;
+import com.sun.tools.javac.code.Type;
+import java.util.List;
+import org.gradle.api.GradleException;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = BugPattern.SeverityLevel.WARNING,
+        summary = "GradleException should only be thrown by Gradle internal code. "
+                + "Prefer throwing RuntimeException or another appropriate exception instead.")
+public final class GradleExceptionUsage extends BugChecker implements BugChecker.ThrowTreeMatcher {
+    private static final Matcher<ExpressionTree> compileTimeConstExpressionMatcher =
+            new CompileTimeConstantExpressionMatcher();
+    private static final Matcher<ExpressionTree> ERROR = Matchers.isSubtypeOf(GradleException.class);
+
+    @Override
+    public Description matchThrow(ThrowTree tree, VisitorState state) {
+        ExpressionTree expression = tree.getExpression();
+        if (!(expression instanceof NewClassTree newClassTree)) {
+            return Description.NO_MATCH;
+        }
+        if (!ERROR.matches(newClassTree.getIdentifier(), state)) {
+            return Description.NO_MATCH;
+        }
+        return buildDescription(tree).addFix(generateFix(newClassTree, state)).build();
+    }
+
+    private static SuggestedFix generateFix(NewClassTree newClassTree, VisitorState state) {
+        Type throwableType = ASTHelpers.getType(newClassTree.getIdentifier());
+
+        if (!ASTHelpers.isSameType(throwableType, state.getTypeFromString(GradleException.class.getName()), state)) {
+            return SuggestedFix.emptyFix();
+        }
+
+        List<? extends ExpressionTree> arguments = newClassTree.getArguments();
+        if (arguments.isEmpty()) {
+            SuggestedFix.Builder fix = SuggestedFix.builder();
+            String qualifiedName = SuggestedFixes.qualifyType(state, fix, RuntimeException.class.getName());
+            return fix.replace(newClassTree.getIdentifier(), qualifiedName).build();
+        }
+
+        ExpressionTree firstArgument = arguments.get(0);
+        if (ASTHelpers.isSameType(
+                ASTHelpers.getResultType(firstArgument), state.getTypeFromString(String.class.getName()), state)) {
+            return SuggestedFix.builder()
+                    .replace(newClassTree.getIdentifier(), "RuntimeException")
+                    .build();
+        }
+
+        return SuggestedFix.emptyFix();
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleExceptionUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/GradleExceptionUsageTest.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+class GradleExceptionUsageTest {
+
+    @Test
+    void testGradleError() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.gradle.api.GradleException;",
+                        "class Test {",
+                        "   void f() {",
+                        "       // BUG: Diagnostic contains: Prefer throwing RuntimeException or another appropriate"
+                                + " exception instead",
+                        "       throw new GradleException();",
+                        "   }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testRethrowIsAllowed() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import org.gradle.api.GradleException;",
+                        "class Test {",
+                        "   void f(GradleException e) {",
+                        "       throw e;",
+                        "   }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    void testFix() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import org.gradle.api.GradleException;",
+                        "class Test {",
+                        "   void f1() {",
+                        "       throw new GradleException();",
+                        "   }",
+                        "   void f2(Throwable t) {",
+                        "       throw new GradleException(\"constant\", t);",
+                        "   }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import org.gradle.api.GradleException;",
+                        "class Test {",
+                        "   void f1() {",
+                        "       throw new RuntimeException();",
+                        "   }",
+                        "   void f2(Throwable t) {",
+                        "       throw new RuntimeException(\"constant\", t);",
+                        "   }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    private CompilationTestHelper helper() {
+        return CompilationTestHelper.newInstance(GradleExceptionUsage.class, getClass());
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(GradleExceptionUsage.class, getClass());
+    }
+}

--- a/changelog/@unreleased/pr-3135.v2.yml
+++ b/changelog/@unreleased/pr-3135.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Implement Error Prone `GradleExceptionUsage` to discourage throwing
+    `GradleException`s in production code
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3135

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -42,6 +42,7 @@ public abstract class BaselineErrorProneExtension {
             "ExecutorSubmitRunnableFutureIgnored",
             "ExtendsErrorOrThrowable",
             "FinalClass",
+            "GradleExceptionUsage",
             "IllegalSafeLoggingArgument",
             "ImmutableMapDuplicateKeyStrategy",
             "ImmutablesStyle",
@@ -99,6 +100,7 @@ public abstract class BaselineErrorProneExtension {
 
     /**
      * .
+     *
      * @deprecated Interact with SuppressibleErrorProneExtension instead. This only provided for backcompat.
      */
     @Deprecated


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

[`GradleException`s should only originate from within Gradle's internal code](https://github.com/palantir/gradle-incremental-configuration-cache/pull/1#discussion_r2155101552). This is [not immediately obvious from the docs](https://docs.gradle.org/current/javadoc/org/gradle/api/GradleException.html). 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Implement Error Prone `GradleExceptionUsage` to discourage throwing `GradleException`s in production code
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

