### PR TITLE
Remove `-Xlint:deprecation` compiler argument

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ allprojects {
 
     pluginManager.withPlugin('java') {
         tasks.withType(JavaCompile) {
-            options.compilerArgs += ['-Werror', '-Xlint:deprecation']
+            options.compilerArgs += ['-Werror']
             options.errorprone {
                 // Temporarily disable some checks. Remove these line after upgrading Baseline.
                 disable("DangerousIdentityKey")

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -177,7 +177,6 @@ tasks.withType(Test) {
 // and so none of these checks were active until we switched to the java compiler.
 pluginManager.withPlugin('java') {
     tasks.withType(JavaCompile) {
-        options.compilerArgs = (options.compilerArgs - '-Xlint:deprecation')
         options.errorprone {
             disable("BadImport")
             disable("DefaultCharset")


### PR DESCRIPTION
## Before this PR
This has been superseded by https://github.com/palantir/gradle-baseline/pull/3244 and is being removed everywhere. I'm manually fixing this repo because it has an unusual pattern of enabling it and disabling it in a submodule, which would be harder to properly handle with excavator

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove `-Xlint:deprecation` compiler argument
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

