### PR TITLE
[Safe-logging] Get safety from type parameter arguments

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/safety/SafetyAnnotations.java
@@ -37,6 +37,7 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.SymbolMetadata;
 import com.sun.tools.javac.code.TargetType;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.code.Type.WildcardType;
 import com.sun.tools.javac.util.List;
 import java.util.HashSet;
@@ -107,6 +108,15 @@ public final class SafetyAnnotations {
         Safety treeTypeSafety = treeType == null
                 ? Safety.UNKNOWN
                 : Safety.mergeAssumingUnknownIsSame(getSafety(treeType, state), getSafety(treeType.tsym, state));
+        if (treeType instanceof TypeVar) {
+            // If the type is a type variable, we can also merge with the safety of the upper bound of the type variable
+            Type upperBound = treeType.getUpperBound();
+            Safety upperBoundSafety = upperBound == null
+                    ? Safety.UNKNOWN
+                    : Safety.mergeAssumingUnknownIsSame(
+                            getSafety(upperBound, state), getSafety(upperBound.tsym, state));
+            treeTypeSafety = Safety.mergeAssumingUnknownIsSame(treeTypeSafety, upperBoundSafety);
+        }
         Type symbolType = treeSymbol == null ? null : treeSymbol.type;
         // If the type extracted from the symbol matches the type extracted from the tree, avoid duplicate work.
         // However, in some cases type parameter information is excluded from one, but not the other.

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -411,6 +411,32 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void testUnsafeMethodTypeParameter() {
+        helper().addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        import com.palantir.logsafe.*;
+                        import java.util.function.*;
+                        import java.util.*;
+
+                        @Unsafe
+                        interface UnsafeType {}
+
+                        class Test {
+                          static <T extends UnsafeType> void f(T value) {
+                            // BUG: Diagnostic contains: Dangerous argument value:
+                            // arg is 'UNSAFE' but the parameter requires 'SAFE'.
+                            fun(value);
+                          }
+
+                          static void fun(@Safe Object in) {}
+                        }
+                        """)
+                .doTest();
+    }
+
+    @Test
     public void testTypeParamsDifferFromBase() {
         helper().addSourceLines(
                         "Test.java",

--- a/changelog/@unreleased/pr-3147.v2.yml
+++ b/changelog/@unreleased/pr-3147.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[Safe-logging] Get safety from type parameter arguments'
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3147


### PR DESCRIPTION
## Before this PR
When a method is defined with a type parameter, we are not currently checking its safety, which we can do based on the upper-bound.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[Safe-logging] Get safety from type parameter arguments
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

