### PR TITLE
update individual plugins readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ _Baseline is a family of Gradle plugins for configuring Java projects with sensi
 | `com.palantir.baseline-encoding`                   | Ensures projects use the UTF-8 encoding in compile tasks.
 | `com.palantir.baseline-release-compatibility`      | Ensures projects targeting older JREs only compile against classes and methods available in those JREs.
 | `com.palantir.baseline-testing`                    | Configures test tasks to dump heap dumps (hprof files) for convenient debugging
-| `com.palantir.baseline-test-heap`                  | TODO
-| `com.palantir.baseline-java-compiler-diagnostics`  | TODO
-| `com.palantir.baseline-java-compiler-heap          | TODO
-| `com.palantir.baseline-java-properties`            | TODO
+| `com.palantir.baseline-test-heap`                  | Increases the default Test task heap from 512m to 2g.
+| `com.palantir.baseline-java-compiler-diagnostics`  | Applies the `-Xmaxwarns` and `-Xmaxwarns` compiler options with a very large limit to avoid truncating failure info.
+| `com.palantir.baseline-java-compiler-heap`         | Increases the default JavaCompile task heap from 512m to 2g.
+| `com.palantir.baseline-java-properties`            | Applies the `-parameters` compiler option to include additional metadata for reflection on method parameters.
 | `com.palantir.baseline-immutables`                 | Enables incremental compilation for the [Immutables](http://immutables.github.io/) annotation processor.
-| `com.palantir.baseline-module-jvm-args`            | TODO
+| `com.palantir.baseline-module-jvm-args`            | Propagate and collect required exports from transitive dependencies, and applies them to compilation and execution for runtime dependencies.
 | `com.palantir.baseline-java-versions`              | Configures JDK versions in a consistent way via Gradle Toolchains.
 | `com.palantir.baseline-prefer-project-modules`     | Configures Gradle to prefer project modules over external modules on dependency resolution per default.
 

--- a/README.md
+++ b/README.md
@@ -8,25 +8,30 @@
 
 _Baseline is a family of Gradle plugins for configuring Java projects with sensible defaults for code-style, static analysis, dependency versioning, CircleCI and IntelliJ IDEA/Eclipse integration._
 
-| Plugin                                         | Description            |
-|------------------------------------------------|------------------------|
-| `com.palantir.baseline-idea`                   | Configures [Intellij IDEA](https://www.jetbrains.com/idea/) with code style and copyright headers
-| `com.palantir.baseline-eclipse`                | Configures [Eclipse](https://www.eclipse.org/downloads/) with code style and copyright headers
-| `com.palantir.baseline-error-prone`            | Static analysis for your Java code using Google's [error-prone](http://errorprone.info/).
-| `com.palantir.baseline-checkstyle`             | Enforces consistent Java formatting using [checkstyle](http://checkstyle.sourceforge.io/)
-| `com.palantir.baseline-format`                 | Formats your java files to comply with checkstyle
-| `com.palantir.baseline-scalastyle`             | Enforces formatting using [scalastyle](https://github.com/scalastyle/scalastyle)
-| `com.palantir.baseline-class-uniqueness`       | Analyses your classpath to ensure no fully-qualified class is defined more than once.
-| `com.palantir.baseline-circleci`               | [CircleCI](https://circleci.com/) integration using `$CIRCLE_ARTIFACTS` and `$CIRCLE_TEST_REPORTS` dirs
-| `com.palantir.baseline-config`                 | Config files for the above plugins
-| `com.palantir.baseline-reproducibility`        | Sensible defaults to ensure Jar, Tar and Zip tasks can be reproduced
-| `com.palantir.baseline-exact-dependencies`     | Ensures projects explicitly declare all the dependencies they rely on, no more and no less
-| `com.palantir.baseline-encoding`               | Ensures projects use the UTF-8 encoding in compile tasks.
-| `com.palantir.baseline-release-compatibility`  | Ensures projects targeting older JREs only compile against classes and methods available in those JREs.
-| `com.palantir.baseline-testing`                | Configures test tasks to dump heap dumps (hprof files) for convenient debugging
-| `com.palantir.baseline-immutables`             | Enables incremental compilation for the [Immutables](http://immutables.github.io/) annotation processor.
-| `com.palantir.baseline-java-versions`          | Configures JDK versions in a consistent way via Gradle Toolchains.
-| `com.palantir.baseline-prefer-project-modules` | Configures Gradle to prefer project modules over external modules on dependency resolution per default.
+| Plugin                                             | Description            |
+|----------------------------------------------------|------------------------|
+| `com.palantir.baseline-idea`                       | Configures [Intellij IDEA](https://www.jetbrains.com/idea/) with code style and copyright headers
+| `com.palantir.baseline-eclipse`                    | Configures [Eclipse](https://www.eclipse.org/downloads/) with code style and copyright headers
+| `com.palantir.baseline-error-prone`                | Static analysis for your Java code using Google's [error-prone](http://errorprone.info/).
+| `com.palantir.baseline-checkstyle`                 | Enforces consistent Java formatting using [checkstyle](http://checkstyle.sourceforge.io/)
+| `com.palantir.baseline-format`                     | Formats your java files to comply with checkstyle
+| `com.palantir.baseline-scala`                      | Enforces formatting using [scalastyle](https://github.com/scalastyle/scalastyle)
+| `com.palantir.baseline-class-uniqueness`           | Analyses your classpath to ensure no fully-qualified class is defined more than once.
+| `com.palantir.baseline-circleci`                   | [CircleCI](https://circleci.com/) integration using `$CIRCLE_ARTIFACTS` and `$CIRCLE_TEST_REPORTS` dirs
+| `com.palantir.baseline-config`                     | Config files for the above plugins
+| `com.palantir.baseline-reproducibility`            | Sensible defaults to ensure Jar, Tar and Zip tasks can be reproduced
+| `com.palantir.baseline-exact-dependencies`         | Ensures projects explicitly declare all the dependencies they rely on, no more and no less
+| `com.palantir.baseline-encoding`                   | Ensures projects use the UTF-8 encoding in compile tasks.
+| `com.palantir.baseline-release-compatibility`      | Ensures projects targeting older JREs only compile against classes and methods available in those JREs.
+| `com.palantir.baseline-testing`                    | Configures test tasks to dump heap dumps (hprof files) for convenient debugging
+| `com.palantir.baseline-test-heap`                  | TODO
+| `com.palantir.baseline-java-compiler-diagnostics`  | TODO
+| `com.palantir.baseline-java-compiler-heap          | TODO
+| `com.palantir.baseline-java-properties`            | TODO
+| `com.palantir.baseline-immutables`                 | Enables incremental compilation for the [Immutables](http://immutables.github.io/) annotation processor.
+| `com.palantir.baseline-module-jvm-args`            | TODO
+| `com.palantir.baseline-java-versions`              | Configures JDK versions in a consistent way via Gradle Toolchains.
+| `com.palantir.baseline-prefer-project-modules`     | Configures Gradle to prefer project modules over external modules on dependency resolution per default.
 
 See also the [Baseline Java Style Guide and Best Practices](./docs).
 

--- a/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-java-compiler-heap.properties
+++ b/gradle-baseline-java/src/main/resources/META-INF/gradle-plugins/com.palantir.baseline-java-compiler-heap.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.baseline.plugins.BaselineJavaCompilerHeap


### PR DESCRIPTION
@CRogers -- I was doing what we discussed and enabling a variety of the baseline plugins ad-hoc because I didn't want all of them.

I started from [this list](https://github.com/palantir/gradle-baseline/blob/develop/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/Baseline.java#L47-L66) to manually applied things and I noticed:
- BaselineTestHeap.class can't be applied
- the readme's name for the scala plugin is wrong
- some of the plugins aren't documented in the readme at all

Probably easier to review the readme change if you ignore whitespace...

==COMMIT_MSG==
update individual plugins readme
==COMMIT_MSG==
