### PR TITLE
Remove DesignForExtension Checkstyle check

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -416,9 +416,6 @@
         <module name="CyclomaticComplexity"> <!-- Java Coding Guidelines: Reduce Cyclomatic Complexity -->
             <property name="switchBlockAsSingleDecisionPoint" value="true"/>
         </module>
-        <module name="DesignForExtension"> <!-- Java Coding Guidelines: Design for extension -->
-            <property name="ignoredAnnotations" value="ParameterizedTest, Test, Before, BeforeEach, After, AfterEach, BeforeClass, BeforeAll, AfterClass, AfterAll"/>
-        </module>
         <module name="JavadocMethod"> <!-- Java Style Guide: Where Javadoc is used -->
             <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>


### PR DESCRIPTION
This check feel more annoying than it is useful. Abstract methods with non-final methods are very common (for example, Immutable classes with derived properties) and we generally don't add Javadoc to internal, non-library methods (adding Javadoc for simple accessors is somewhat tedious is any case).