### PR TITLE
[Error-prone] Add InlineMeInliner to default patch checks

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -43,6 +43,7 @@ public abstract class BaselineErrorProneExtension {
             "ExtendsErrorOrThrowable",
             "FinalClass",
             "IllegalSafeLoggingArgument",
+            "InlineMeInliner",
             "ImmutableMapDuplicateKeyStrategy",
             "ImmutablesStyle",
             "ImplicitPublicBuilderConstructor",


### PR DESCRIPTION
## Before this PR
When libraries specify `@InlineMe` annotations like in https://github.com/palantir/deadlines-java/pull/188/files#diff-f8f90c9951b97fc3abe992cb927e3601222e7e3ce25efb471821039feab57432R179-R181, the current behavior would just suppress it ([example](https://github.com/palantir/dialogue/pull/2704)), when we could instead apply the proposed fix, which is more desirable.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[Error-prone] Add InlineMeInliner to default patch checks
==COMMIT_MSG==

## Possible downsides?
This means that external libraries could in theory change your code through the use of `InlineMe` annotations, but given they could also just change their own code, this doesn't change too much.

