### PR TITLE
Fix `JavaExec` tasks not receiving JVM args from classpath JARs added after configuration

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -187,7 +187,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
             project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
                 ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                        project, extension, project.files(javaExec.getClasspath()), javaExec.getName());
+                        project,
+                        extension,
+                        project.files((Callable<FileCollection>) javaExec::getClasspath),
+                        javaExec.getName());
                 javaExec.getJvmArgumentProviders().add(provider);
                 setTaskInputsFromExtension(javaExec, extension);
             });

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
@@ -562,14 +562,7 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
             }
         '''.stripIndent(true), 'src/test/java/com/ExampleTest.java')
 
-        // Create a jar with Add-Exports in the manifest
-        Manifest manifest = new Manifest()
-        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
-        manifest.getMainAttributes().putValue('Add-Exports', 'java.management/sun.management')
-        File testJar = new File(getProjectDir(),"test.jar");
-        testJar.withOutputStream { fos ->
-            new JarOutputStream(fos, manifest).close()
-        }
+        createJarWithExport('test.jar')
 
         // Mutate classpath after configuration
         buildFile << """
@@ -601,14 +594,7 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
             }
         '''.stripIndent(true))
 
-        // Create a jar with Add-Exports in the manifest
-        Manifest manifest = new Manifest()
-        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
-        manifest.getMainAttributes().putValue('Add-Exports', 'java.management/sun.management')
-        File testJar = new File(getProjectDir(), "addon.jar")
-        testJar.withOutputStream { fos ->
-            new JarOutputStream(fos, manifest).close()
-        }
+        createJarWithExport('addon.jar')
 
         // Create a JavaExec task and mutate its classpath after configuration
         //language=gradle
@@ -632,5 +618,15 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
 
         where:
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
+    }
+
+    def createJarWithExport(String jarName) {
+        Manifest manifest = new Manifest()
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
+        manifest.getMainAttributes().putValue('Add-Exports', 'java.management/sun.management')
+        File jar = file(jarName)
+        jar.withOutputStream { fos ->
+            new JarOutputStream(fos, manifest).close()
+        }
     }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.groovy
@@ -590,4 +590,47 @@ class BaselineModuleJvmArgsIntegrationTest extends IntegrationSpec {
         where:
         gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
     }
+
+    def '#gradleVersionNumber: JavaExec task picks up Add-Exports from jars added to classpath after configuration'() {
+        writeJavaSourceFile('''
+            package com;
+            public class ExampleMain {
+                public static void main(String[] args) {
+                    System.out.println(java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments());
+                }
+            }
+        '''.stripIndent(true))
+
+        // Create a jar with Add-Exports in the manifest
+        Manifest manifest = new Manifest()
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
+        manifest.getMainAttributes().putValue('Add-Exports', 'java.management/sun.management')
+        File testJar = new File(getProjectDir(), "addon.jar")
+        testJar.withOutputStream { fos ->
+            new JarOutputStream(fos, manifest).close()
+        }
+
+        // Create a JavaExec task and mutate its classpath after configuration
+        //language=gradle
+        buildFile << """
+            tasks.register('runExample', JavaExec) {
+                mainClass = 'com.ExampleMain'
+                classpath = sourceSets.main.runtimeClasspath
+            }
+            
+            // Mutate classpath after configuration
+            tasks.named('runExample').configure {
+                classpath += files('addon.jar')
+            }
+        """.stripIndent(true)
+
+        when:
+        def result = runTasksSuccessfully('runExample')
+
+        then:
+        result.standardOutput.contains('--add-exports=java.management/sun.management=ALL-UNNAMED')
+
+        where:
+        gradleVersionNumber << GradleTestVersions.gradleVersionsForTests
+    }
 }


### PR DESCRIPTION
## Before this PR
In #3119, we made `gradle-baseline` configuration cache compatible, but this inadvertently broke the automatic discovery of `--add-exports` and `--add-opens` JVM arguments from JAR manifests. 

PR #3131 attempted to fix this issue by deferring classpath evaluation. While the fix was correctly applied to `Test` tasks using a `Callable<FileCollection>` wrapper, `JavaExec` tasks were incorrectly fixed using `project.files(javaExec.getClasspath())`, which still evaluates the classpath too early during configuration time.

This caused `JavaExec` tasks (like code generation tasks) to miss JVM arguments from dependencies added after initial configuration, requiring users to manually specify these arguments as a workaround.

## After this PR
`JavaExec` tasks now use the same deferred classpath resolution pattern as `Test` tasks, ensuring that all JVM arguments from JAR manifests are properly discovered regardless of when dependencies are added to the classpath.

The fix is simple - we now use `project.files((Callable<FileCollection>) javaExec::getClasspath)` instead of `project.files(javaExec.getClasspath())`, which defers the classpath evaluation until execution time when all dependencies are present.

==COMMIT_MSG==
Fix JavaExec tasks not receiving JVM args from classpath JARs

JavaExec tasks were not picking up `--add-exports`/`--add-opens` from JAR manifests when dependencies were added after configuration time. This applies the same fix used for Test tasks: using a Callable to defer `classpath` resolution until execution time.
==COMMIT_MSG==

## Possible downsides?

## Testing
- Added integration test that verifies `JavaExec` tasks correctly pick up JVM arguments from JARs added to the classpath after configuration
- The test fails without this fix and passes with it
- Checked fixes issues on internal project
