### PR TITLE
Enable ResourceIdentifierGetEqualsUsage fixing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Safe Logging can be found at [github.com/palantir/safe-logging](https://github.c
 - `InvocationTargetExceptionGetTargetException`: InvocationTargetException.getTargetException() predates the general-purpose exception chaining facility. The Throwable.getCause() method is now the preferred means of obtaining this information. [(source)](https://docs.oracle.com/en/java/javase/17/docs/api//java.base/java/lang/reflect/InvocationTargetException.html#getTargetException())
 - `PreferInputStreamTransferTo`: Prefer JDK `InputStream.transferTo(OutputStream)` over utility methods such as `com.google.common.io.ByteStreams.copy(InputStream, OutputStream)`, `org.apache.commons.io.IOUtils.copy(InputStream, OutputStream)`, `org.apache.commons.io.IOUtils.copyLong(InputStream, OutputStream)`.
 - `ConjureEndpointDeprecatedForRemoval`: Conjure endpoints marked with Deprecated and `forRemoval = true` should not be used as they are scheduled to be removed.
+- `ResourceIdentifierGetEqualsUsage`: Use `ResourceIdentifier#has{Instance,Locator,Service,Type}` to avoid allocation when checking RID component equality.
 
 ### Programmatic Application
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -64,6 +64,7 @@ public abstract class BaselineErrorProneExtension {
             "ReadReturnValueIgnored",
             "RedundantMethodReference",
             "RedundantModifier",
+            "ResourceIdentifierGetEqualsUsage",
             "SafeLoggingPropagation",
             "Slf4jLevelCheck",
             "Slf4jLogsafeArgs",


### PR DESCRIPTION
## Before this PR

`ResourceIdentifierGetEqualsUsage` auto-fixes were not enabled and not mentioned in readme.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

