### PR TITLE
Stop checking for punctation in the javadoc summary

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -431,7 +431,7 @@
             <property name="allowedAnnotations" value="Override, Test"/>
         </module>
         <module name="JavadocStyle"><!-- Java Style Guide: Javadoc -->
-            <property name="checkFirstSentence" value="false" />
+            <property name="checkFirstSentence" value="false"/>
         </module>
         <module name="JavadocTagContinuationIndentation"> <!-- Java Style Guide: At-clauses -->
             <property name="offset" value="0"/>
@@ -456,9 +456,6 @@
         <module name="ParameterName"> <!-- Java Style Guide: Parameter names -->
             <property name="format" value="^_?[a-z][a-zA-Z0-9]+$"/>
             <message key="name.invalidPattern" value="Parameter name ''{0}'' must match pattern ''{1}''."/>
-        </module>
-        <module name="SummaryJavadocCheck"> <!-- Java Coding Guidelines: Javadoc -->
-            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
         </module>
 
         <!-- Stricter checks end -->

--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -430,7 +430,9 @@
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
         </module>
-        <module name="JavadocStyle"/> <!-- Java Style Guide: Javadoc -->
+        <module name="JavadocStyle"><!-- Java Style Guide: Javadoc -->
+            <property name="checkFirstSentence" value="false" />
+        </module>
         <module name="JavadocTagContinuationIndentation"> <!-- Java Style Guide: At-clauses -->
             <property name="offset" value="0"/>
         </module>


### PR DESCRIPTION
## Before this PR
Since we first released gradle-baseline, we've had a checkstyle rule enabled that requires the javadoc summary to have some punctuation in it - either a `.`, `!` or `?`. This is part of the [built-in `JavadocStyle` check](https://checkstyle.sourceforge.io/checks/javadoc/javadocstyle.html) **and** the [`SummaryJavadoc`](https://checkstyle.sourceforge.io/checks/javadoc/summaryjavadoc.html) check.

There is a reason for this. In the javadoc HTML (IntelliJ is unaffected), it will use the punctuation to decide what the short description should be - for example, **with this example**:

```java
/**
 * hello hello
 * hello. bye bye
 * something else
 * @param project project parameter
 */
```

vs

```java
/**
 * hello hello
 * hello bye bye
 * something else
 * @param project project parameter
 */
```

**...it gets rendered in javadoc html as:**

<img width="614" height="65" alt="Screenshot 2025-10-13 at 15 15 16" src="https://github.com/user-attachments/assets/3a63c505-6882-488e-9048-4bc89cd4b9d1" />

vs

<img width="744" height="61" alt="Screenshot 2025-10-13 at 15 25 02" src="https://github.com/user-attachments/assets/d3d325ea-b686-4e33-814f-8c023dfe6d97" />

**...and in intellij as:**

<img width="293" height="98" alt="Screenshot 2025-10-13 at 15 13 29" src="https://github.com/user-attachments/assets/a15183ed-bcd1-4791-9204-667005e1844d" />

vs

<img width="289" height="96" alt="Screenshot 2025-10-13 at 15 26 15" src="https://github.com/user-attachments/assets/1bc99e4b-64b0-4bfd-a015-0b1336360d34" />

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Stop checkstyle checking for punctation in the javadoc summary
==COMMIT_MSG==

As listed above, there **is** a reason for check in checkstyle. But overall, I think it's better to get rid of it as the benefit is not worth the overhead for our devs:
1. We rarely - if ever - use rendered Javadoc HTML internally. Instead most people just use intellij to see rendered javadoc, which has no behaviour difference.
2. The worst that happens is there's a bit too long a summary in the Javadoc HTML. If the Javadoc summary is long, people should naturally use sentences which should limit it a bit. But most of the time the summary is just a line anyway.

## Possible downsides?
(as mentioned above) Javadoc summary is too long.

I've also had to remove the check that verifies that these patterns do not exist in the summary javadoc as I've had to remove the whole `SummaryJavadoc` check:
```regexp
@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )
```

I don't think this is too big a deal as:
1. I've never really run into this myself or seen people complain about it
2. When you type `// **` and press enter in intellij it auto adds the `@return` so you are unlike to write "This method returns" imo.

We can always make an errorprone check for it, that we can roll out with auto-suppression.