### PR TITLE
Use `com.palantir.gradle.plugintesting.ConfigurationCacheSpec`

### DIFF
--- a/changelog/@unreleased/pr-3193.v2.yml
+++ b/changelog/@unreleased/pr-3193.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use `com.palantir.gradle.plugintesting.ConfigurationCacheSpec`
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3193

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/ConfigurationCacheTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/ConfigurationCacheTest.groovy
@@ -16,9 +16,10 @@
 
 package com.palantir.baseline
 
+import com.palantir.gradle.plugintesting.ConfigurationCacheSpec
 import nebula.test.IntegrationTestKitSpec
 
-class ConfigurationCacheTest extends IntegrationTestKitSpec {
+class ConfigurationCacheTest extends ConfigurationCacheSpec {
 
     def setup() {
         definePluginOutsideOfPluginBlock = true
@@ -52,16 +53,7 @@ class ConfigurationCacheTest extends IntegrationTestKitSpec {
     }
 
     def "classes task runs with configuration cache without issues"() {
-        when: 'first run'
-        String result = createRunner('classes', '--configuration-cache').build().output
-
-        then: 'check stored'
-        result.contains('Configuration cache entry stored.')
-
-        when: 're-run task'
-        String rerun = createRunner('classes', '--configuration-cache').build().output
-
-        then: 'the cache is used'
-        rerun.contains("Configuration cache entry reused.")
+        expect:
+        runTasksWithConfigurationCacheAndCheck("classes")
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/ConfigurationCacheTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/ConfigurationCacheTest.groovy
@@ -17,7 +17,6 @@
 package com.palantir.baseline
 
 import com.palantir.gradle.plugintesting.ConfigurationCacheSpec
-import nebula.test.IntegrationTestKitSpec
 
 class ConfigurationCacheTest extends ConfigurationCacheSpec {
 


### PR DESCRIPTION
## Before this PR
Had our own way of running configuration cache tests

## After this PR
Now we use the same shared spec from `plugintesting` rather than having it re-implemented everywhere

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use `com.palantir.gradle.plugintesting.ConfigurationCacheSpec`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

