### PR TITLE
Do not flag textBlock lineLength

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -45,6 +45,13 @@
         <property name="max" value="120"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\{@link"/>
     </module>
+
+    <!--  Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
+    <module name="SuppressWithPlainTextCommentFilter">
+        <property name="checkFormat" value="LineLength"/>
+        <property name="offCommentFormat" value='^.*"""\s*$'/>
+        <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
+    </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->
         <module name="SuppressionCommentFilter">

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -45,13 +45,6 @@
         <property name="max" value="120"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\{@link"/>
     </module>
-
-    <!--  Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
-    <module name="SuppressWithPlainTextCommentFilter">
-        <property name="checkFormat" value="LineLength"/>
-        <property name="offCommentFormat" value='^.*"""\s*$'/>
-        <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
-    </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->
         <module name="SuppressionCommentFilter">

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -51,6 +51,12 @@
         <property name="max" value="120"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\{@link"/>
     </module>
+    <!--  Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
+    <module name="SuppressWithPlainTextCommentFilter">
+        <property name="checkFormat" value="LineLength"/>
+        <property name="offCommentFormat" value='^.*"""\s*$'/>
+        <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
+    </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->
         <module name="SuppressionCommentFilter">

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -51,8 +51,7 @@
         <property name="max" value="120"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\{@link"/>
     </module>
-    <!--  Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
-    <module name="SuppressWithPlainTextCommentFilter">
+    <module name="SuppressWithPlainTextCommentFilter"> <!-- Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
         <property name="checkFormat" value="LineLength"/>
         <property name="offCommentFormat" value='^.*"""\s*$'/>
         <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
In preparation for https://github.com/palantir/palantir-java-format/pull/1419. Makes sure that textBlock lineLength are not flagged as checkstyleErrors. Applied the same [regex as in the checkstyle repo.](https://github.com/mohitsatr/checkstyle/blob/7ddea2b02b219dcba8350ecfeb115b3c0d2c51aa/src/main/resources/google_checks.xml#L62-L66)

==COMMIT_MSG==
Do not flag textBlock lineLength
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

