### PR TITLE
disable PatternMatchingInstanceof

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -97,7 +97,11 @@ public abstract class BaselineErrorProneExtension {
             "ObjectsHashCodePrimitive",
             "PreferInstanceofOverGetKind",
             "ProtectedMembersInFinalClass",
-            "PatternMatchingInstanceof",
+            // 2025-10-31
+            // This rule can generate bad code and code that fails checkstyle.  Disable until upstream fixes.
+            // See https://github.com/google/error-prone/issues/5158 - fixed in 2.43.0, but that release requires jdk 21
+            // https://github.com/google/error-prone/issues/4922 - creates names that conflict with existing variables
+            // "PatternMatchingInstanceof",
             "UnnecessaryQualifier",
             "UnnecessaryParentheses",
             "UnusedException",


### PR DESCRIPTION
## Before this PR
This rule can generate both code that doesn't compile and code that compiles but fails checkstyle.
https://github.com/google/error-prone/issues/4922 - creates names that conflict with existing variables
See https://github.com/google/error-prone/issues/5158 - fixed in 2.43.0, but that release requires jdk 21 which we can't update to yet.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

