### PR TITLE
baseline-module-jvm-args: Extract code into methods & move tests into nested classes to group them

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -86,159 +86,169 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     @SuppressWarnings("checkstyle:MethodLength")
     public final void apply(Project project) {
         project.getPluginManager().withPlugin("java", unused -> {
-            @SuppressWarnings({"for-rollout:GradleTypesAsFields", "for-rollout:NonAbstractGradleType"})
-            BaselineModuleJvmArgsExtension extension =
-                    project.getExtensions().create(EXTENSION_NAME, BaselineModuleJvmArgsExtension.class, project);
+            applyToJavaProject(project);
+        });
+    }
 
-            // javac isn't provided `--add-exports` args for the time being due to
-            // https://github.com/gradle/gradle/issues/18824
-            // However, we set sourceCompatibility in BaselineJavaVersion to opt out of the '--release' flag.
-            project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
-                TaskProvider<JavaCompile> javaCompileProvider =
-                        project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
-                javaCompileProvider.configure(javaCompile -> {
-                    ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                            project,
-                            extension,
-                            project.files(project.getConfigurations()
-                                    .named(sourceSet.getAnnotationProcessorConfigurationName())),
-                            javaCompile.getName());
-                    provider.getBaselineJavaVersionEnabled()
-                            .set(project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class)));
+    private void applyToJavaProject(Project project) {
+        @SuppressWarnings({"for-rollout:GradleTypesAsFields", "for-rollout:NonAbstractGradleType"})
+        BaselineModuleJvmArgsExtension extension =
+                project.getExtensions().create(EXTENSION_NAME, BaselineModuleJvmArgsExtension.class, project);
 
-                    javaCompile.getOptions().getCompilerArgumentProviders().add(provider);
+        // Derive this plugin's `enablePreview` property from BaselineJavaVersion's extension
+        project.getPlugins().withType(BaselineJavaVersion.class, _unused -> {
+            BaselineJavaVersionExtension javaVersionsExtension =
+                    project.getExtensions().getByType(BaselineJavaVersionExtension.class);
+            extension.setEnablePreview(javaVersionsExtension.runtime().map(chosenJavaVersion -> {
+                return chosenJavaVersion.enablePreview()
+                        ? Optional.of(chosenJavaVersion.javaLanguageVersion())
+                        : Optional.empty();
+            }));
+        });
 
-                    setTaskInputsFromExtension(javaCompile, extension);
-                });
+        project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
+            configureSourceSet(project, sourceSet, extension);
+        });
 
-                TaskProvider<Task> javadocTaskProvider = null;
-                try {
-                    javadocTaskProvider = project.getTasks().named(sourceSet.getJavadocTaskName());
-                } catch (UnknownTaskException e) {
-                    // skip
-                }
-                if (javadocTaskProvider != null) {
-                    javadocTaskProvider.configure(javadocTask -> {
-                        javadocTask.doFirst(new Action<Task>() {
-                            @Override
-                            public void execute(Task task) {
-                                // The '--release' flag is set when BaselineJavaVersion is not used.
-                                if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
-                                    log.debug(
-                                            "BaselineModuleJvmArgs not applying args to compilation task {} on {} "
-                                                    + "due to lack of BaselineJavaVersion",
-                                            task.getName(),
-                                            project.getPath());
-                                    return;
-                                }
+        project.getTasks().withType(Test.class).configureEach(test -> {
+            ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
+                    project, extension, project.files((Callable<FileCollection>) test::getClasspath), test.getName());
+            test.getJvmArgumentProviders().add(provider);
+            setTaskInputsFromExtension(test, extension);
+        });
 
-                                Javadoc javadoc = (Javadoc) task;
+        project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
+            ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
+                    project,
+                    extension,
+                    project.files((Callable<FileCollection>) javaExec::getClasspath),
+                    javaExec.getName());
+            javaExec.getJvmArgumentProviders().add(provider);
+            setTaskInputsFromExtension(javaExec, extension);
+        });
 
-                                MinimalJavadocOptions options = javadoc.getOptions();
-                                if (options instanceof CoreJavadocOptions coreOptions) {
-                                    ImmutableList<JarManifestModuleInfo> info =
-                                            collectClasspathInfoForSourceSet(sourceSet);
-                                    List<String> exportValues = Stream.concat(
-                                                    // Compilation only supports exports, so we union with opens.
-                                                    Stream.concat(
-                                                            extension.exports().get().stream(),
-                                                            extension.opens().get().stream()),
-                                                    info.stream()
-                                                            .flatMap(item -> Stream.concat(
-                                                                    item.exports().stream(), item.opens().stream())))
-                                            .distinct()
-                                            .sorted()
-                                            .map(item -> item + "=ALL-UNNAMED")
-                                            .collect(ImmutableList.toImmutableList());
-                                    log.debug(
-                                            "BaselineModuleJvmArgs building {} on {} with exports: {}",
-                                            javadoc.getName(),
-                                            project.getPath(),
-                                            exportValues);
-                                    if (!exportValues.isEmpty()) {
-                                        coreOptions
-                                                // options are automatically prefixed with '-' internally
-                                                .addMultilineStringsOption("-add-exports")
-                                                .setValue(exportValues);
-                                    }
-                                } else {
-                                    log.error(
-                                            "MinimalJavadocOptions implementation was "
-                                                    + "not CoreJavadocOptions, rather '{}'",
-                                            options.getClass().getName());
-                                }
-                            }
-                        });
+        project.getTasks().withType(Jar.class).configureEach(jar -> {
+            String jarName = jar.getName();
+            String projectPath = jar.getProject().getPath();
 
-                        setTaskInputsFromExtension(javadocTask, extension);
-                    });
-                }
-            });
-
-            project.getTasks().withType(Test.class).configureEach(test -> {
-                ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                        project,
-                        extension,
-                        project.files((Callable<FileCollection>) test::getClasspath),
-                        test.getName());
-                test.getJvmArgumentProviders().add(provider);
-                setTaskInputsFromExtension(test, extension);
-            });
-
-            project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
-                ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                        project,
-                        extension,
-                        project.files((Callable<FileCollection>) javaExec::getClasspath),
-                        javaExec.getName());
-                javaExec.getJvmArgumentProviders().add(provider);
-                setTaskInputsFromExtension(javaExec, extension);
-            });
-
-            // Derive this plugin's `enablePreview` property from BaselineJavaVersion's extension
-            project.getPlugins().withType(BaselineJavaVersion.class, _unused -> {
-                BaselineJavaVersionExtension javaVersionsExtension =
-                        project.getExtensions().getByType(BaselineJavaVersionExtension.class);
-                extension.setEnablePreview(javaVersionsExtension.runtime().map(chosenJavaVersion -> {
-                    return chosenJavaVersion.enablePreview()
-                            ? Optional.of(chosenJavaVersion.javaLanguageVersion())
-                            : Optional.empty();
-                }));
-            });
-
-            project.getTasks().withType(Jar.class).configureEach(new Action<Jar>() {
+            jar.doFirst(new Action<Task>() {
                 @Override
-                public void execute(Jar jar) {
-                    String jarName = jar.getName();
-                    String projectPath = jar.getProject().getPath();
-
-                    jar.doFirst(new Action<Task>() {
+                public void execute(Task task) {
+                    jar.manifest(new Action<Manifest>() {
                         @Override
-                        public void execute(Task task) {
-                            jar.manifest(new Action<Manifest>() {
-                                @Override
-                                public void execute(Manifest manifest) {
-                                    addManifestAttribute(
-                                            jarName, projectPath, manifest, ADD_EXPORTS_ATTRIBUTE, extension.exports());
-                                    addManifestAttribute(
-                                            jarName, projectPath, manifest, ADD_OPENS_ATTRIBUTE, extension.opens());
-                                    addManifestAttribute(
-                                            jarName,
-                                            projectPath,
-                                            manifest,
-                                            ENABLE_PREVIEW_ATTRIBUTE,
-                                            extension.getEnablePreview().map(maybeVersion -> maybeVersion.stream()
-                                                    .map(v -> Integer.toString(v.asInt()))
-                                                    .collect(Collectors.toSet())));
-                                }
-                            });
+                        public void execute(Manifest manifest) {
+                            addManifestAttribute(
+                                    jarName, projectPath, manifest, ADD_EXPORTS_ATTRIBUTE, extension.exports());
+                            addManifestAttribute(
+                                    jarName, projectPath, manifest, ADD_OPENS_ATTRIBUTE, extension.opens());
+                            addManifestAttribute(
+                                    jarName,
+                                    projectPath,
+                                    manifest,
+                                    ENABLE_PREVIEW_ATTRIBUTE,
+                                    extension.getEnablePreview().map(maybeVersion -> maybeVersion.stream()
+                                            .map(v -> Integer.toString(v.asInt()))
+                                            .collect(Collectors.toSet())));
                         }
                     });
-
-                    setTaskInputsFromExtension(jar, extension);
                 }
             });
+
+            setTaskInputsFromExtension(jar, extension);
         });
+    }
+
+    private void configureSourceSet(Project project, SourceSet sourceSet, BaselineModuleJvmArgsExtension extension) {
+        project.getTasks()
+                .named(sourceSet.getCompileJavaTaskName(), JavaCompile.class)
+                .configure(javaCompile -> {
+                    configureJavaCompile(project, sourceSet, extension, javaCompile);
+                });
+
+        configureJavadoc(project, sourceSet, extension);
+    }
+
+    private static void configureJavaCompile(
+            Project project, SourceSet sourceSet, BaselineModuleJvmArgsExtension extension, JavaCompile javaCompile) {
+
+        // javac isn't provided `--add-exports` args for the time being due to
+        // https://github.com/gradle/gradle/issues/18824
+        // However, we set sourceCompatibility in BaselineJavaVersion to opt out of the '--release' flag.
+
+        ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
+                project,
+                extension,
+                project.files(project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName())),
+                javaCompile.getName());
+        provider.getBaselineJavaVersionEnabled()
+                .set(project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class)));
+
+        javaCompile.getOptions().getCompilerArgumentProviders().add(provider);
+
+        setTaskInputsFromExtension(javaCompile, extension);
+    }
+
+    private void configureJavadoc(Project project, SourceSet sourceSet, BaselineModuleJvmArgsExtension extension) {
+        TaskProvider<Task> javadocTaskProvider = null;
+        try {
+            javadocTaskProvider = project.getTasks().named(sourceSet.getJavadocTaskName());
+        } catch (UnknownTaskException e) {
+            // skip
+        }
+        if (javadocTaskProvider != null) {
+            javadocTaskProvider.configure(javadocTask -> {
+                javadocTask.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        // The '--release' flag is set when BaselineJavaVersion is not used.
+                        if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
+                            log.debug(
+                                    "BaselineModuleJvmArgs not applying args to compilation task {} on {} "
+                                            + "due to lack of BaselineJavaVersion",
+                                    task.getName(),
+                                    project.getPath());
+                            return;
+                        }
+
+                        Javadoc javadoc = (Javadoc) task;
+
+                        MinimalJavadocOptions options = javadoc.getOptions();
+                        if (options instanceof CoreJavadocOptions coreOptions) {
+                            ImmutableList<JarManifestModuleInfo> info = collectClasspathInfoForSourceSet(sourceSet);
+                            List<String> exportValues = Stream.concat(
+                                            // Compilation only supports exports, so we union with opens.
+                                            Stream.concat(
+                                                    extension.exports().get().stream(),
+                                                    extension.opens().get().stream()),
+                                            info.stream()
+                                                    .flatMap(item -> Stream.concat(
+                                                            item.exports().stream(), item.opens().stream())))
+                                    .distinct()
+                                    .sorted()
+                                    .map(item -> item + "=ALL-UNNAMED")
+                                    .collect(ImmutableList.toImmutableList());
+                            log.debug(
+                                    "BaselineModuleJvmArgs building {} on {} with exports: {}",
+                                    javadoc.getName(),
+                                    project.getPath(),
+                                    exportValues);
+                            if (!exportValues.isEmpty()) {
+                                coreOptions
+                                        // options are automatically prefixed with '-' internally
+                                        .addMultilineStringsOption("-add-exports")
+                                        .setValue(exportValues);
+                            }
+                        } else {
+                            log.error(
+                                    "MinimalJavadocOptions implementation was " + "not CoreJavadocOptions, rather '{}'",
+                                    options.getClass().getName());
+                        }
+                    }
+                });
+
+                setTaskInputsFromExtension(javadocTask, extension);
+            });
+        }
     }
 
     private static ModuleJvmArgsArgumentProvider newModuleJvmArgsArgumentProvider(

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @GradlePluginTests
@@ -64,349 +65,361 @@ class BaselineModuleJvmArgsIntegrationTest {
             """);
     }
 
-    @Test
-    void compiles_with_locally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            moduleJvmArgs {
-               exports = ['jdk.compiler/com.sun.tools.javac.code']
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    com.sun.tools.javac.code.Symbol.class.toString();
+    @Nested
+    class Compilation {
+        @Test
+        void compiles_with_locally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   exports = ['jdk.compiler/com.sun.tools.javac.code']
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("compileJava").buildsSuccessfully();
-    }
-
-    @Test
-    void compiles_with_locally_defined_opens(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            moduleJvmArgs {
-               opens = ['jdk.compiler/com.sun.tools.javac.code']
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    com.sun.tools.javac.code.Symbol.class.toString();
-                }
-            }
-            """);
-
-        gradle.withArgs("compileJava").buildsSuccessfully();
-    }
-
-    @Test
-    void builds_javadoc_with_locally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            moduleJvmArgs {
-               exports = ['jdk.compiler/com.sun.tools.javac.code']
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                /**
-                 * Javadoc {@link com.sun.tools.javac.code.Symbol}.
-                 * @param args Program arguments
-                 */
-                public static void main(String[] args) {
-                    com.sun.tools.javac.code.Symbol.class.toString();
-                }
-            }
-            """);
-
-        gradle.withArgs("javadoc").buildsSuccessfully();
-    }
-
-    @Test
-    void builds_javadoc_with_locally_defined_opens(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            moduleJvmArgs {
-               opens = ['jdk.compiler/com.sun.tools.javac.code']
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                /**
-                 * Javadoc {@link com.sun.tools.javac.code.Symbol}.
-                 * @param args Program arguments
-                 */
-                public static void main(String[] args) {
-                    com.sun.tools.javac.code.Symbol.class.toString();
-                }
-            }
-            """);
-
-        gradle.withArgs("javadoc").buildsSuccessfully();
-    }
-
-    @Test
-    void runs_with_locally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            moduleJvmArgs {
-               exports = ['java.management/sun.management']
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    System.out.println(String.join(
-                        " ",
-                        java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
-                }
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
-
-        // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
-        // with an equals.
-        assertThat(result.output()).contains("--add-exports=java.management/sun.management=ALL-UNNAMED");
-    }
-
-    @Test
-    void runs_with_locally_defined_exports_with_the_release_plugin_not_toolchains(
-            GradleInvoker gradle, RootProject rootProject) {
-
-        rootProject.buildGradle().prepend("""
-            plugins {
-                id 'com.palantir.baseline-release-compatibility'
-            }
-            """);
-
-        rootProject.buildGradle().append("""
-            moduleJvmArgs {
-               exports = ['java.management/sun.management']
-            }
-            sourceCompatibility = 11
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    System.out.println(String.join(
-                        " ",
-                        java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
-                }
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
-
-        // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
-        // with an equals.
-        assertThat(result.output()).contains("--add-exports=java.management/sun.management=ALL-UNNAMED");
-    }
-
-    @Test
-    void runs_with_locally_defined_opens(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            moduleJvmArgs {
-               opens 'java.management/sun.management'
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    System.out.println(String.join(
-                        " ",
-                        java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
-                }
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
-        assertThat(result.output()).contains("--add-opens=java.management/sun.management=ALL-UNNAMED");
-    }
-
-    @Test
-    void adds_locally_defined_exports_to_the_jar_manifest(GradleInvoker gradle, RootProject rootProject)
-            throws IOException {
-
-        rootProject.buildGradle().append("""
-            moduleJvmArgs {
-               exports = ['java.management/sun.management']
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    System.out.println(String.join(
-                        " ",
-                        java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
-                }
-            }
-            """);
-
-        gradle.withArgs("jar").buildsSuccessfully();
-
-        File libsDir = rootProject.buildDir().path().resolve("libs").toFile();
-        JarFile jarFile = Arrays.stream(libsDir.listFiles())
-                .filter(file -> file.getName().endsWith(".jar"))
-                .map(file -> {
-                    try {
-                        return new JarFile(file);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        com.sun.tools.javac.code.Symbol.class.toString();
                     }
-                })
-                .findFirst()
-                .orElseThrow();
-        String manifestValue = jarFile.getManifest().getMainAttributes().getValue("Add-Exports");
-        assertThat(manifestValue).isEqualTo("java.management/sun.management");
-
-        assertThat(jarFile.getManifest().getMainAttributes().containsKey("Baseline-Enable-Preview"))
-                .isFalse();
-    }
-
-    @Test
-    void adds_baseline_enable_preview_attribute_to_jar_manifest(GradleInvoker gradle, RootProject rootProject)
-            throws IOException {
-
-        rootProject.buildGradle().append("""
-            javaVersions {
-                runtime = '11_PREVIEW'
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("jar").buildsSuccessfully();
+            gradle.withArgs("compileJava").buildsSuccessfully();
+        }
 
-        File libsDir = rootProject.buildDir().path().resolve("libs").toFile();
-        JarFile jarFile = Arrays.stream(libsDir.listFiles())
-                .filter(file -> file.getName().endsWith(".jar"))
-                .map(file -> {
-                    try {
-                        return new JarFile(file);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
+        @Test
+        void compiles_with_locally_defined_opens(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   opens = ['jdk.compiler/com.sun.tools.javac.code']
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        com.sun.tools.javac.code.Symbol.class.toString();
                     }
-                })
-                .findFirst()
-                .orElseThrow();
-        String manifestValue = jarFile.getManifest().getMainAttributes().getValue("Baseline-Enable-Preview");
-        assertThat(manifestValue).isEqualTo("11");
+                }
+                """);
+
+            gradle.withArgs("compileJava").buildsSuccessfully();
+        }
     }
 
-    @Test
-    void executes_with_externally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
-        createJarWithExport(rootProject, "test.jar");
-
-        rootProject.buildGradle().append("""
-            dependencies {
-                implementation files('test.jar')
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    System.out.println(String.join(
-                        " ",
-                        java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+    @Nested
+    class Javadoc {
+        @Test
+        void builds_javadoc_with_locally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   exports = ['jdk.compiler/com.sun.tools.javac.code']
                 }
-            }
-            """);
+                """);
 
-        InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
-
-        // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
-        // with an equals.
-        assertThat(result.output()).contains("--add-exports=java.management/sun.management=ALL-UNNAMED");
-    }
-
-    @Test
-    void handles_jars_with_no_manifest(GradleInvoker gradle, RootProject rootProject) {
-        String jarName = "test.jar";
-        createEmptyJar(rootProject, jarName);
-
-        rootProject.buildGradle().append("""
-            dependencies {
-                implementation files('test.jar')
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    System.out.println(String.join(
-                        " ",
-                        java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
-                }
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
-        assertThat(result.output()).doesNotContain("--add-exports");
-    }
-
-    @Test
-    void does_not_add_externally_defined_exports_to_the_jar_manifest(GradleInvoker gradle, RootProject rootProject)
-            throws IOException {
-
-        createJarWithExport(rootProject, "test.jar");
-
-        rootProject.buildGradle().append("""
-            dependencies {
-                implementation files('test.jar')
-            }
-            """);
-
-        rootProject.mainSourceSet().java().writeClass("""
-            package com;
-            public class Example {
-                public static void main(String[] args) {
-                    System.out.println(String.join(
-                        " ",
-                        java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
-                }
-            }
-            """);
-
-        gradle.withArgs("jar").buildsSuccessfully();
-
-        File libsDir = rootProject.buildDir().path().resolve("libs").toFile();
-        JarFile jarFile = Arrays.stream(libsDir.listFiles())
-                .filter(file -> file.getName().endsWith(".jar"))
-                .map(file -> {
-                    try {
-                        return new JarFile(file);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    /**
+                     * Javadoc {@link com.sun.tools.javac.code.Symbol}.
+                     * @param args Program arguments
+                     */
+                    public static void main(String[] args) {
+                        com.sun.tools.javac.code.Symbol.class.toString();
                     }
-                })
-                .findFirst()
-                .orElseThrow();
-        String manifestValue = jarFile.getManifest().getMainAttributes().getValue("Add-Exports");
-        assertThat(manifestValue).isNull();
+                }
+                """);
+
+            gradle.withArgs("javadoc").buildsSuccessfully();
+        }
+
+        @Test
+        void builds_javadoc_with_locally_defined_opens(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   opens = ['jdk.compiler/com.sun.tools.javac.code']
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    /**
+                     * Javadoc {@link com.sun.tools.javac.code.Symbol}.
+                     * @param args Program arguments
+                     */
+                    public static void main(String[] args) {
+                        com.sun.tools.javac.code.Symbol.class.toString();
+                    }
+                }
+                """);
+
+            gradle.withArgs("javadoc").buildsSuccessfully();
+        }
+    }
+
+    @Nested
+    class ApplicationRun {
+        @Test
+        void runs_with_locally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   exports = ['java.management/sun.management']
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        System.out.println(String.join(
+                            " ",
+                            java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+                    }
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
+
+            // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
+            // with an equals.
+            assertThat(result.output()).contains("--add-exports=java.management/sun.management=ALL-UNNAMED");
+        }
+
+        @Test
+        void runs_with_locally_defined_exports_with_the_release_plugin_not_toolchains(
+                GradleInvoker gradle, RootProject rootProject) {
+
+            rootProject.buildGradle().prepend("""
+                plugins {
+                    id 'com.palantir.baseline-release-compatibility'
+                }
+                """);
+
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   exports = ['java.management/sun.management']
+                }
+                sourceCompatibility = 11
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        System.out.println(String.join(
+                            " ",
+                            java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+                    }
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
+
+            // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
+            // with an equals.
+            assertThat(result.output()).contains("--add-exports=java.management/sun.management=ALL-UNNAMED");
+        }
+
+        @Test
+        void runs_with_locally_defined_opens(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   opens 'java.management/sun.management'
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        System.out.println(String.join(
+                            " ",
+                            java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+                    }
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
+            assertThat(result.output()).contains("--add-opens=java.management/sun.management=ALL-UNNAMED");
+        }
+
+        @Test
+        void executes_with_externally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
+            createJarWithExport(rootProject, "test.jar");
+
+            rootProject.buildGradle().append("""
+                dependencies {
+                    implementation files('test.jar')
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        System.out.println(String.join(
+                            " ",
+                            java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+                    }
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
+
+            // Gradle appears to normalize args, joining '--add-exports java.management/sun.management=ALL-UNNAMED'
+            // with an equals.
+            assertThat(result.output()).contains("--add-exports=java.management/sun.management=ALL-UNNAMED");
+        }
+    }
+
+    @Nested
+    class JarManifest {
+        @Test
+        void adds_locally_defined_exports_to_the_jar_manifest(GradleInvoker gradle, RootProject rootProject)
+                throws IOException {
+
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   exports = ['java.management/sun.management']
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        System.out.println(String.join(
+                            " ",
+                            java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+                    }
+                }
+                """);
+
+            gradle.withArgs("jar").buildsSuccessfully();
+
+            File libsDir = rootProject.buildDir().path().resolve("libs").toFile();
+            JarFile jarFile = Arrays.stream(libsDir.listFiles())
+                    .filter(file -> file.getName().endsWith(".jar"))
+                    .map(file -> {
+                        try {
+                            return new JarFile(file);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    })
+                    .findFirst()
+                    .orElseThrow();
+            String manifestValue = jarFile.getManifest().getMainAttributes().getValue("Add-Exports");
+            assertThat(manifestValue).isEqualTo("java.management/sun.management");
+
+            assertThat(jarFile.getManifest().getMainAttributes().containsKey("Baseline-Enable-Preview"))
+                    .isFalse();
+        }
+
+        @Test
+        void adds_baseline_enable_preview_attribute_to_jar_manifest(GradleInvoker gradle, RootProject rootProject)
+                throws IOException {
+
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    runtime = '11_PREVIEW'
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                    }
+                }
+                """);
+
+            gradle.withArgs("jar").buildsSuccessfully();
+
+            File libsDir = rootProject.buildDir().path().resolve("libs").toFile();
+            JarFile jarFile = Arrays.stream(libsDir.listFiles())
+                    .filter(file -> file.getName().endsWith(".jar"))
+                    .map(file -> {
+                        try {
+                            return new JarFile(file);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    })
+                    .findFirst()
+                    .orElseThrow();
+            String manifestValue = jarFile.getManifest().getMainAttributes().getValue("Baseline-Enable-Preview");
+            assertThat(manifestValue).isEqualTo("11");
+        }
+
+        @Test
+        void handles_jars_with_no_manifest(GradleInvoker gradle, RootProject rootProject) {
+            String jarName = "test.jar";
+            createEmptyJar(rootProject, jarName);
+
+            rootProject.buildGradle().append("""
+                dependencies {
+                    implementation files('test.jar')
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        System.out.println(String.join(
+                            " ",
+                            java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+                    }
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("run").buildsSuccessfully();
+            assertThat(result.output()).doesNotContain("--add-exports");
+        }
+
+        @Test
+        void does_not_add_externally_defined_exports_to_the_jar_manifest(GradleInvoker gradle, RootProject rootProject)
+                throws IOException {
+
+            createJarWithExport(rootProject, "test.jar");
+
+            rootProject.buildGradle().append("""
+                dependencies {
+                    implementation files('test.jar')
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        System.out.println(String.join(
+                            " ",
+                            java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()));
+                    }
+                }
+                """);
+
+            gradle.withArgs("jar").buildsSuccessfully();
+
+            File libsDir = rootProject.buildDir().path().resolve("libs").toFile();
+            JarFile jarFile = Arrays.stream(libsDir.listFiles())
+                    .filter(file -> file.getName().endsWith(".jar"))
+                    .map(file -> {
+                        try {
+                            return new JarFile(file);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    })
+                    .findFirst()
+                    .orElseThrow();
+            String manifestValue = jarFile.getManifest().getMainAttributes().getValue("Add-Exports");
+            assertThat(manifestValue).isNull();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
I'm currently working on getting baseline-module-jvm-args to work with compiling using a higher version of a compiler and running with `--release`. I need to make quite a few changes to the code, but unfortunately there's so much nesting it's making it hard to write readable code. Additionally, there are so many tests that are not grouped together, which is confusing as junit does not run them in their source declared order.

## After this PR
I've extracted the code to methods. I haven't actually changed the code other than pressing cmd+alt+m to extract method in intellij.

I've grouped some of the tests together in using `@Nested`. The tests have not be changed in anyway.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

