### PR TITLE
[Error-prone] [DeprecatedApiUsage] Fix import statement check

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/AbstractDeprecatedApiCheck.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/AbstractDeprecatedApiCheck.java
@@ -21,12 +21,12 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import java.util.Optional;
 import javax.lang.model.element.Name;
 
@@ -57,9 +57,8 @@ public abstract class AbstractDeprecatedApiCheck extends BugChecker
 
     @Override
     public final Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
-        Symbol symbol = ASTHelpers.getSymbol(tree);
-        if (symbol != null && symbol.owner instanceof PackageSymbol) {
-            // This is an import statement, which we don't want to flag
+        if (isImportStatement(state)) {
+            // We don't want to flag import statements, as those cannot be suppressed.
             return Description.NO_MATCH;
         }
 
@@ -86,6 +85,10 @@ public abstract class AbstractDeprecatedApiCheck extends BugChecker
                 s -> s.owner.getQualifiedName() + "#" + s.getQualifiedName().toString());
         String description = getErrorDescription(qualifiedName);
         return buildDescription(tree).setMessage(description).build();
+    }
+
+    private boolean isImportStatement(VisitorState state) {
+        return ASTHelpers.findEnclosingNode(state.getPath(), ImportTree.class) != null;
     }
 
     private Optional<Name> getCurrentClass(VisitorState state) {

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DeprecatedApiUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DeprecatedApiUsageTest.java
@@ -332,7 +332,9 @@ public class DeprecatedApiUsageTest {
     }
 
     @Test
-    public void do_not_warn_on_importing_deprecated_class() {
+    // Error-prone wants to inline the Deprecated annotation, which looks worse
+    @SuppressWarnings("MisformattedTestData")
+    public void do_not_warn_on_import_statements() {
         helper().addSourceLines(
                         "Helper.java",
                         // language=Java
@@ -343,10 +345,26 @@ public class DeprecatedApiUsageTest {
                         public class Helper {}
                         """)
                 .addSourceLines(
+                        "Parent.java",
+                        // language=Java
+                        """
+                        package com;
+
+                        public class Parent {
+                            @Deprecated
+                            public static String CONSTANT = "constant";
+
+                            @Deprecated
+                            public static class Nested {}
+                        }
+                        """)
+                .addSourceLines(
                         "Test.java",
                         // language=Java
                         """
                         import com.Helper;
+                        import com.Parent.Nested;
+                        import static com.Parent.CONSTANT;
 
                         class Test {}
                         """)


### PR DESCRIPTION
## Before this PR
The check to ignore import statements (which cannot be suppressed) added in https://github.com/palantir/gradle-baseline/pull/3244 was incorrect and did not work for e.g. nested classes or field imports

## After this PR
==COMMIT_MSG==
[Error-prone] [DeprecatedApiUsage] Fix import statement check
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

