### PR TITLE
Remove Preconditions RegexpSinglelineJava checkstyle rule

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -302,14 +302,6 @@
             <property name="format" value="ImmutableSet\.Builder.*new ImmutableSet\.Builder"/>
             <property name="message" value="Use ImmutableSet.builder() for variable assignment."/>
         </module>
-        <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Check parameters for validity -->
-            <property name="format" value="Preconditions\.checkNotNull\((?!.*,)([^()]*(\(([^()]*|\(([^()]*|\([^()]*\))*\))*\)[^()]*)*)\)"/>
-            <property name="message" value="Use Preconditions.checkNotNull(Object, String)."/>
-        </module>
-        <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Check parameters for validity -->
-            <property name="format" value="Validate\.notNull\((?!.*,)([^()]*(\(([^()]*|\(([^()]*|\([^()]*\))*\))*\)[^()]*)*)\)"/>
-            <property name="message" value="Use Validate.notNull(Object, String)."/>
-        </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="^\s*super\(\);"/>
             <property name="message" value="This is unnecessary; please delete."/>


### PR DESCRIPTION
This one is a bit silly. It disallows

```java
import com.palantir.logsafe.Preconditions;

Preconditions.checkNotNull(foo);
```

but not

```java
import static com.palantir.logsafe.Preconditions.checkNotNull;

checkNotNull(foo);
```

The latter is far more common in our code (since our checkstyle rules allow this to be statically imported), so this rules is mostly useless.

Not to mention that the regex used here is quite complicated...