### PR TITLE
Ignore static variables in record array field check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousRecordArrayField.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/DangerousRecordArrayField.java
@@ -30,6 +30,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import javax.lang.model.element.Modifier;
 
 /**
  * Warns that users should not have a {@link java.util.regex.Pattern} as a key to a Set or Map.
@@ -65,7 +66,8 @@ public final class DangerousRecordArrayField extends BugChecker implements BugCh
     private static boolean hasArrayField(ClassTree classTree, VisitorState state) {
         for (Tree member : classTree.getMembers()) {
             if (member instanceof VariableTree variableTree) {
-                if (IS_ARRAY_VARIABLE.matches(variableTree, state)) {
+                if (IS_ARRAY_VARIABLE.matches(variableTree, state)
+                        && !variableTree.getModifiers().getFlags().contains(Modifier.STATIC)) {
                     return true;
                 }
             }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousRecordArrayFieldTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousRecordArrayFieldTest.java
@@ -121,7 +121,7 @@ public final class DangerousRecordArrayFieldTest {
     }
 
     @Test
-    public void testStaticFieldInRecord() {
+    public void testStaticArrayFieldInRecord() {
         compilationHelper
                 .addSourceLines(
                         "Test.java",
@@ -129,7 +129,23 @@ public final class DangerousRecordArrayFieldTest {
                         "import java.util.regex.Pattern;",
                         "class Test {",
                         "    private record MyRecord(String name) {",
-                        "        public static byte[] PAYLOAD = new byte[0];",
+                        "        public static byte[] STATIC_PAYLOAD = new byte[0];",
+                        "    }",
+                        "}")
+                .doTest();
+    }
+
+    @Test
+    public void testStaticAndNonStaticArrayFieldInRecord() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.regex.Pattern;",
+                        "class Test {",
+                        "    // BUG: Diagnostic contains: Record type has an array field and",
+                        "    private record MyRecord(String name, byte[] payload) {",
+                        "        public static byte[] STATIC_PAYLOAD = new byte[0];",
                         "    }",
                         "}")
                 .doTest();

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousRecordArrayFieldTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DangerousRecordArrayFieldTest.java
@@ -119,4 +119,19 @@ public final class DangerousRecordArrayFieldTest {
                         "}")
                 .doTest();
     }
+
+    @Test
+    public void testStaticFieldInRecord() {
+        compilationHelper
+                .addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.regex.Pattern;",
+                        "class Test {",
+                        "    private record MyRecord(String name) {",
+                        "        public static byte[] PAYLOAD = new byte[0];",
+                        "    }",
+                        "}")
+                .doTest();
+    }
 }


### PR DESCRIPTION
## Before this PR
This check doesn't ignore static fields, so it emits a warning even in cases like these:
```
public record SomeRecord(String foo) {
    public static final String[] SOME_CONSTANT = new String[] { "foo", "bar" };
}
```
Static fields are not compared in `.equals`, so this code is safe and does not exhibit any weird behavior unless there is _also_ a non-static array field in the record. In this example, we should expect instances of `SomeRecord` to be equal if their `foo` fields are equal.

## After this PR
Static fields are ignored in this check. The presence of non-static array fields still triggers the warning.

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

