### PR TITLE
Add PreferUncheckedIoException check

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
     -com.google.common.base.Preconditions.checkNotNull(variable, "message");
     +com.palantir.logsafe.Preconditions.checkNotNull(variable, "message"); // equivalent functionality is available in the safe-logging variant
     ```
+- `PreferUncheckedIoExcepetion`: Prefer UncheckedIOException or SafeUncheckedIoException when wrapping IOException.
 - `ShutdownHook`: Applications should not use `Runtime#addShutdownHook`.
 - `GradleCacheableTaskAction`: Gradle plugins should not call `Task.doFirst` or `Task.doLast` with a lambda, as that is not cacheable. See [gradle/gradle#5510](https://github.com/gradle/gradle/issues/5510) for more details.
 - `PreferBuiltInConcurrentKeySet`: Discourage relying on Guava's `com.google.common.collect.Sets.newConcurrentHashSet()`, when Java's `java.util.concurrent.ConcurrentHashMap.newKeySet()` serves the same purpose.

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferUncheckedIoException.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferUncheckedIoException.java
@@ -37,7 +37,8 @@ import java.io.UncheckedIOException;
         link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
         linkType = BugPattern.LinkType.CUSTOM,
         severity = SeverityLevel.ERROR,
-        summary = "Prefer UncheckedIOException or SafeUncheckedIoException when wrapping IOException")
+        summary = "Prefer UncheckedIOException or SafeUncheckedIoException when wrapping IOException so consumers can"
+                + " more accurately categorize errors")
 public final class PreferUncheckedIoException extends BugChecker implements NewClassTreeMatcher {
 
     private static final Matcher<ExpressionTree> STRING_MATCHER = Matchers.isSameType(String.class);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferUncheckedIoException.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferUncheckedIoException.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.NewClassTree;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.ERROR,
+        summary = "Prefer UncheckedIOException or SafeUncheckedIoException when wrapping IOException")
+public final class PreferUncheckedIoException extends BugChecker implements NewClassTreeMatcher {
+
+    private static final Matcher<ExpressionTree> STRING_MATCHER = Matchers.isSameType(String.class);
+    private static final Matcher<ExpressionTree> IO_EXCEPTION_MATCHER = Matchers.isSubtypeOf(IOException.class);
+
+    private static final Matcher<ExpressionTree> RUNTIME_EXCEPTION_MATCHER =
+            MethodMatchers.constructor().forClass(RuntimeException.class.getName());
+    private static final Matcher<ExpressionTree> SAFE_RUNTIME_EXCEPTION_MATCHER =
+            MethodMatchers.constructor().forClass("com.palantir.logsafe.exceptions.SafeRuntimeException");
+
+    @Override
+    public Description matchNewClass(NewClassTree tree, VisitorState state) {
+        if (RUNTIME_EXCEPTION_MATCHER.matches(tree, state) && matchesArguments(tree, state)) {
+            return buildDescription(tree)
+                    .addFix(SuggestedFix.builder()
+                            .addImport(UncheckedIOException.class.getName())
+                            .replace(tree.getIdentifier(), UncheckedIOException.class.getSimpleName())
+                            .build())
+                    .build();
+        }
+
+        if (SAFE_RUNTIME_EXCEPTION_MATCHER.matches(tree, state) && matchesArguments(tree, state)) {
+            return buildDescription(tree)
+                    .addFix(SuggestedFix.builder()
+                            .addImport("com.palantir.logsafe.exceptions.SafeUncheckedIoException")
+                            .replace(tree.getIdentifier(), "SafeUncheckedIoException")
+                            .build())
+                    .build();
+        }
+
+        return Description.NO_MATCH;
+    }
+
+    private static boolean matchesArguments(NewClassTree tree, VisitorState state) {
+        return switch (tree.getArguments().size()) {
+            case 0 -> {
+                yield false;
+            }
+            case 1 -> {
+                yield IO_EXCEPTION_MATCHER.matches(tree.getArguments().get(0), state);
+            }
+            default -> {
+                yield STRING_MATCHER.matches(tree.getArguments().get(0), state)
+                        && IO_EXCEPTION_MATCHER.matches(tree.getArguments().get(1), state);
+            }
+        };
+    }
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferUncheckedIoExceptionTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/PreferUncheckedIoExceptionTest.java
@@ -1,0 +1,178 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import org.junit.jupiter.api.Test;
+
+class PreferUncheckedIoExceptionTest {
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(PreferUncheckedIoException.class, getClass());
+    }
+
+    @Test
+    void wrapRuntimeException() {
+        fix().addInputLines(
+                        "Test.java",
+                        """
+                        import com.palantir.logsafe.exceptions.SafeRuntimeException;
+
+                        class Test {
+                            Throwable wrap1(RuntimeException e) {
+                                return new RuntimeException(e);
+                            }
+
+                            Throwable wrap2(RuntimeException e) {
+                                return new RuntimeException("message", e);
+                            }
+
+                            Throwable wrap3(RuntimeException e) {
+                                return new SafeRuntimeException(e);
+                            }
+
+                            Throwable wrap4(RuntimeException e) {
+                                return new SafeRuntimeException("message", e);
+                            }
+                        }
+                        """
+                                .split("\n"))
+                .expectUnchanged()
+                .doTest();
+    }
+
+    @Test
+    void wrapIoException() {
+        fix().addInputLines(
+                        "Test.java",
+                        """
+                        import com.palantir.logsafe.SafeArg;
+                        import com.palantir.logsafe.exceptions.SafeRuntimeException;
+                        import java.io.IOException;
+
+                        class Test {
+                            Throwable wrap1(IOException e) {
+                                return new RuntimeException(e);
+                            }
+
+                            Throwable wrap2(IOException e) {
+                                return new RuntimeException("message", e);
+                            }
+
+                            Throwable wrap3(IOException e) {
+                                return new SafeRuntimeException(e);
+                            }
+
+                            Throwable wrap4(IOException e) {
+                                return new SafeRuntimeException("message", e, SafeArg.of("name", "value"));
+                            }
+                        }
+                        """
+                                .split("\n"))
+                .addOutputLines(
+                        "Test.java",
+                        """
+                        import com.palantir.logsafe.SafeArg;
+                        import com.palantir.logsafe.exceptions.SafeRuntimeException;
+                        import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
+                        import java.io.IOException;
+                        import java.io.UncheckedIOException;
+
+                        class Test {
+                            Throwable wrap1(IOException e) {
+                                return new UncheckedIOException(e);
+                            }
+
+                            Throwable wrap2(IOException e) {
+                                return new UncheckedIOException("message", e);
+                            }
+
+                            Throwable wrap3(IOException e) {
+                                return new SafeUncheckedIoException(e);
+                            }
+
+                            Throwable wrap4(IOException e) {
+                                return new SafeUncheckedIoException("message", e, SafeArg.of("name", "value"));
+                            }
+                        }
+                        """
+                                .split("\n"))
+                .doTest();
+    }
+
+    @Test
+    void wrapCustomIoException() {
+        fix().addInputLines(
+                        "Test.java",
+                        """
+                        import com.palantir.logsafe.SafeArg;
+                        import com.palantir.logsafe.exceptions.SafeRuntimeException;
+                        import java.io.IOException;
+
+                        class Test {
+                            class CustomIoException extends IOException {}
+
+                            Throwable wrap1(CustomIoException e) {
+                                return new RuntimeException(e);
+                            }
+
+                            Throwable wrap2(CustomIoException e) {
+                                return new RuntimeException("message", e);
+                            }
+
+                            Throwable wrap3(CustomIoException e) {
+                                return new SafeRuntimeException(e);
+                            }
+
+                            Throwable wrap4(CustomIoException e) {
+                                return new SafeRuntimeException("message", e, SafeArg.of("name", "value"));
+                            }
+                        }
+                        """
+                                .split("\n"))
+                .addOutputLines(
+                        "Test.java",
+                        """
+                        import com.palantir.logsafe.SafeArg;
+                        import com.palantir.logsafe.exceptions.SafeRuntimeException;
+                        import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
+                        import java.io.IOException;
+                        import java.io.UncheckedIOException;
+
+                        class Test {
+                            class CustomIoException extends IOException {}
+
+                            Throwable wrap1(CustomIoException e) {
+                                return new UncheckedIOException(e);
+                            }
+
+                            Throwable wrap2(CustomIoException e) {
+                                return new UncheckedIOException("message", e);
+                            }
+
+                            Throwable wrap3(CustomIoException e) {
+                                return new SafeUncheckedIoException(e);
+                            }
+
+                            Throwable wrap4(CustomIoException e) {
+                                return new SafeUncheckedIoException("message", e, SafeArg.of("name", "value"));
+                            }
+                        }
+                        """
+                                .split("\n"))
+                .doTest();
+    }
+}

--- a/changelog/@unreleased/pr-3173.v2.yml
+++ b/changelog/@unreleased/pr-3173.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add `PreferUncheckedIoException` check to prefer `UncheckedIOException`
+    or `SafeUncheckedIoException` when wrapping `IOExcepetion`.
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3173


### PR DESCRIPTION
Prefer using `UncheckedIOException` or `SafeUncheckedIOException` when wrapping and rethrowing `IOException`. This helps consumers of these exceptions better better categorize errors.

```diff
  try {
      // do something
  } catch (IOException e) {
-     new RuntimeException("IO failed", e);
+     new UncheckedIOException("IO failed", e);
  }

  try {
      // do something
  } catch (IOException e) {
-     new SafeRuntimeException("IO failed", e);
+     new SafeUncheckedIoException("IO failed", e);
  }
```