### PR TITLE
Fix: Ensure `CheckUnusedDependencies` works on non-GCV locked projects

### DIFF
--- a/changelog/@unreleased/pr-3194.v2.yml
+++ b/changelog/@unreleased/pr-3194.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensure `CheckUnusedDependencies` works on non-GCV locked projects
+  links:
+  - https://github.com/palantir/gradle-baseline/pull/3194

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -88,7 +88,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                 .register(
                         checkUnusedDependenciesNameForSourceSet(sourceSet), CheckUnusedDependenciesTask.class, task -> {
                             task.dependsOn(sourceSet.getClassesTaskName());
-                            task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
+                            task.getSourceClasses().setFrom(sourceSet.getOutput().getClassesDirs());
                             task.getDependenciesConfigurations().add(compileClasspath);
                             task.withDeclaredDependenciesFrom(implementation);
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -16,9 +16,6 @@
 
 package com.palantir.baseline.plugins;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.baseline.tasks.CheckImplicitDependenciesParentTask;
 import com.palantir.baseline.tasks.CheckImplicitDependenciesTask;
@@ -28,10 +25,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.StringUtils;
@@ -43,18 +38,14 @@ import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.attributes.LibraryElements;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.util.GUtil;
 
 /** Validates that java projects declare exactly the dependencies they rely on, no more and no less. */
 public final class BaselineExactDependencies implements Plugin<Project> {
@@ -93,101 +84,13 @@ public final class BaselineExactDependencies implements Plugin<Project> {
         NamedDomainObjectProvider<Configuration> compileClasspath =
                 project.getConfigurations().named(sourceSet.getCompileClasspathConfigurationName());
 
-        NamedDomainObjectProvider<Configuration> explicitCompile = project.getConfigurations()
-                .register("baseline-exact-dependencies-" + sourceSet.getName(), conf -> {
-                    conf.setDescription(String.format(
-                            "Tracks the explicit (not inherited) dependencies added to either %s "
-                                    + "or compile (deprecated)",
-                            sourceSet.getImplementationConfigurationName()));
-                    conf.setVisible(false);
-                    conf.setCanBeConsumed(false);
-
-                    conf.attributes(attributes -> {
-                        // This ensures we resolve 'compile' variants rather than 'runtime'
-                        // This is the same attribute that's being set on compileClasspath
-                        attributes.attribute(
-                                Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_API));
-                        // Ensure we resolve the classes directory for local projects where possible, rather than the
-                        // 'jar' file.
-                        attributes.attribute(
-                                LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                                project.getObjects().named(LibraryElements.class, LibraryElements.CLASSES));
-                    });
-
-                    conf.withDependencies(deps -> {
-                        // Pick up GCV locks. We're making an internal assumption that this configuration exists,
-                        // but we can rely on this since we control GCV.
-                        // Alternatively, we could tell GCV to lock this configuration, at the cost of a slightly more
-                        // expensive 'unifiedClasspath' resolution during lock computation.
-                        if (project.getRootProject().getPluginManager().hasPlugin("com.palantir.versions-lock")) {
-                            conf.extendsFrom(project.getConfigurations().getByName("lockConstraints"));
-                        }
-                        // Inherit the excludes from compileClasspath too (that get aggregated from all its
-                        // super-configurations).
-                        compileClasspath.get().getExcludeRules().forEach(rule -> conf.exclude(excludeRuleAsMap(rule)));
-                    });
-
-                    // Since we are copying configurations before resolving 'explicitCompile', make double sure that
-                    // it's not
-                    // being resolved (or dependencies realized via `.getIncoming().getDependencies()`) too early.
-                    AtomicBoolean projectsEvaluated = new AtomicBoolean();
-                    project.getGradle().projectsEvaluated(g -> projectsEvaluated.set(true));
-                    conf.getIncoming()
-                            .beforeResolve(ir -> Preconditions.checkState(
-                                    projectsEvaluated.get()
-                                            || (project.getGradle()
-                                                            .getStartParameter()
-                                                            .isConfigureOnDemand()
-                                                    && project.getState().getExecuted()),
-                                    "Tried to resolve %s too early.",
-                                    conf));
-                });
-
-        // Figure out what our compile dependencies are while ignoring dependencies we've inherited from other source
-        // sets. For example, if we are `test`, some of our configurations extend from the `main` source set:
-        // testImplementation     extendsFrom(implementation)
-        //  \-- testCompile       extendsFrom(compile)
-        // We therefore want to look at only the dependencies _directly_ declared in the implementation and compile
-        // configurations (belonging to our source set)
-        project.afterEvaluate(p -> {
-            Configuration implConfig = implementation.get();
-            Configuration implCopy = implConfig.copy();
-
-            // Preserves the configuration role behavior from Gradle 7, Gradle 8 fails to
-            // preserve these values when copying a configuration
-            implCopy.setCanBeResolved(implConfig.isCanBeResolved());
-            implCopy.setCanBeConsumed(implConfig.isCanBeConsumed());
-
-            // Without these, explicitCompile will successfully resolve 0 files and you'll waste 1 hour trying
-            // to figure out why.
-            project.getConfigurations().add(implCopy);
-
-            explicitCompile.get().extendsFrom(implCopy);
-
-            Optional<Configuration> maybeCompile =
-                    Optional.ofNullable(project.getConfigurations().findByName(getCompileConfigurationName(sourceSet)));
-
-            // For Gradle 6 and below, the compile configuration might still be used.
-            maybeCompile.ifPresent(compile -> {
-                Configuration compileCopy = compile.copy();
-                // Ensure it's not resolvable, otherwise plugins that resolve all configurations might have
-                // a bad time resolving this with GCV, if you have direct dependencies without corresponding entries in
-                // versions.props, but instead rely on getting a version for them from the lock file.
-                compileCopy.setCanBeResolved(false);
-                compileCopy.setCanBeConsumed(false);
-
-                project.getConfigurations().add(compileCopy);
-
-                explicitCompile.get().extendsFrom(compileCopy);
-            });
-        });
-
         TaskProvider<CheckUnusedDependenciesTask> sourceSetUnusedDependencies = project.getTasks()
                 .register(
                         checkUnusedDependenciesNameForSourceSet(sourceSet), CheckUnusedDependenciesTask.class, task -> {
                             task.dependsOn(sourceSet.getClassesTaskName());
                             task.setSourceClasses(sourceSet.getOutput().getClassesDirs());
-                            task.getDependenciesConfigurations().add(explicitCompile);
+                            task.getDependenciesConfigurations().add(compileClasspath);
+                            task.withDeclaredDependenciesFrom(implementation);
 
                             // ignore intra-project dependencies, which are typically added automatically for things
                             // like test fixtures
@@ -201,7 +104,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             task.ignore("org.junit.jupiter", "junit-jupiter");
 
                             // pick up ignores configured globally on the parent task
-                            task.ignore(checkUnusedDependencies.get().getIgnore());
+                            task.ignore(checkUnusedDependencies.flatMap(CheckUnusedDependenciesParentTask::getIgnore));
                         });
         checkUnusedDependencies.configure(task -> task.dependsOn(sourceSetUnusedDependencies));
         TaskProvider<CheckImplicitDependenciesTask> sourceSetCheckImplicitDependencies = project.getTasks()
@@ -217,37 +120,14 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                             task.ignore("org.slf4j", "slf4j-api");
 
                             // pick up ignores configured globally on the parent task
-                            task.ignore(checkImplicitDependencies.get().getIgnore());
+                            task.ignore(
+                                    checkImplicitDependencies.flatMap(CheckImplicitDependenciesParentTask::getIgnore));
                         });
         checkImplicitDependencies.configure(task -> task.dependsOn(sourceSetCheckImplicitDependencies));
     }
 
     static String checkUnusedDependenciesNameForSourceSet(SourceSet sourceSet) {
         return "checkUnusedDependencies" + StringUtils.capitalize(sourceSet.getName());
-    }
-
-    /**
-     * The {@code SourceSet#getCompileConfigurationName()} method got removed in Gradle 7. Because we want to stay
-     * compatible with Gradle 6 but can't compile this method, we reimplement it temporarily.
-     * TODO(fwindheuser): Remove after dropping support for Gradle 6.
-     */
-    private static String getCompileConfigurationName(SourceSet sourceSet) {
-        String baseName = sourceSet.getName().equals(SourceSet.MAIN_SOURCE_SET_NAME)
-                ? ""
-                : GUtil.toCamelCase(sourceSet.getName());
-        return StringUtils.uncapitalize(baseName + StringUtils.capitalize("compile"));
-    }
-
-    private static Map<String, String> excludeRuleAsMap(ExcludeRule rule) {
-        // Both 'ExcludeRule#getGroup' and 'ExcludeRule#getModule' can return null.
-        Builder<String, String> excludeRule = ImmutableMap.builder();
-        if (rule.getGroup() != null) {
-            excludeRule.put("group", rule.getGroup());
-        }
-        if (rule.getModule() != null) {
-            excludeRule.put("module", rule.getModule());
-        }
-        return excludeRule.build();
     }
 
     /** Given a {@code com/palantir/product/Foo.class} file, what other classes does it import/reference. */
@@ -274,21 +154,13 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     }
 
     public static String asDependencyStringWithName(ResolvedArtifact artifact) {
-        return asDependencyString(artifact, true);
-    }
-
-    public static String asDependencyStringWithoutName(ResolvedArtifact artifact) {
-        return asDependencyString(artifact, false);
-    }
-
-    private static String asDependencyString(ResolvedArtifact artifact, boolean withName) {
         ComponentIdentifier componentId = artifact.getId().getComponentIdentifier();
         if (componentId instanceof ProjectComponentIdentifier projectComponentId) {
             StringBuilder builder = new StringBuilder()
                     .append("project('")
                     .append(projectComponentId.getProjectPath())
                     .append("')");
-            if (withName) {
+            if (true) {
                 builder.append(" <-- ").append(artifact.getName());
             }
             return builder.toString();

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -156,14 +156,7 @@ public final class BaselineExactDependencies implements Plugin<Project> {
     public static String asDependencyStringWithName(ResolvedArtifact artifact) {
         ComponentIdentifier componentId = artifact.getId().getComponentIdentifier();
         if (componentId instanceof ProjectComponentIdentifier projectComponentId) {
-            StringBuilder builder = new StringBuilder()
-                    .append("project('")
-                    .append(projectComponentId.getProjectPath())
-                    .append("')");
-            if (true) {
-                builder.append(" <-- ").append(artifact.getName());
-            }
-            return builder.toString();
+            return "project('%s') <-- %s".formatted(projectComponentId.getProjectPath(), artifact.getName());
         }
 
         return asString(artifact);

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java
@@ -88,7 +88,8 @@ public final class BaselineExactDependencies implements Plugin<Project> {
                 .register(
                         checkUnusedDependenciesNameForSourceSet(sourceSet), CheckUnusedDependenciesTask.class, task -> {
                             task.dependsOn(sourceSet.getClassesTaskName());
-                            task.getSourceClasses().setFrom(sourceSet.getOutput().getClassesDirs());
+                            task.getSourceClasses()
+                                    .setFrom(sourceSet.getOutput().getClassesDirs());
                             task.getDependenciesConfigurations().add(compileClasspath);
                             task.withDeclaredDependenciesFrom(implementation);
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -16,76 +16,87 @@
 
 package com.palantir.baseline.tasks;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Streams;
 import com.palantir.baseline.plugins.BaselineExactDependencies;
 import com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion;
+import java.io.Serializable;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.DependencyArtifact;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 
-@SuppressWarnings("for-rollout:NonAbstractGradleType")
-public class CheckUnusedDependenciesTask extends DefaultTask {
+public abstract class CheckUnusedDependenciesTask extends DefaultTask {
 
-    @SuppressWarnings("for-rollout:GradleTypesAsFields")
-    private final ListProperty<Configuration> dependenciesConfigurations;
+    @Input
+    public abstract SetProperty<String> getIgnored();
 
-    @SuppressWarnings("for-rollout:GradleTypesAsFields")
-    private final ListProperty<Configuration> sourceOnlyConfigurations;
+    @Classpath
+    public abstract ListProperty<Configuration> getDependenciesConfigurations();
 
-    @SuppressWarnings("for-rollout:GradleTypesAsFields")
-    private final Property<FileCollection> sourceClasses;
+    @Input
+    protected abstract SetProperty<ExplicitDependency> getExplicitDependencies();
 
-    @SuppressWarnings("for-rollout:GradleTypesAsFields")
-    private final SetProperty<String> ignore;
+    @Classpath
+    public abstract ConfigurableFileCollection getSourceClasses();
+
+    @Inject
+    protected abstract ObjectFactory getObjectFactory();
+
+    private final Usage consistentVersionsUsage;
 
     public CheckUnusedDependenciesTask() {
         setGroup("Verification");
         setDescription("Ensures no extraneous dependencies are declared");
-        dependenciesConfigurations = getProject().getObjects().listProperty(Configuration.class);
-        dependenciesConfigurations.set(Collections.emptyList());
-        sourceOnlyConfigurations = getProject().getObjects().listProperty(Configuration.class);
-        sourceOnlyConfigurations.set(Collections.emptyList());
-        sourceClasses = getProject().getObjects().property(FileCollection.class);
-        ignore = getProject().getObjects().setProperty(String.class);
-        ignore.set(Collections.emptySet());
+        consistentVersionsUsage = getObjectFactory().newInstance(Usage.class, "consistent-versions-usage");
         getOutputs().upToDateWhen(_task -> true);
     }
 
     @TaskAction
     public final void checkUnusedDependencies() {
-        Set<ResolvedConfiguration> resolvedConfigurations = dependenciesConfigurations.get().stream()
+        Set<ResolvedConfiguration> resolvedConfigurations = getDependenciesConfigurations().get().stream()
                 .map(Configuration::getResolvedConfiguration)
                 .collect(Collectors.toSet());
         BaselineExactDependencies.INDEXES.populateIndexes(resolvedConfigurations);
 
+        Set<ExplicitDependency> explicitlyDeclaredDependencies =
+                getExplicitDependencies().get();
         Set<ResolvedArtifact> declaredArtifacts = resolvedConfigurations.stream()
                 .flatMap(resolved -> resolved.getFirstLevelModuleDependencies().stream())
+                .filter(resolvedDependency -> resolvedDependency.getModuleArtifacts().stream()
+                        .map(ExplicitDependency::from)
+                        .anyMatch(explicitlyDeclaredDependencies::contains))
                 .flatMap(dependency -> dependency.getModuleArtifacts().stream())
                 .filter(dependency ->
                         BaselineExactDependencies.VALID_ARTIFACT_EXTENSIONS.contains(dependency.getExtension()))
                 .collect(Collectors.toSet());
 
-        excludeSourceOnlyDependencies();
-
         Set<String> necessaryArtifactsDeclaration = Streams.stream(
-                        sourceClasses.get().iterator())
+                        getSourceClasses().iterator())
                 .flatMap(BaselineExactDependencies::referencedClasses)
                 .flatMap(BaselineExactDependencies.INDEXES::classToArtifacts)
                 .map(BaselineExactDependencies::asString)
@@ -105,7 +116,7 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         List<ResolvedArtifact> unusedArtifacts = possiblyUnusedArtifacts.stream()
                 .filter(artifact -> !shouldIgnore(artifact))
                 .sorted(Comparator.comparing(BaselineExactDependencies::asString))
-                .collect(Collectors.toList());
+                .toList();
         if (!unusedArtifacts.isEmpty()) {
             // TODO(dfox): don't print warnings for jars that define service loaded classes (e.g. meta-inf)
             StringBuilder builder = new StringBuilder();
@@ -119,26 +130,6 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
         }
     }
 
-    /**
-     * Excludes any source only dependencies configured by the user, as they would be incorrectly flagged as unused by
-     * this task due to BaselineExactDependencies use of
-     * {@link org.apache.maven.shared.dependency.analyzer.asm.ASMDependencyAnalyzer} which only looks at the
-     * dependencies of the generated byte-code, not the union of compile + runtime dependencies.
-     */
-    private void excludeSourceOnlyDependencies() {
-        sourceOnlyConfigurations
-                .get()
-                .forEach(config -> config.getResolvedConfiguration().getFirstLevelModuleDependencies().stream()
-                        .flatMap(dependency -> dependency.getModuleArtifacts().stream())
-                        .forEach(artifact -> ignoreDependency(config, artifact)));
-    }
-
-    private void ignoreDependency(Configuration config, ResolvedArtifact artifact) {
-        String dependencyId = BaselineExactDependencies.asString(artifact);
-        getLogger().info("Ignoring {} dependency: {}", config.getName(), dependencyId);
-        ignore.add(dependencyId);
-    }
-
     private Path buildFile() {
         return getProject()
                 .getRootDir()
@@ -146,59 +137,67 @@ public class CheckUnusedDependenciesTask extends DefaultTask {
                 .relativize(getProject().getBuildFile().toPath());
     }
 
-    private boolean shouldIgnore(ResolvedArtifact artifact) {
-        return ignore.get().contains(BaselineExactDependencies.asString(artifact));
+    private boolean isNotGcvDependency(ModuleDependency dependency) {
+        return !consistentVersionsUsage.equals(dependency.getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE));
     }
 
-    @Classpath
-    public final ListProperty<Configuration> getDependenciesConfigurations() {
-        return dependenciesConfigurations;
+    private boolean shouldIgnore(ResolvedArtifact artifact) {
+        return getIgnored().get().contains(BaselineExactDependencies.asString(artifact));
     }
 
     public final void dependenciesConfiguration(Configuration dependenciesConfiguration) {
-        this.dependenciesConfigurations.add(Objects.requireNonNull(dependenciesConfiguration));
-    }
-
-    @Input
-    public final Provider<List<Configuration>> getSourceOnlyConfigurations() {
-        return sourceOnlyConfigurations;
-    }
-
-    /**
-     * Don't use this unless this configuration is resolvable.
-     *
-     * @deprecated This task only looks at <em>directly declared</em> compile dependencies that also appear in the
-     * runtime classpath, so there's no need to exclude anything like {@code compileOnly} anymore.
-     */
-    @Deprecated
-    public final void sourceOnlyConfiguration(Configuration configuration) {
-        Preconditions.checkNotNull(configuration, "This method requires a non-null configuration");
-        Preconditions.checkArgument(
-                configuration.isCanBeResolved(),
-                "May only add sourceOnlyConfiguration if it is resolvable: %s",
-                configuration);
-        this.sourceOnlyConfigurations.add(Objects.requireNonNull(configuration));
-    }
-
-    @Classpath
-    public final Provider<FileCollection> getSourceClasses() {
-        return sourceClasses;
+        getDependenciesConfigurations().add(Objects.requireNonNull(dependenciesConfiguration));
     }
 
     public final void setSourceClasses(FileCollection newClasses) {
-        this.sourceClasses.set(getProject().files(newClasses));
+        getSourceClasses().setFrom(newClasses);
     }
 
     public final void ignore(Provider<Set<String>> value) {
-        ignore.addAll(value);
+        getIgnored().addAll(value);
     }
 
     public final void ignore(String group, String name) {
-        ignore.add(BaselineExactDependencies.ignoreCoordinate(group, name));
+        getIgnored().add(BaselineExactDependencies.ignoreCoordinate(group, name));
     }
 
-    @Input
-    public final Provider<Set<String>> getIgnored() {
-        return ignore;
+    public final void withDeclaredDependenciesFrom(Provider<Configuration> configuration) {
+        Predicate<ModuleDependency> isNotGcvDependency = this::isNotGcvDependency;
+        getExplicitDependencies().addAll(configuration.map(conf -> new Iterable<ExplicitDependency>() {
+            @Override
+            public @NotNull Iterator<ExplicitDependency> iterator() {
+                return conf.getDependencies().withType(ModuleDependency.class).stream()
+                        .filter(isNotGcvDependency)
+                        .flatMap(ExplicitDependency::from)
+                        .iterator();
+            }
+        }));
+    }
+
+    protected record ExplicitDependency(
+            String group, String name, @Nullable String classifier, @Nullable String extension)
+            implements Serializable {
+
+        private static Stream<ExplicitDependency> from(ModuleDependency dependency) {
+            if (!dependency.getArtifacts().isEmpty()) {
+                return dependency.getArtifacts().stream()
+                        .map(artifact -> new ExplicitDependency(
+                                dependency.getGroup(),
+                                dependency.getName(),
+                                artifact.getClassifier(),
+                                artifact.getExtension()));
+            }
+
+            return Stream.of(
+                    new ExplicitDependency(
+                            dependency.getGroup(), dependency.getName(), null, DependencyArtifact.DEFAULT_TYPE),
+                    new ExplicitDependency(dependency.getGroup(), dependency.getName(), null, ""));
+        }
+
+        private static ExplicitDependency from(ResolvedArtifact resolvedArtifact) {
+            ModuleVersionIdentifier id = resolvedArtifact.getModuleVersion().getId();
+            return new ExplicitDependency(
+                    id.getGroup(), id.getName(), resolvedArtifact.getClassifier(), resolvedArtifact.getExtension());
+        }
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -46,6 +46,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
@@ -62,6 +63,7 @@ public abstract class CheckUnusedDependenciesTask extends DefaultTask {
     protected abstract SetProperty<ExplicitDependency> getExplicitDependencies();
 
     @Classpath
+    @InputFiles
     public abstract ConfigurableFileCollection getSourceClasses();
 
     @Inject

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -45,7 +45,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
@@ -62,7 +61,6 @@ public abstract class CheckUnusedDependenciesTask extends DefaultTask {
     protected abstract SetProperty<ExplicitDependency> getExplicitDependencies();
 
     @Classpath
-    @InputFiles
     public abstract ConfigurableFileCollection getSourceClasses();
 
     @Inject

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -39,7 +39,6 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
@@ -149,10 +148,6 @@ public abstract class CheckUnusedDependenciesTask extends DefaultTask {
 
     public final void dependenciesConfiguration(Configuration dependenciesConfiguration) {
         getDependenciesConfigurations().add(Objects.requireNonNull(dependenciesConfiguration));
-    }
-
-    public final void setSourceClasses(FileCollection newClasses) {
-        getSourceClasses().setFrom(newClasses);
     }
 
     public final void ignore(Provider<Set<String>> value) {

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineExactDependenciesTest.groovy
@@ -17,6 +17,7 @@
 package com.palantir.baseline
 
 import com.palantir.gradle.plugintesting.GradleTestVersions
+import nebula.test.multiproject.MultiProjectIntegrationInfo
 
 import java.nio.file.Files
 import org.gradle.testkit.runner.BuildResult
@@ -31,7 +32,7 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
             id 'java'
             id 'com.palantir.baseline-exact-dependencies'
             id 'com.palantir.baseline' apply false
-            id 'com.palantir.consistent-versions' version '2.31.0' apply false
+            id 'com.palantir.consistent-versions' version '2.36.0' apply false
         }
     '''.stripIndent(true)
 
@@ -343,6 +344,72 @@ class BaselineExactDependenciesTest extends AbstractPluginTest {
 
         where:
         gradleVersion << GradleTestVersions.gradleVersionsForTests
+    }
+
+    def "Ensure checkUnusedDependencies works with GCV when project is excluded from GCV locks"() {
+        given: 'we set up a build file where GCV is disabled for that project but the plugin is still applied'
+        buildFile << standardBuildFile
+
+        // language=Gradle
+        buildFile << """
+            apply plugin: 'com.palantir.consistent-versions'
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.baseline-exact-dependencies'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            // ensure compileClasspath is not locked in this project *but* GCV is still enabled
+            versionsLock {
+                disableJavaPluginDefaults()
+            }
+            
+            dependencies {
+                implementation 'com.google.guava:guava', {
+                  version { strictly '33.4.7-jre' }
+                }
+                
+                // pre #3194, this would fail to resolve for `compileClasspath` because 
+                // `baseline-exact-dependencies-main` (a copy of `implementation`) would "steal" the 
+                // `withDependenciesAction` that adds the constraints from `versions.props` to `implementation` for 
+                // itself.  
+                implementation 'com.palantir.tokens:auth-tokens'
+            }
+        """.stripIndent(true)
+
+        file("versions.props") << """
+            com.google.guava:guava = 33.4.8-jre
+            com.palantir.tokens:* = 3.18.0
+        """.stripIndent(true)
+
+        file("src/main/java/com/p1/TestClassNoDeps.java") << """
+            package com.p1;
+
+            import java.util.Set;
+            import com.google.common.collect.Iterables;
+            import com.palantir.tokens.auth.BearerToken;
+            
+            class TestClassNoDeps {
+                public void bla() {
+                    Iterables.filter(Set.of(1, 2, 3), integer -> integer % 2 == 0);
+                    BearerToken.valueOf("asdf");
+                }
+            }
+        """
+
+        with("writeVersionsLock").withGradleVersion(gradleVersion).build()
+
+        when: 'we run checkUnusedDependencies'
+        def result = with('checkUnusedDependencies', '--stacktrace', "--debug")
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'we do not see any failures'
+        result.tasks(TaskOutcome.FAILED).isEmpty()
+
+        where:
+        gradleVersion << (["8.12.1", "8.14.3"] + GradleTestVersions.getGradleVersionsForTests()).unique()
     }
 
     /**


### PR DESCRIPTION
## Before this PR
Lots of different things interplaying here. Gradle-consistent-versions, Gradle versions after 8.12.1 and this `BaselineExactDependencies` plugin. FWIW this was working pre-gradle 12. I think Gradle changed something that changed the timing/ordering of certain pieces causing failures.

How `checkUnusedDependencies` used to work is that:
* It will make a copy of the `Configuration` via `Configuration#copy`. The docs say that it will retain all its attributes except those from a superconfiguration i.e. configurations that it extends via `Configuration#extendsFrom`. A corollary of this is that what is resolved is just the explicitly declared dependencies in that configuration. This is `baseline-exact-dependencies-(main|test|integrationTest|<sourceSetName>)`
  * I think copies were also desirable pre gradle 5/6 in case you didn't want to resolve the underlying configuration and then you end up getting stuck because resolution was cached. I think this matters less now that we have the concept of different types of configuration i.e. declarable vs resolvable etc.
* When you come to running the task, you resolve the configurations but you look at the first level of dependencies i.e. not the transitives => the things explicitly declared in the `Configuration`. For how the unused dependencies configuration is set up, this is true. It won't contain any explicit dependencies in parent `Configurations` since we did a `copy` at the beginning.
* You look at the contents of the explicitly declared dependencies, and you find all the classes referenced there.
* You then look at the contents of your source, analyse it and find all the classes that are referenced.
* You then cross-reference to see if any dependencies listed have any usages. If not, the dependencies are unused and they should be removed from the build file.

### First issue: locked but shouldn't be locked

```
Could not resolve all dependencies for configuration ':conjure-java-jersey-server:baseline-exact-dependencies-main'.
...
Could not resolve org.glassfish.jersey.core:jersey-common:{strictly 2.40}.
Required by:
    project :conjure-java-jersey-server
Caused by: org.gradle.api.GradleException: Cannot find a version of 'org.glassfish.jersey.core:jersey-common' that satisfies the version constraints:
   Dependency path 'com.palantir.conjure.java.runtime:conjure-java-jersey-server:8.22.0-3-g230f65a' --> 'org.glassfish.jersey.core:jersey-common:{strictly 2.40}'
   Constraint path 'com.palantir.conjure.java.runtime:conjure-java-jersey-server:8.22.0-3-g230f65a' --> 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization:8.22.0-3-g230f65a' (apiElements) --> 'org.glassfish.jersey.core:jersey-common:3.1.3' because of the following reason: Computed from com.palantir.consistent-versions' versions.lock in conjure-java-runtime
   Constraint path 'com.palantir.conjure.java.runtime:conjure-java-jersey-server:8.22.0-3-g230f65a' --> 'com.palantir.conjure.java.runtime:conjure-java-runtime:8.22.0-3-g230f65a' (gcvLocks) --> 'org.glassfish.jersey.core:jersey-common:{strictly 3.1.3}' because of the following reason: Locked by versions.lock
   Constraint path 'com.palantir.conjure.java.runtime:conjure-java-jersey-server:8.22.0-3-g230f65a' --> 'com.palantir.tracing:tracing-jersey:6.24.0' (compile) --> 'org.glassfish.jersey.core:jersey-server:3.1.3' (compile) --> 'org.glassfish.jersey.core:jersey-common:3.1.3' because of the following reason: Computed from com.palantir.consistent-versions' versions.lock in conjure-java-runtime
   Constraint path 'com.palantir.conjure.java.runtime:conjure-java-jersey-server:8.22.0-3-g230f65a' --> 'com.palantir.tracing:tracing-jersey:6.24.0' (compile) --> 'org.glassfish.jersey.core:jersey-server:3.1.3' (compile) --> 'org.glassfish.jersey.core:jersey-client:3.1.3' (compile) --> 'org.glassfish.jersey.core:jersey-common:3.1.3' because of the following reason: Computed from com.palantir.consistent-versions' versions.lock in conjure-java-runtime
   Constraint path 'com.palantir.conjure.java.runtime:conjure-java-jersey-server:8.22.0-3-g230f65a' --> 'com.palantir.conjure.java.runtime:conjure-java-runtime:8.22.0-3-g230f65a' (gcvVersionsPropsConstraints) --> 'org.glassfish.jersey._:_:3.1.3' (default) --> 'org.glassfish.jersey.core:jersey-common:3.1.3' because of the following reason: belongs to platform org.glassfish.jersey._:_:3.1.3
```

Unable to upgrade to Gradle 8.12.1+ because Gradle could not satisfy the constraints i.e. `conjure-java-jersey-server` has a strict constraint on `org.glassfish.jersey.core:jersey-common:strictly 2.40`. However, we're also getting strict constraints from `versions.lock` for `org.glassfish.jersey.core:jersey-common:strictly 3.1.3`. 

This would be expected if this project is opted into GCV, but it has opted out! So why is GCV being applied here?

We go back and have a look at how the `baseline-exact-dependencies-main` configuration is set up:

https://github.com/palantir/gradle-baseline/blob/1aee935e36443f926e9099b235c74cc5bfb42f78/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineExactDependencies.java#L117-L128

We unilaterally add GCV *locks* to this configuration as long as GCV is applied as a plugin. This is wrong because the underlying thing being copied `compileClasspath` has opted out. So not only are you potentially getting an inconsistent resolution between `compileClasspath` and `baseline-exact-dependencies-main`, you're now getting constraints that you're actively trying to avoid. In this case, CJR is trying to test an old version of Jersey, whilst keeping the rest of the repo up to date.

For most repositories, this is desired behaviour, because the `compileClasspath` *will* be locked, so it does what you want.

I could not think of a nice way to conditionally lock this configuration, the locks were somehow set on a parent configuration of `compileClasspath` so it wasn't immediately working and it had proceeded to effectively opt out *every* copy from getting locked. This worked fine for what I was trying to achieve for this repository and I only realised retrospectively this is what was happening and I had to bail on this approach.

### Second issue: this task appears to be consistently failing in places but it is typically disabled
Initially could not figure out why it was only affecting https://github.com/palantir/conjure-java-runtime. But it turns out other internal repositories had the task disabled so we weren't seeing these failures/blockages.

### Third issue: `compileClasspath` can't resolve dependencies due to missing versions

In later versions of gradle, you'd get an error message like this when running `checkUnusedDependenciesMain`:

```
$ gw :sls-logging-log4j-slf4j:checkUnusedDependenciesMain

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':sls-logging-log4j-slf4j:compileJava'.
> Could not resolve all dependencies for configuration ':sls-logging-log4j-slf4j:compileClasspath'.
   > Could not find org.apache.logging.log4j:log4j-core:.
     Required by:
         project :sls-logging-log4j-slf4j
```

> Note: the project is different, but failures are similar.

How is this even possible? `compileClasspath` should get its versions from GCV either via `versions.props` for minimum bounds (when not locked) and exact dependencies via (`versions.lock`) when it is locked.

This is where it gets particularly insidious. When you make a copy of a `Configuration` you also get all of its `withDependencies` actions. In the `VersionsPropsPlugin`, there is a `withDependencies` action where in effect it will add the constraints from `versions.props` to every configuration. If you have that a configuration copy, you don't actually know that it has the version props applied already. So what `VersionsPropsPlugin` does is pass in a `AtomicBoolean` that allows exactly one of the configurations to run a particular block. It's a bit cursed, but for whatever reason, this has always seemed to work in Gradle pre-8.12. Now, what's weird is that the `baseline-exact-dependencies-main` configuration is effectively claiming *both* `withDependencies` blocks which means that `compileClasspath` does not get any versions, hence the error.

To be a bit more explicit, if you have:
* configuration `impl` with dependency set `deps_1`, atomic boolean `atomic_1` and `with_dependencies_action_1`. Note: this is `compileClasspath`.
* configuration `implCopy` with dependency set `deps_2`, atomic boolean `atomic_2` and `with_dependencies_action_1` and `with_dependencies_action_2`. Note: This is what `baseline-exact-dependencies-main` is.

* If `implCopy` runs its `withDependencies` blocks before `impl`. Then we run both `with_dependencies_action_1` and `with_dependencies_action_2` with `deps_2` as the parameter. That sets `atomic_1` and `atomic_2` to `true`. Note, the constraints are then added after this point, and they are added to `deps_2`.
* now `impl` wants to resolve, it will try to run `with_dependencies_action_1`, `atomic_1` is already set, so do nothing => constraints are not added => error we see. 

If you run it in reverse:
* If `impl` runs its `withDependencies` blocks first, then we run `dependencies_action_1`, that sets `atomic_1`. This adds the constraints to `deps_1`
* now `implCopy` wants to resolve, it will try to run `with_dependencies_action_1`. It will do nothing because it’s been actioned already, it can then run `with_dependencies_action_2` which *won’t* be set, and then the constraints are added to `deps_2`. Thereby achieving a proper copy!

It's not clear to me why the ordering changed, and in any case, it shouldn't matter.

I tried to come up with a mechanism that would allow us to keep the copies and have some way of identifying who the right configuration is and who the original `withDependencies` action belonged to, but I also couldn't come up with something that I was convinced of and that I could explain to others.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

`gradle-baseline` is quite an old plugin. It's seen numerous Gradle Versions i.e. around Gradle 4/5. Lots of things in Gradle have changed over the years. Of note are:
* the `java-library` plugin. This is what introduced `api` and `implementation` to dependencies
* codifying more explicitly `declarable`, `resolvable`, `consumable` configurations.

This plugin likely existed at a point where not enough plugins and repositories had migrated to the correct application of these concepts so we had to support the old thing until a later point. As a result, there are many workarounds in this plugin.

Fortunately, I think we are past that inflection point and we can use these features properly, since we are basically a Gradle 7.6+ minimum requirement.

To that end, how we fix this is:
* do not bother with copying a `Configuration`. After this experience, I'm convinced that copying is actually something we never want to do, and we should set up our `Configurations` in a way to avoid falling into this trap again
* Resolve the `compileClasspath`. That is exactly what needs to be resolved, we won't miss anything either. My qualm with the previous approach is that by excluding parent configuration dependencies, the resolution set may be different because they don't contribute to the resolution.
* Have the `checkUnusedDependencies` task, take in an explicit list of dependencies from the *declarable* configuration i.e. `implementation`. This configuration is never meant to be resolved, it is supposed to be extended from or copied into a *resolvable* configuration. If we just get `Configuration#getDependencies`, it won't get the dependencies from the parent configurations i.e. `api`. This exactly matches our intent, i.e. is the dependency we've written under `implementation` used or not.
* We post filter the full resolution with the explicit list of dependencies and then we're done.

There are actually a good number of benefits here:
* simpler to grok plugin
* implementation closely matches our desired intent
* less deprecated usages that would be errors in Gradle 9 i.e. we would have had to do something about this eventually.
* TIL: `DomainObjectCollection`s are still mostly lazy and similar any sort of collection `Provider#addAll` method. It will invoke the `iterator` at point of use, so effectively at the last possible moment. Where it typically falters is if we try to do anything with the `DomainObjectCollection` before hand e.g. `stream` over the contents. We need to ensure the collection does not happen at declaration time. So I do the transformation and then convert the `Stream` to an `Iterable` and then pass that to the `Provider` and it works a charm! It's a little ugly but it's significantly better here.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
It's a little weird to do jar processing in tasks. We should probably just make this artifact transforms (not cacheable of course). However, I've not done enough digging to see whether this is actually a problem or not. Plus this PR is relatively large already (at least the PR description is).
