### PR TITLE
[Error-prone] [Deprecation] Ignore deprecated classes coming from the same repo

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/AbstractDeprecatedApiCheck.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/AbstractDeprecatedApiCheck.java
@@ -127,7 +127,8 @@ public abstract class AbstractDeprecatedApiCheck extends BugChecker
 
     @Nullable
     private ClassSymbol getOwningClass(Symbol symbol) {
-        Symbol owner = symbol.owner;
+        // The symbol itself may be a class symbol, in which case, there might not even be an owner.
+        Symbol owner = symbol;
         while (owner != null && !(owner instanceof ClassSymbol)) {
             owner = owner.owner;
         }

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DeprecatedApiUsageTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/DeprecatedApiUsageTest.java
@@ -384,6 +384,41 @@ public class DeprecatedApiUsageTest {
                 .doTest();
     }
 
+    @Test
+    // Error-prone wants to inline the Deprecated annotation, which looks worse
+    @SuppressWarnings("MisformattedTestData")
+    public void throws_on_deprecated_nested_class_usage() {
+        helper().addSourceLines(
+                        "app/Helper.java",
+                        // language=Java
+                        """
+                        package app;
+
+                        public class Helper {
+                            @Deprecated
+                            public static class Nested {}
+                        }
+                        """)
+                .addSourceLines(
+                        "Test.java",
+                        // language=Java
+                        """
+                        // This import should not get flagged
+                        import app.Helper;
+                        import java.util.stream.Stream;
+
+                        class Test {
+                          public void fun() {
+                            // BUG: Diagnostic contains: Helper.Nested is deprecated
+                            Stream.of(new Helper.Nested())
+                                // BUG: Diagnostic contains: Helper.Nested is deprecated
+                                .forEach((Helper.Nested c) -> c.toString());
+                          }
+                        }
+                        """)
+                .doTest();
+    }
+
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(DeprecatedApiUsage.class, getClass());
     }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -168,18 +168,27 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
 
         file('src/main/java/test/DeprecatedClass.java') << '''
             package test;
+            @Deprecated(forRemoval = true)
             public class DeprecatedClass {
                 @Deprecated(forRemoval = true)
                 static void deprecated() {}
+                
+                // Testing nested classes too
+                @Deprecated(forRemoval = true)
+                public static class Inner {}
             }
         '''.stripIndent(true)
 
         file('src/main/java/test/Test.java') << '''
             package test;
             public class Test {
-                void test() {
-                    DeprecatedClass.deprecated();
+                // The object parameter is to ensure that we also notice classes
+                //   marked as deprecated in the same project/repo
+                void test(DeprecatedClass obj) {
+                    obj.deprecated();
                 }
+                
+                void testInner(DeprecatedClass.Inner _obj) {}
             }
         '''.stripIndent(true)
 
@@ -207,18 +216,27 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
 
         file('lib/src/main/java/test/DeprecatedClass.java') << '''
             package test;
+            @Deprecated(forRemoval = true)
             public class DeprecatedClass {
                 @Deprecated(forRemoval = true)
                 static void deprecated() {}
+                
+                // Testing nested classes too
+                @Deprecated(forRemoval = true)
+                public static class Inner {}
             }
         '''.stripIndent(true)
 
         file('app/src/main/java/test/Test.java') << '''
             package test;
             public class Test {
-                void test() {
-                    DeprecatedClass.deprecated();
+                // The object parameter is to ensure that we also notice classes
+                //   marked as deprecated in the same project/repo
+                void test(DeprecatedClass obj) {
+                    obj.deprecated();
                 }
+                
+                void testInner(DeprecatedClass.Inner _obj) {}
             }
         '''.stripIndent(true)
 


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/gradle-baseline/pull/3253 introduced the ability to ignore deprecations declared in the same repository.

https://github.com/palantir/gradle-baseline/pull/3274 also made us throw when using a deprecated class.

However, the first one missed the fact that the deprecated symbol might be a class symbol itself, and thus not have an owner (when not a nested class), which made us miss the information that it came from the same repo.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[Error-prone] [Deprecation] Ignore deprecated classes coming from the same repo
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

