### PR TITLE
Disable `InsecureCryptoUsage` instead of `InsecureCipherMode`

### DIFF
--- a/changelog/@unreleased/pr-3188.v2.yml
+++ b/changelog/@unreleased/pr-3188.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Disable `InsecureCryptoUsage` instead of `InsecureCipherMode`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3188

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -186,7 +186,7 @@ public final class BaselineErrorProne implements Plugin<Project> {
                 "ImplementAssertionWithChaining",
                 "InconsistentOverloads",
                 "InitializeInline",
-                "InsecureCipherMode",
+                "InsecureCryptoUsage",
                 "InterfaceWithOnlyStatics",
                 "InterruptedExceptionSwallowed",
                 "Interruption",


### PR DESCRIPTION
## Before this PR
See https://github.com/google/error-prone/issues/5170 and https://github.com/google/error-prone/pull/5169

There is a bug in error-prone where, if you disable a check through its alternate name, and use `-XepPatchCheck:`, it will throw an exception.

And while `InsecureCipherMode` is the [name of the class](https://github.com/google/error-prone/blob/4384ed81ed0b639307292bf5b12f820e8cfdd419/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java), it isn't the main check name, which is `[InsecureCryptoUsage](https://github.com/google/error-prone/blob/4384ed81ed0b639307292bf5b12f820e8cfdd419/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java#L36)`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Disable `InsecureCryptoUsage` instead of `InsecureCipherMode`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

