### PR TITLE
test: demo issue with inferring map type

### DIFF
--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/IllegalSafeLoggingArgumentTest.java
@@ -1414,6 +1414,40 @@ class IllegalSafeLoggingArgumentTest {
     }
 
     @Test
+    public void collectToMapDiscrepancy() {
+        helper().addSourceLines(
+                        "Test.java",
+                        "import java.util.*;",
+                        "import java.util.function.*;",
+                        "import java.util.stream.Collector;",
+                        "import java.util.stream.Collectors;",
+                        "import com.palantir.logsafe.*;",
+                        "class Test {",
+                        "  void testDroppingCollector_unsafeArgs() {",
+                        "    List<SomethingYouShouldntLog> unsafe =",
+                        "        List.of(new SomethingYouShouldntLog(1, 2));",
+                        "",
+                        "    // BUG: Diagnostic contains:  Dangerous argument value: arg is 'DO_NOT_LOG' but the"
+                                + " parameter requires 'UNSAFE'.",
+                        "    testUnsafe(unsafe.stream().collect(toMap(SomethingYouShouldntLog::b,"
+                                + " SomethingYouShouldntLog::b)));",
+                        "  }",
+                        "",
+                        "  public static <T, K, U> Collector<T, ?, Map<K, U>> toMap(",
+                        "      Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U>"
+                                + " valueMapper) {",
+                        "    return Collectors.toMap(keyMapper, valueMapper);",
+                        "  }",
+                        "",
+                        "  private void testUnsafe(@Unsafe Map<Integer, Integer> val) {}",
+                        "",
+                        "  @DoNotLog",
+                        "  private record SomethingYouShouldntLog(@DoNotLog Integer a, @Unsafe Integer b) {}",
+                        "}")
+                .doTest();
+    }
+
+    @Test
     public void testOptionalUnwrapping() {
         helper().addSourceLines(
                         "Test.java",


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Demonstrates a case discussed on slack where any custom collectors will be marked as do not log when operating on donotlog objects regardless of how they're used.

This affects the use of custom collectors and 
```java
    @Test
    void testDroppingCollector_unsafeArgs() {
        List<SomethingYouShouldntLog> unsafe =
                List.of(new SomethingYouShouldntLog("1", "2", "3"), new SomethingYouShouldntLog("4", "5", "6"));

        testUnsafe(unsafe.stream()
                .collect(MapCollectors.dropCollisions(
                        SomethingYouShouldntLog::b, SomethingYouShouldntLog::c, duplicate -> {
                            log.warn("a duplicate occurred", UnsafeArg.of("arg1", duplicate));
                        })));
    }

    private void testUnsafe(@Unsafe Map<String, String> val) {
        assertThat(val).isEqualTo(Map.of("2", "3", "5", "6"));
    }

    // Does not occur for the java toMap collector because its exempt, but will if you wrap it
    public static <T, @Unsafe K, @Unsafe U> Collector<T, ?, Map<K, U>> toMap(
            Function<? super T, @Unsafe ? extends K> keyMapper, Function<? super T, @Unsafe ? extends U> valueMapper) {
        return Collectors.toMap(keyMapper, valueMapper);
    }

    @DoNotLog
    private record SomethingYouShouldntLog(@DoNotLog String a, @Unsafe String b, @Unsafe String c) {}
```


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

