### PR TITLE
baseline-module-jvm-args: Fix bug where compiler plugin `--add-exports` are added to `compilerArgs` instead of `forkArgs`; allow `--release` and `--add-exports` compiler args to be used together

### DIFF
--- a/baseline-module-jvm-args-compiler-plugins/build.gradle
+++ b/baseline-module-jvm-args-compiler-plugins/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'java-library'
+apply plugin: 'com.palantir.external-publish-jar'
+
+dependencies {
+    annotationProcessor 'com.google.auto.service:auto-service'
+    compileOnly 'com.google.auto.service:auto-service'
+}
+
+moduleJvmArgs {
+    exports = [
+        'jdk.compiler/com.sun.source.util',
+        'jdk.compiler/com.sun.tools.javac.api',
+        'jdk.compiler/com.sun.tools.javac.comp',
+        'jdk.compiler/com.sun.tools.javac.util'
+    ]
+    opens = ['jdk.compiler/com.sun.tools.javac.comp']
+}

--- a/baseline-module-jvm-args-compiler-plugins/src/main/java/com/palantir/baseline/modulejvmargs/compilerplugins/AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection.java
+++ b/baseline-module-jvm-args-compiler-plugins/src/main/java/com/palantir/baseline/modulejvmargs/compilerplugins/AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection.java
@@ -25,9 +25,9 @@ import com.sun.tools.javac.util.Context;
 import java.lang.reflect.Field;
 
 /**
- * The JDK devs arbitrarily decided that you cannot use the `--release` arg along with `--add-exports`
+ * The JDK devs arbitrarily decided that you cannot use the {@code --release} arg along with {@code --add-exports}
  * if it's exporting a "system module" ie one that is shipped with the JDK. This is problematic, as if
- * we want to use `--release` to use a higher JDK to compile against a lower version of the Java
+ * we want to use {@code --release} to use a higher JDK to compile against a lower version of the Java
  * standard library, when someone uses BaselineModuleJvmArgs to add an exports or opens arg to
  * access system modules, they will immediately face this error and be unable to compile. A good example
  * of something that needs extra exports are compiler plugin eg any sort error-prone code, including
@@ -39,7 +39,7 @@ import java.lang.reflect.Field;
  * in Javac's Modules component to be true. We are very fortunate that the error does not actually get
  * created until after Plugin initialisation occurs
  * (<a href="https://github.com/openjdk/jdk/blame/a33aa65fbc70a91fe21e9016c393bb5a764cd75a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java#L1676">here</a>)
- * meaning we can change what we need to change during within a self-contained Plugin.
+ * meaning we can change what we need to change during within a self-contained {@code Plugin}.
  * <br><br>
  * The risk here is that the compiler changes such that we can no longer do this hack, particularly
  * if the timing of the error changes and happens to early before we can prevent it. However, the code
@@ -70,9 +70,16 @@ public final class AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerIn
             // We can but pray that it does not change in the future.
             Field allowAccessIntoSystem = Modules.class.getDeclaredField("allowAccessIntoSystem");
             allowAccessIntoSystem.setAccessible(true);
+            // This requires --add-opens on jdk.compiler/com.sun.tools.javac.comp as it is
+            // reflectively changing code in that module
             allowAccessIntoSystem.setBoolean(modules, true);
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(
+                    "Failed to allow the `--add-exports` and `--release` options to be used together by reflectively"
+                            + " changing the compiler internals. This likely means the compiler"
+                            + " implementation has changed the code that makes this work need to be updated in "
+                            + "https://github.com/palantir/gradle-baseline",
+                    e);
         }
     }
 }

--- a/baseline-module-jvm-args-compiler-plugins/src/main/java/com/palantir/baseline/modulejvmargs/compilerplugins/AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection.java
+++ b/baseline-module-jvm-args-compiler-plugins/src/main/java/com/palantir/baseline/modulejvmargs/compilerplugins/AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection.java
@@ -25,7 +25,24 @@ import com.sun.tools.javac.util.Context;
 import java.lang.reflect.Field;
 
 /**
- * The name is intentionally long to instil the appropriate level of fear.
+ * The JDK devs arbitrarily decided that you cannot use the `--release` arg along with `--add-exports`
+ * if it's exporting a "system module" ie one that is shipped with the JDK. This is problematic, as if
+ * we want to use `--release` to use a higher JDK to compile against a lower version of the Java
+ * standard library, when someone uses BaselineModuleJvmArgs to add an exports or opens arg to
+ * access system modules, they will immediately face this error and be unable to compile. A good example
+ * of something that needs extra exports are compiler plugin eg any sort error-prone code, including
+ * custom BugCheckers. Or even this very compiler plugin (see build.gradle)!
+ * <br><br>
+ * This is a problem I, frankly, just don't want to have. So we "fix" it with this Javac plugin that
+ * will force the field
+ * <a href="https://github.com/openjdk/jdk/blame/a33aa65fbc70a91fe21e9016c393bb5a764cd75a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java#L150">allowAccessIntoSystem</a>
+ * in Javac's Modules component to be true. We are very fortunate that the error does not actually get
+ * created until after Plugin initialisation occurs
+ * (<a href="https://github.com/openjdk/jdk/blame/a33aa65fbc70a91fe21e9016c393bb5a764cd75a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java#L1676">here</a>)
+ * meaning we can change what we need to change during within a self-contained Plugin.
+ * <br><br>
+ * The name is intentionally long to instil the appropriate level of fear and make it obvious there is
+ * serious customisation happening to the compiler.
  */
 @AutoService(Plugin.class)
 public final class AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection

--- a/baseline-module-jvm-args-compiler-plugins/src/main/java/com/palantir/baseline/modulejvmargs/compilerplugins/AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection.java
+++ b/baseline-module-jvm-args-compiler-plugins/src/main/java/com/palantir/baseline/modulejvmargs/compilerplugins/AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection.java
@@ -41,6 +41,11 @@ import java.lang.reflect.Field;
  * (<a href="https://github.com/openjdk/jdk/blame/a33aa65fbc70a91fe21e9016c393bb5a764cd75a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java#L1676">here</a>)
  * meaning we can change what we need to change during within a self-contained Plugin.
  * <br><br>
+ * The risk here is that the compiler changes such that we can no longer do this hack, particularly
+ * if the timing of the error changes and happens to early before we can prevent it. However, the code
+ * has not changed yet since it was introduced 8 years ago (at time of writing) so is hopefully
+ * unlikely to change.
+ * <br><br>
  * The name is intentionally long to instil the appropriate level of fear and make it obvious there is
  * serious customisation happening to the compiler.
  */

--- a/baseline-module-jvm-args-compiler-plugins/src/main/java/com/palantir/baseline/modulejvmargs/compilerplugins/AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection.java
+++ b/baseline-module-jvm-args-compiler-plugins/src/main/java/com/palantir/baseline/modulejvmargs/compilerplugins/AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.modulejvmargs.compilerplugins;
+
+import com.google.auto.service.AutoService;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.Plugin;
+import com.sun.tools.javac.api.BasicJavacTask;
+import com.sun.tools.javac.comp.Modules;
+import com.sun.tools.javac.util.Context;
+import java.lang.reflect.Field;
+
+/**
+ * The name is intentionally long to instil the appropriate level of fear.
+ */
+@AutoService(Plugin.class)
+public final class AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection
+        implements Plugin {
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public void init(JavacTask task, String... _args) {
+        Context context = ((BasicJavacTask) task).getContext();
+        Modules modules = Modules.instance(context);
+
+        try {
+            // As of writing, this field has not been changed in 8 years:
+            // https://github.com/openjdk/jdk/blame/a33aa65fbc70a91fe21e9016c393bb5a764cd75a/
+            //      src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java#L150
+            // We can but pray that it does not change in the future.
+            Field allowAccessIntoSystem = Modules.class.getDeclaredField("allowAccessIntoSystem");
+            allowAccessIntoSystem.setAccessible(true);
+            allowAccessIntoSystem.setBoolean(modules, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -65,10 +65,11 @@ dependencies {
 
 // Baseline errorprone needs to give jars to the compilation process to enable testing, so we publish to maven
 // local first then they are available to the test process.
-tasks.test.dependsOn tasks.findByPath(':gradle-baseline-java-config:publishToMavenLocal')
-tasks.test.dependsOn tasks.findByPath(':baseline-error-prone:publishToMavenLocal')
-tasks.test.dependsOn tasks.findByPath(':baseline-null-away:publishToMavenLocal')
-tasks.test.dependsOn tasks.publishToMavenLocal
+tasks.test.dependsOn ':gradle-baseline-java-config:publishToMavenLocal'
+tasks.test.dependsOn ':baseline-error-prone:publishToMavenLocal'
+tasks.test.dependsOn ':baseline-module-jvm-args-compiler-plugins:publishToMavenLocal'
+tasks.test.dependsOn ':baseline-null-away:publishToMavenLocal'
+tasks.test.dependsOn tasks.named('publishToMavenLocal')
 
 test {
     environment 'CIRCLE_ARTIFACTS', "${buildDir}/artifacts"
@@ -77,6 +78,7 @@ test {
     // This sets the baselineErrorProneGradle property so that the tests know which version of baseline-error-prone
     // to request from mavenLocal()
     environment 'ORG_GRADLE_PROJECT_baselineErrorProneVersion', project.version
+    environment 'ORG_GRADLE_PROJECT_baselineModuleJvmArgsCompilerPluginsVersion', project.version
 
     systemProperty 'ignoreDeprecations', 'true'
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -397,6 +397,39 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         @Inject
         protected abstract ProjectLayout getProjectLayout();
 
+        @Override
+        public final Iterable<String> asArguments() {
+            List<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
+            Stream<String> allExports = Stream.concat(
+                    getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
+            Stream<String> allOpens = Stream.concat(
+                    getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
+
+            List<String> args = runtimeArgs(allExports, allOpens);
+
+            log.debug(
+                    "BaselineModuleJvmArgs configuring {} with exports: {}",
+                    getTaskPath().get(),
+                    args);
+
+            return args;
+        }
+
+        private static List<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
+            Stream<String> exportsArgs =
+                    allExports.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
+            Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
+            return Stream.concat(exportsArgs, opensArgs).toList();
+        }
+
+        private static Stream<String> addExportArg(String modulePackagePair) {
+            return Stream.of("--add-exports", modulePackagePair + "=ALL-UNNAMED");
+        }
+
+        private static Stream<String> addOpensArg(String modulePackagePair) {
+            return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
+        }
+
         public static CommandLineArgumentProvider fromJustClasspath(
                 Task task, Callable<FileCollection> classpathCallable) {
             return create(task).configureWithClasspath(classpathCallable);
@@ -443,48 +476,17 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return provider;
         }
 
-        private static BaselineModuleJvmArgsExtension extension(Task task) {
-            return task.getProject().getExtensions().getByType(BaselineModuleJvmArgsExtension.class);
-        }
-
-        // The `getClasspath()` methods on many task types are not as lazy as you'd hope.
-        // Taking a Callable prevents the mistake of forcing the classpath too early.
+        /**
+         * The `getClasspath()` methods on many task types are not as lazy as you'd hope.
+         * Taking a Callable prevents the mistake of forcing the classpath too early.
+         */
         private ModuleJvmArgsArgumentProvider configureWithClasspath(Callable<FileCollection> classpathCallable) {
             getClasspath().from(getProjectLayout().files(classpathCallable));
             return this;
         }
 
-        @Override
-        public final Iterable<String> asArguments() {
-            List<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
-            Stream<String> allExports = Stream.concat(
-                    getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
-            Stream<String> allOpens = Stream.concat(
-                    getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
-
-            List<String> args = runtimeArgs(allExports, allOpens);
-
-            log.debug(
-                    "BaselineModuleJvmArgs configuring {} with exports: {}",
-                    getTaskPath().get(),
-                    args);
-
-            return args;
-        }
-
-        private static List<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
-            Stream<String> exportsArgs =
-                    allExports.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
-            Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
-            return Stream.concat(exportsArgs, opensArgs).toList();
-        }
-
-        private static Stream<String> addExportArg(String modulePackagePair) {
-            return Stream.of("--add-exports", modulePackagePair + "=ALL-UNNAMED");
-        }
-
-        private static Stream<String> addOpensArg(String modulePackagePair) {
-            return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
+        private static BaselineModuleJvmArgsExtension extension(Task task) {
+            return task.getProject().getExtensions().getByType(BaselineModuleJvmArgsExtension.class);
         }
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -115,13 +115,14 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
         project.getTasks().withType(Test.class).configureEach(test -> {
             test.getJvmArgumentProviders()
-                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtension(test, test::getClasspath));
+                    .add(ModuleJvmArgsArgumentProvider.forRuntimeUsingExtensionWithClasspath(test, test::getClasspath));
             setTaskInputsFromExtension(test, extension);
         });
 
         project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
             javaExec.getJvmArgumentProviders()
-                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtension(javaExec, javaExec::getClasspath));
+                    .add(ModuleJvmArgsArgumentProvider.forRuntimeUsingExtensionWithClasspath(
+                            javaExec, javaExec::getClasspath));
             setTaskInputsFromExtension(javaExec, extension);
         });
 
@@ -230,8 +231,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 .getOptions()
                 .getForkOptions()
                 .getJvmArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.fromJustClasspath(
-                        javaCompile, sourceSet::getAnnotationProcessorPath));
+                .add(ModuleJvmArgsArgumentProvider.forRuntime(javaCompile)
+                        .withClasspath(sourceSet::getAnnotationProcessorPath));
 
         // For the compiler args, we do not want any --add-exports/--add-opens:
         //   1. From the annotationProcessor classpath. These are for *compiler plugins* like errorprone,
@@ -243,7 +244,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         javaCompile
                 .getOptions()
                 .getCompilerArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javaCompile));
+                .add(ModuleJvmArgsArgumentProvider.forCompilation(javaCompile).usingExtensionFor(javaCompile));
 
         setTaskInputsFromExtension(javaCompile, extension);
     }
@@ -270,15 +271,14 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                         return;
                     }
 
-                    Iterable<String> addExportsAndOpensArgs =
-                            ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javadoc)
-                                    // Technically this will have `--add-opens` which are not used in compilation
-                                    // (they need to changed to --add-exports), but we're going to strip out
-                                    // `--add-opens`/`-add-exports` in the next step anyway due to Javadoc
-                                    // task's weird `addMultilineStringsOption` method, so they will all
-                                    // effectively become --add-exports
-                                    .configureWithClasspath(sourceSet::getAnnotationProcessorPath)
-                                    .asArguments();
+                    Iterable<String> addExportsAndOpensArgs = ModuleJvmArgsArgumentProvider.forCompilation(javadoc)
+                            // Technically this will have `--add-opens` which are not used in compilation
+                            // (they need to changed to --add-exports), but we're going to strip out
+                            // `--add-opens`/`-add-exports` in the next step anyway due to Javadoc
+                            // task's weird `addMultilineStringsOption` method, so they will all
+                            // effectively become --add-exports
+                            .withClasspath(sourceSet::getAnnotationProcessorPath)
+                            .asArguments();
 
                     List<String> exportValues = StreamSupport.stream(addExportsAndOpensArgs.spliterator(), false)
                             .filter(option -> !option.startsWith("--add"))
@@ -397,20 +397,23 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         @Internal
         public abstract Property<String> getTaskPath();
 
+        @Internal
+        public abstract Property<Boolean> getForCompilation();
+
         @Inject
         protected abstract ProviderFactory getProviderFactory();
 
         @Override
         public final Iterable<String> asArguments() {
-            Stream<String> exportsArgs = getExports().get().stream()
+            List<String> exportsArgs = getExports().get().stream()
                     .distinct()
                     .sorted()
-                    .flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
+                    .flatMap(ModuleJvmArgsArgumentProvider::addExportArg).toList();
 
-            Stream<String> opensArgs =
-                    getOpens().get().stream().distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
+            List<String> opensArgs =
+                    getOpens().get().stream().distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg).toList();
 
-            List<String> args = Stream.concat(exportsArgs, opensArgs).toList();
+            List<String> args = Stream.concat(exportsArgs, getForCompilation().get() ? opensArgs).toList();
 
             log.debug(
                     "BaselineModuleJvmArgs configuring {} with exports: {}",
@@ -428,27 +431,20 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
         }
 
-        public static ModuleJvmArgsArgumentProvider fromJustClasspath(
+        public static ModuleJvmArgsArgumentProvider forRuntimeUsingExtensionWithClasspath(
                 Task task, Callable<FileCollection> classpathCallable) {
-            return create(task).configureWithClasspath(classpathCallable);
+            return forRuntime(task).usingExtensionFor(task).withClasspath(classpathCallable);
         }
 
-        public static ModuleJvmArgsArgumentProvider fromJustExtensionForCompilation(Task task) {
+        public static ModuleJvmArgsArgumentProvider forRuntime(Task task) {
             ModuleJvmArgsArgumentProvider argumentProvider = create(task);
-
-            argumentProvider.getExports().addAll(extension(task).exports());
-            // For compilation, `--add-opens` does nothing at all. Instead, each of the `opens` needs to
-            // become an export for compilation to work.
-            argumentProvider.getExports().addAll(extension(task).opens());
-
+            argumentProvider.getForCompilation().set(false);
             return argumentProvider;
         }
 
-        public static ModuleJvmArgsArgumentProvider fromClasspathAndExtension(
-                Task task, Callable<FileCollection> classpathCallable) {
-            ModuleJvmArgsArgumentProvider argumentProvider = create(task).configureWithClasspath(classpathCallable);
-            argumentProvider.getExports().addAll(extension(task).exports());
-            argumentProvider.getOpens().addAll(extension(task).opens());
+        public static ModuleJvmArgsArgumentProvider forCompilation(Task task) {
+            ModuleJvmArgsArgumentProvider argumentProvider = create(task);
+            argumentProvider.getForCompilation().set(true);
             return argumentProvider;
         }
 
@@ -461,11 +457,18 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return provider;
         }
 
+        public final ModuleJvmArgsArgumentProvider usingExtensionFor(Task task) {
+            getExports().addAll(extension(task).exports());
+            getOpens().addAll(extension(task).opens());
+
+            return this;
+        }
+
         /**
          * The `getClasspath()` methods on many task types are not as lazy as you'd hope.
          * Taking a Callable prevents the mistake of forcing the classpath too early.
          */
-        private ModuleJvmArgsArgumentProvider configureWithClasspath(Callable<FileCollection> classpathCallable) {
+        public final ModuleJvmArgsArgumentProvider withClasspath(Callable<FileCollection> classpathCallable) {
             Provider<List<JarManifestModuleInfo>> jarManifestModuleInfos =
                     getProviderFactory().provider(classpathCallable).map(BaselineModuleJvmArgs::collectClasspathInfo);
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -412,7 +412,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 Task task, Callable<FileCollection> classpathCallable) {
             ModuleJvmArgsArgumentProvider argumentProvider = create(task).configureWithClasspath(classpathCallable);
             argumentProvider.getExports().addAll(extension(task).exports());
-            argumentProvider.getExports().addAll(extension(task).opens());
+            argumentProvider.getOpens().addAll(extension(task).opens());
             return argumentProvider;
         }
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -469,13 +469,13 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             Provider<List<JarManifestModuleInfo>> jarManifestModuleInfos =
                     getProviderFactory().provider(classpathCallable).map(BaselineModuleJvmArgs::collectClasspathInfo);
 
-            getExports().addAll(jarManifestModuleInfos.map(extract(JarManifestModuleInfo::exports)));
-            getOpens().addAll(jarManifestModuleInfos.map(extract(JarManifestModuleInfo::opens)));
+            getExports().addAll(jarManifestModuleInfos.map(extractArgType(JarManifestModuleInfo::exports)));
+            getOpens().addAll(jarManifestModuleInfos.map(extractArgType(JarManifestModuleInfo::opens)));
 
             return this;
         }
 
-        private Transformer<List<String>, List<JarManifestModuleInfo>> extract(
+        private Transformer<List<String>, List<JarManifestModuleInfo>> extractArgType(
                 Function<JarManifestModuleInfo, List<String>> extractor) {
             return jarManifestModuleInfos -> jarManifestModuleInfos.stream()
                     .flatMap(info -> extractor.apply(info).stream())

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -96,17 +96,30 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
                 TaskProvider<JavaCompile> javaCompileProvider =
                         project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
+
                 javaCompileProvider.configure(javaCompile -> {
-                    ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
+                    ModuleJvmArgsArgumentProvider forkOptionsArgProvider = newModuleJvmArgsArgumentProvider(
                             project,
-                            extension,
-                            project.files(project.getConfigurations()
-                                    .named(sourceSet.getAnnotationProcessorConfigurationName())),
+                            Optional.empty(),
+                            Optional.of(project.files(project.getConfigurations()
+                                    .named(sourceSet.getAnnotationProcessorConfigurationName()))),
                             javaCompile.getName());
-                    provider.getBaselineJavaVersionEnabled()
+
+                    forkOptionsArgProvider
+                            .getBaselineJavaVersionEnabled()
                             .set(project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class)));
 
-                    javaCompile.getOptions().getCompilerArgumentProviders().add(provider);
+                    javaCompile
+                            .getOptions()
+                            .getForkOptions()
+                            .getJvmArgumentProviders()
+                            .add(forkOptionsArgProvider);
+
+                    javaCompile
+                            .getOptions()
+                            .getCompilerArgumentProviders()
+                            .add(newModuleJvmArgsArgumentProvider(
+                                    project, Optional.of(extension), Optional.empty(), javaCompile.getName()));
 
                     setTaskInputsFromExtension(javaCompile, extension);
                 });
@@ -250,6 +263,24 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         provider.getExports().set(extension.exports());
         provider.getOpens().set(extension.opens());
         provider.getClasspath().from(classpath);
+        provider.getProjectPath().set(project.getPath());
+        provider.getTaskName().set(taskName);
+        return provider;
+    }
+
+    private static ModuleJvmArgsArgumentProvider newModuleJvmArgsArgumentProvider(
+            Project project,
+            Optional<BaselineModuleJvmArgsExtension> useExportsOpensFromExtension,
+            Optional<ConfigurableFileCollection> useExportsOpensFromClasspath,
+            String taskName) {
+        ModuleJvmArgsArgumentProvider provider = project.getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
+        useExportsOpensFromExtension.ifPresent(extension -> {
+            provider.getExports().set(extension.exports());
+            provider.getOpens().set(extension.opens());
+        });
+        useExportsOpensFromClasspath.ifPresent(classpath -> {
+            provider.getClasspath().from(classpath);
+        });
         provider.getProjectPath().set(project.getPath());
         provider.getTaskName().set(taskName);
         return provider;

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -98,6 +98,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                         project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
 
                 javaCompileProvider.configure(javaCompile -> {
+                    Provider<Boolean> baselineJavaVersionsEnabled =
+                            project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class));
+
                     ModuleJvmArgsArgumentProvider forkOptionsArgProvider = newModuleJvmArgsArgumentProvider(
                             project,
                             Optional.empty(),
@@ -105,9 +108,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                                     .named(sourceSet.getAnnotationProcessorConfigurationName()))),
                             javaCompile.getName());
 
-                    forkOptionsArgProvider
-                            .getBaselineJavaVersionEnabled()
-                            .set(project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class)));
+                    forkOptionsArgProvider.getBaselineJavaVersionEnabled().set(baselineJavaVersionsEnabled);
 
                     javaCompile
                             .getOptions()
@@ -115,11 +116,12 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                             .getJvmArgumentProviders()
                             .add(forkOptionsArgProvider);
 
-                    javaCompile
-                            .getOptions()
-                            .getCompilerArgumentProviders()
-                            .add(newModuleJvmArgsArgumentProvider(
-                                    project, Optional.of(extension), Optional.empty(), javaCompile.getName()));
+                    ModuleJvmArgsArgumentProvider compilerArgsProvider = newModuleJvmArgsArgumentProvider(
+                            project, Optional.of(extension), Optional.empty(), javaCompile.getName());
+
+                    compilerArgsProvider.getBaselineJavaVersionEnabled().set(baselineJavaVersionsEnabled);
+
+                    javaCompile.getOptions().getCompilerArgumentProviders().add(compilerArgsProvider);
 
                     setTaskInputsFromExtension(javaCompile, extension);
                 });

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -230,8 +230,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 .getOptions()
                 .getForkOptions()
                 .getJvmArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.fromJustClasspath(
-                        javaCompile, sourceSet::getAnnotationProcessorPath));
+                .add(ModuleJvmArgsArgumentProvider.fromJustClasspath(javaCompile, sourceSet::getAnnotationProcessorPath)
+                        .withExtraDescription("forkArgs"));
 
         // For the compiler args, we do not want any --add-exports/--add-opens:
         //   1. From the annotationProcessor classpath. These are for *compiler plugins* like errorprone,
@@ -243,7 +243,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         javaCompile
                 .getOptions()
                 .getCompilerArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javaCompile));
+                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javaCompile)
+                        .withExtraDescription("compilerArgs"));
 
         setTaskInputsFromExtension(javaCompile, extension);
     }
@@ -394,7 +395,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         public abstract SetProperty<String> getOpens();
 
         @Internal
-        public abstract Property<String> getTaskPath();
+        public abstract Property<String> getDescription();
 
         @Inject
         protected abstract ProviderFactory getProviderFactory();
@@ -413,7 +414,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
             log.debug(
                     "BaselineModuleJvmArgs configuring {} with exports: {}",
-                    getTaskPath().get(),
+                    getDescription().get(),
                     args);
 
             return args;
@@ -461,11 +462,16 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return argumentProvider;
         }
 
+        public final ModuleJvmArgsArgumentProvider withExtraDescription(String description) {
+            getDescription().set(getDescription().get() + " " + description);
+            return this;
+        }
+
         private static ModuleJvmArgsArgumentProvider create(Task task) {
             ModuleJvmArgsArgumentProvider provider =
                     task.getProject().getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
 
-            provider.getTaskPath().set(task.getPath());
+            provider.getDescription().set(task.getPath());
 
             return provider;
         }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -201,6 +201,19 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     private static void configureJavaCompile(
             Project project, SourceSet sourceSet, BaselineModuleJvmArgsExtension extension, JavaCompile javaCompile) {
 
+        // We will *always* fork the compiler - for both consistency and correctness:
+        // Consistency: when fork=false, Gradle will sometimes still make a forked Gradle worker daemon
+        //              for compilation! If the main Gradle daemon is running on the correct JDK major version,
+        //              Gradle will just use the current daemon. However, if the main Gradle daemon is
+        //              running with a different JDK Gradle will fork off a worker daemon to do the compilation.
+        //              There are material differences in behaviour when it is forked vs not forked, so
+        //              we always for consistency.
+        // Correctness: If fork=false and Gradle thinks it can reuse the main Gradle daemon as it's running
+        //              with the correct JDK major version, the main daemon will not necessarily have
+        //              the required --add-exports/--add-opens set on the process running the compilations,
+        //              *even if* we've specified them in forkOptions. Forking stops this from happening.
+        javaCompile.getOptions().setFork(true);
+
         Provider<Boolean> baselineJavaVersionsEnabled =
                 project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class));
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -159,7 +159,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     private void addReleaseAndAddExportsArgsFixingCompilerPlugin(Project project) {
         // There is more info about the plugin in its implementation class.
         // The gist is we change the compiler internals using reflection to allow the `--release`
-        // and `--add-exports` args to be used together with compiler errors.
+        // and `--add-exports` args to be used together without compiler errors.
 
         // We always apply the plugin even if it's not necessary for two reasons:
         //   1. There's no way to lazily add an arg based on the values of other args without forcing

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -42,6 +42,7 @@ import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -113,14 +114,15 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         });
 
         project.getTasks().withType(Test.class).configureEach(test -> {
-            RuntimeArgumentProvider provider = newModuleJvmArgsArgumentProvider(test, test::getClasspath);
-            test.getJvmArgumentProviders().add(provider);
+            test.getJvmArgumentProviders()
+                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtensionExportOpens(test, test::getClasspath));
             setTaskInputsFromExtension(test, extension);
         });
 
         project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
-            RuntimeArgumentProvider provider = newModuleJvmArgsArgumentProvider(javaExec, javaExec::getClasspath);
-            javaExec.getJvmArgumentProviders().add(provider);
+            javaExec.getJvmArgumentProviders()
+                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtensionExportOpens(
+                            javaExec, javaExec::getClasspath));
             setTaskInputsFromExtension(javaExec, extension);
         });
 
@@ -209,25 +211,17 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         //              *even if* we've specified them in forkOptions. Forking stops this from happening.
         javaCompile.getOptions().setFork(true);
 
-        RuntimeArgumentProvider forkOptionsArgProvider =
-                project.getObjects().newInstance(RuntimeArgumentProvider.class);
-        forkOptionsArgProvider.getTaskPath().set(javaCompile.getPath());
-        forkOptionsArgProvider
-                .getClasspath()
-                .from(project.files(
-                        project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName())));
+        javaCompile
+                .getOptions()
+                .getForkOptions()
+                .getJvmArgumentProviders()
+                .add(ModuleJvmArgsArgumentProvider.fromJustClasspath(
+                        javaCompile, sourceSet::getAnnotationProcessorPath));
 
-        javaCompile.getOptions().getForkOptions().getJvmArgumentProviders().add(forkOptionsArgProvider);
-
-        CompilerArgsArgumentProvider compilerArgsProvider =
-                project.getObjects().newInstance(CompilerArgsArgumentProvider.class);
-        compilerArgsProvider.getExports().set(extension.exports());
-        compilerArgsProvider.getOpens().set(extension.opens());
-        compilerArgsProvider.getTaskPath().set(javaCompile.getPath());
-        compilerArgsProvider.getBaselineJavaVersionEnabled().set(project.provider(() -> project.getPlugins()
-                .hasPlugin(BaselineJavaVersion.class)));
-
-        javaCompile.getOptions().getCompilerArgumentProviders().add(compilerArgsProvider);
+        javaCompile
+                .getOptions()
+                .getCompilerArgumentProviders()
+                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionExportsOpens(javaCompile));
 
         setTaskInputsFromExtension(javaCompile, extension);
     }
@@ -293,25 +287,6 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 setTaskInputsFromExtension(javadocTask, extension);
             });
         }
-    }
-
-    /**
-     * @param classpathCallable The `getClasspath()` methods on many task types are not as lazy as you'd hope.
-     *                          Taking a Callable prevents the mistake of forcing the classpath too early.
-     */
-    private static RuntimeArgumentProvider newModuleJvmArgsArgumentProvider(
-            Task task, Callable<FileCollection> classpathCallable) {
-
-        BaselineModuleJvmArgsExtension extension =
-                task.getProject().getExtensions().getByType(BaselineModuleJvmArgsExtension.class);
-
-        RuntimeArgumentProvider provider = task.getProject().getObjects().newInstance(RuntimeArgumentProvider.class);
-        provider.getExports().set(extension.exports());
-        provider.getOpens().set(extension.opens());
-        provider.getClasspath().from(task.getProject().files(classpathCallable));
-        provider.getTaskPath().set(task.getPath());
-
-        return provider;
     }
 
     private static void setTaskInputsFromExtension(Task task, BaselineModuleJvmArgsExtension extension) {
@@ -404,8 +379,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         class Builder extends ImmutableJarManifestModuleInfo.Builder {}
     }
 
-    public abstract static class RuntimeArgumentProvider implements CommandLineArgumentProvider {
-        private static final Logger log = Logging.getLogger(RuntimeArgumentProvider.class);
+    public abstract static class ModuleJvmArgsArgumentProvider implements CommandLineArgumentProvider {
+        private static final Logger log = Logging.getLogger(ModuleJvmArgsArgumentProvider.class);
 
         @Internal
         public abstract SetProperty<String> getExports();
@@ -418,6 +393,47 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
         @Internal
         public abstract Property<String> getTaskPath();
+
+        @Inject
+        protected abstract ProjectLayout getProjectLayout();
+
+        public static CommandLineArgumentProvider fromJustClasspath(
+                Task task, Callable<FileCollection> classpathCallable) {
+            return create(task).configureWithClasspath(classpathCallable);
+        }
+
+        public static CommandLineArgumentProvider fromJustExtensionExportsOpens(Task task) {
+            return create(task).configureWithExtension(task);
+        }
+
+        public static CommandLineArgumentProvider fromClasspathAndExtensionExportOpens(
+                Task task, Callable<FileCollection> classpathCallable) {
+            return create(task).configureWithClasspath(classpathCallable).configureWithExtension(task);
+        }
+
+        private static ModuleJvmArgsArgumentProvider create(Task task) {
+            ModuleJvmArgsArgumentProvider provider =
+                    task.getProject().getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
+
+            provider.getTaskPath().set(task.getPath());
+
+            return provider;
+        }
+
+        private ModuleJvmArgsArgumentProvider configureWithExtension(Task task) {
+            BaselineModuleJvmArgsExtension extension =
+                    task.getProject().getExtensions().getByType(BaselineModuleJvmArgsExtension.class);
+            getExports().set(extension.exports());
+            getOpens().set(extension.opens());
+            return this;
+        }
+
+        // The `getClasspath()` methods on many task types are not as lazy as you'd hope.
+        // Taking a Callable prevents the mistake of forcing the classpath too early.
+        private ModuleJvmArgsArgumentProvider configureWithClasspath(Callable<FileCollection> classpathCallable) {
+            getClasspath().from(getProjectLayout().files(classpathCallable));
+            return this;
+        }
 
         @Override
         public final Iterable<String> asArguments() {
@@ -438,8 +454,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         }
 
         private static List<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
-            Stream<String> exportsArgs = allExports.distinct().sorted().flatMap(RuntimeArgumentProvider::addExportArg);
-            Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(RuntimeArgumentProvider::addOpensArg);
+            Stream<String> exportsArgs =
+                    allExports.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
+            Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
             return Stream.concat(exportsArgs, opensArgs).toList();
         }
 
@@ -449,55 +466,6 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
         private static Stream<String> addOpensArg(String modulePackagePair) {
             return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
-        }
-    }
-
-    public abstract static class CompilerArgsArgumentProvider implements CommandLineArgumentProvider {
-        private static final Logger log = Logging.getLogger(RuntimeArgumentProvider.class);
-
-        @Internal
-        public abstract SetProperty<String> getExports();
-
-        @Internal
-        public abstract SetProperty<String> getOpens();
-
-        @Internal
-        public abstract Property<Boolean> getBaselineJavaVersionEnabled();
-
-        @Internal
-        public abstract Property<String> getTaskPath();
-
-        @Override
-        public final Iterable<String> asArguments() {
-            boolean isBaselineJavaVersionEnabled =
-                    getBaselineJavaVersionEnabled().getOrElse(false);
-
-            if (!isBaselineJavaVersionEnabled) {
-                log.debug(
-                        "BaselineModuleJvmArgs not applying args to compilation task {} due to lack of "
-                                + "BaselineJavaVersion",
-                        getTaskPath().get());
-                return ImmutableList.of();
-            }
-
-            // For compilation, `--add-opens` does nothing at all. Instead, each of the `opens` needs to
-            // become an export for compilation to work
-            List<String> args = Stream.concat(getExports().get().stream(), getOpens().get().stream())
-                    .distinct()
-                    .sorted()
-                    .flatMap(CompilerArgsArgumentProvider::addExportArg)
-                    .toList();
-
-            log.debug(
-                    "BaselineModuleJvmArgs configuring {} with exports: {}",
-                    getTaskPath().get(),
-                    args);
-
-            return args;
-        }
-
-        private static Stream<String> addExportArg(String modulePackagePair) {
-            return Stream.of("--add-exports", modulePackagePair + "=ALL-UNNAMED");
         }
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,8 +40,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.java.archives.Manifest;
@@ -48,6 +49,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.JavaExec;
@@ -229,8 +231,11 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 .getOptions()
                 .getForkOptions()
                 .getJvmArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.fromJustClasspath(
-                        javaCompile, sourceSet::getAnnotationProcessorPath));
+                .add(ModuleJvmArgsArgumentProvider.create(javaCompile)
+                        .configureWithClasspath(javaCompile
+                                .getProject()
+                                .getConfigurations()
+                                .named(sourceSet.getAnnotationProcessorConfigurationName())));
 
         // For the compiler args, we do not want any --add-exports/--add-opens:
         //   1. From the annotationProcessor classpath. These are for *compiler plugins* like errorprone,
@@ -242,7 +247,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         javaCompile
                 .getOptions()
                 .getCompilerArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javaCompile));
+                .add(ModuleJvmArgsArgumentProvider.create(javaCompile)
+                        .
+                );
 
         setTaskInputsFromExtension(javaCompile, extension);
     }
@@ -394,7 +401,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         public abstract SetProperty<String> getOpens();
 
         @Internal
-        public abstract ConfigurableFileCollection getClasspath();
+        public abstract Property<Boolean> getForCompilation();
 
         @Internal
         public abstract Property<String> getTaskPath();
@@ -402,15 +409,23 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         @Inject
         protected abstract ProjectLayout getProjectLayout();
 
+        @Inject
+        protected abstract ProviderFactory getProviderFactory();
+
         @Override
         public final Iterable<String> asArguments() {
-            List<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
             Stream<String> allExports = Stream.concat(
                     getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
             Stream<String> allOpens = Stream.concat(
                     getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
 
-            List<String> args = runtimeArgs(allExports, allOpens);
+            List<Arg> args = blah(allExports, allOpens);
+
+            if (getForCompilation().get()) {
+                args = args.stream().map(Arg::forceToBeExports).toList();
+            }
+
+            return args;
 
             log.debug(
                     "BaselineModuleJvmArgs configuring {} with exports: {}",
@@ -420,10 +435,45 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return args;
         }
 
+        private List<Arg> args() {
+            List<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
+            Stream<String> allExports = Stream.concat(
+                    getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
+            Stream<String> allOpens = Stream.concat(
+                    getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
+
+            List<Arg> args = blah(allExports, allOpens);
+
+            if (getForCompilation().get()) {
+                args = args.stream().map(Arg::forceToBeExports).toList();
+            }
+
+            return args;
+        }
+
+        public final List<String> argsForJavadoc() {}
+
+        private enum ArgType {
+            EXPORTS,
+            OPENS;
+        }
+
+        private record Arg(ArgType argType, String module) {
+            public Arg forceToBeExports() {
+                return new Arg(ArgType.EXPORTS, module);
+            }
+        }
+
         private static List<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
             Stream<String> exportsArgs =
                     allExports.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
             Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
+            return Stream.concat(exportsArgs, opensArgs).toList();
+        }
+
+        private static List<Arg> blah(Stream<String> allExports, Stream<String> allOpens) {
+            Stream<Arg> exportsArgs = allExports.distinct().sorted().map(module -> new Arg(ArgType.EXPORTS, module));
+            Stream<Arg> opensArgs = allOpens.distinct().sorted().map(module -> new Arg(ArgType.OPENS, module));
             return Stream.concat(exportsArgs, opensArgs).toList();
         }
 
@@ -472,9 +522,26 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
          * The `getClasspath()` methods on many task types are not as lazy as you'd hope.
          * Taking a Callable prevents the mistake of forcing the classpath too early.
          */
-        private ModuleJvmArgsArgumentProvider configureWithClasspath(Callable<FileCollection> classpathCallable) {
-            getClasspath().from(getProjectLayout().files(classpathCallable));
+        private ModuleJvmArgsArgumentProvider configureWithClasspath(Provider<Configuration> classpathCallable) {
+            Provider<List<JarManifestModuleInfo>> listProperty =
+                    classpathCallable.map(classpath -> collectClasspathInfo(classpath.resolve()));
+
+            getExports().addAll(extract(listProperty, JarManifestModuleInfo::exports));
+            getOpens().addAll(extract(listProperty, JarManifestModuleInfo::opens));
             return this;
+        }
+
+        private ModuleJvmArgsArgumentProvider forCompilation() {
+            getForCompilation().set(true);
+            return this;
+        }
+
+        private Provider<List<String>> extract(
+                Provider<List<JarManifestModuleInfo>> jarManifestModuleInfosProvider,
+                Function<JarManifestModuleInfo, List<String>> extractor) {
+            return jarManifestModuleInfosProvider.map(jarManifestModuleInfos -> jarManifestModuleInfos.stream()
+                    .flatMap(info -> extractor.apply(info).stream())
+                    .toList());
         }
 
         private static BaselineModuleJvmArgsExtension extension(Task task) {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -95,6 +95,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         BaselineModuleJvmArgsExtension extension =
                 project.getExtensions().create(EXTENSION_NAME, BaselineModuleJvmArgsExtension.class, project);
 
+        addReleaseAndAddExportsArgsFixingCompilerPlugin(project);
+
         // Derive this plugin's `enablePreview` property from BaselineJavaVersion's extension
         project.getPlugins().withType(BaselineJavaVersion.class, _unused -> {
             BaselineJavaVersionExtension javaVersionsExtension =
@@ -158,6 +160,34 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         });
     }
 
+    private void addReleaseAndAddExportsArgsFixingCompilerPlugin(Project project) {
+        String version = Optional.ofNullable(
+                        (String) project.findProperty("baselineModuleJvmArgsCompilerPluginsVersion"))
+                .or(() -> Optional.ofNullable(
+                        BaselineErrorProne.class.getPackage().getImplementationVersion()))
+                .orElseThrow(() -> new RuntimeException(
+                        "baseline-module-jvm-args-compiler-plugins implementation version not found"));
+
+        project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
+            project.getDependencies()
+                    .add(
+                            sourceSet.getAnnotationProcessorConfigurationName(),
+                            "com.palantir.baseline:baseline-module-jvm-args-compiler-plugins:" + version);
+
+            project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class, javaCompile -> {
+                javaCompile.getOptions().getCompilerArgumentProviders().add(new CommandLineArgumentProvider() {
+                    private static final String COMPILER_PLUGIN_NAME =
+                            "AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection";
+
+                    @Override
+                    public Iterable<String> asArguments() {
+                        return List.of("-Xplugin:" + COMPILER_PLUGIN_NAME);
+                    }
+                });
+            });
+        });
+    }
+
     private void configureSourceSet(Project project, SourceSet sourceSet, BaselineModuleJvmArgsExtension extension) {
         project.getTasks()
                 .named(sourceSet.getCompileJavaTaskName(), JavaCompile.class)
@@ -171,19 +201,26 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     private static void configureJavaCompile(
             Project project, SourceSet sourceSet, BaselineModuleJvmArgsExtension extension, JavaCompile javaCompile) {
 
-        // javac isn't provided `--add-exports` args for the time being due to
-        // https://github.com/gradle/gradle/issues/18824
-        // However, we set sourceCompatibility in BaselineJavaVersion to opt out of the '--release' flag.
+        Provider<Boolean> baselineJavaVersionsEnabled =
+                project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class));
 
-        ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
+        ModuleJvmArgsArgumentProvider forkOptionsArgProvider = newModuleJvmArgsArgumentProvider(
                 project,
-                extension,
-                project.files(project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName())),
+                Optional.empty(),
+                Optional.of(project.files(
+                        project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName()))),
                 javaCompile.getName());
-        provider.getBaselineJavaVersionEnabled()
-                .set(project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class)));
 
-        javaCompile.getOptions().getCompilerArgumentProviders().add(provider);
+        forkOptionsArgProvider.getBaselineJavaVersionEnabled().set(baselineJavaVersionsEnabled);
+
+        javaCompile.getOptions().getForkOptions().getJvmArgumentProviders().add(forkOptionsArgProvider);
+
+        ModuleJvmArgsArgumentProvider compilerArgsProvider = newModuleJvmArgsArgumentProvider(
+                project, Optional.of(extension), Optional.empty(), javaCompile.getName());
+
+        compilerArgsProvider.getBaselineJavaVersionEnabled().set(baselineJavaVersionsEnabled);
+
+        javaCompile.getOptions().getCompilerArgumentProviders().add(compilerArgsProvider);
 
         setTaskInputsFromExtension(javaCompile, extension);
     }
@@ -256,10 +293,22 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             BaselineModuleJvmArgsExtension extension,
             ConfigurableFileCollection classpath,
             String taskName) {
+        return newModuleJvmArgsArgumentProvider(project, Optional.of(extension), Optional.of(classpath), taskName);
+    }
+
+    private static ModuleJvmArgsArgumentProvider newModuleJvmArgsArgumentProvider(
+            Project project,
+            Optional<BaselineModuleJvmArgsExtension> useExportsOpensFromExtension,
+            Optional<ConfigurableFileCollection> useExportsOpensFromClasspath,
+            String taskName) {
         ModuleJvmArgsArgumentProvider provider = project.getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
-        provider.getExports().set(extension.exports());
-        provider.getOpens().set(extension.opens());
-        provider.getClasspath().from(classpath);
+        useExportsOpensFromExtension.ifPresent(extension -> {
+            provider.getExports().set(extension.exports());
+            provider.getOpens().set(extension.opens());
+        });
+        useExportsOpensFromClasspath.ifPresent(classpath -> {
+            provider.getClasspath().from(classpath);
+        });
         provider.getProjectPath().set(project.getPath());
         provider.getTaskName().set(taskName);
         return provider;

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,15 +40,15 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.JavaExec;
@@ -394,23 +395,22 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         public abstract SetProperty<String> getOpens();
 
         @Internal
-        public abstract ConfigurableFileCollection getClasspath();
-
-        @Internal
         public abstract Property<String> getTaskPath();
 
         @Inject
-        protected abstract ProjectLayout getProjectLayout();
+        protected abstract ProviderFactory getProviderFactory();
 
         @Override
         public final Iterable<String> asArguments() {
-            List<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
-            Stream<String> allExports = Stream.concat(
-                    getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
-            Stream<String> allOpens = Stream.concat(
-                    getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
+            Stream<String> exportsArgs = getExports().get().stream()
+                    .distinct()
+                    .sorted()
+                    .flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
 
-            List<String> args = runtimeArgs(allExports, allOpens);
+            Stream<String> opensArgs =
+                    getOpens().get().stream().distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
+
+            List<String> args = Stream.concat(exportsArgs, opensArgs).toList();
 
             log.debug(
                     "BaselineModuleJvmArgs configuring {} with exports: {}",
@@ -418,13 +418,6 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                     args);
 
             return args;
-        }
-
-        private static List<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
-            Stream<String> exportsArgs =
-                    allExports.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
-            Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
-            return Stream.concat(exportsArgs, opensArgs).toList();
         }
 
         private static Stream<String> addExportArg(String modulePackagePair) {
@@ -473,8 +466,20 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
          * Taking a Callable prevents the mistake of forcing the classpath too early.
          */
         private ModuleJvmArgsArgumentProvider configureWithClasspath(Callable<FileCollection> classpathCallable) {
-            getClasspath().from(getProjectLayout().files(classpathCallable));
+            Provider<List<JarManifestModuleInfo>> jarManifestModuleInfos =
+                    getProviderFactory().provider(classpathCallable).map(BaselineModuleJvmArgs::collectClasspathInfo);
+
+            getExports().addAll(jarManifestModuleInfos.map(extract(JarManifestModuleInfo::exports)));
+            getOpens().addAll(jarManifestModuleInfos.map(extract(JarManifestModuleInfo::opens)));
+
             return this;
+        }
+
+        private Transformer<List<String>, List<JarManifestModuleInfo>> extract(
+                Function<JarManifestModuleInfo, List<String>> extractor) {
+            return jarManifestModuleInfos -> jarManifestModuleInfos.stream()
+                    .flatMap(info -> extractor.apply(info).stream())
+                    .toList();
         }
 
         private static BaselineModuleJvmArgsExtension extension(Task task) {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -307,21 +307,13 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             BaselineModuleJvmArgsExtension extension,
             ConfigurableFileCollection classpath,
             String taskName) {
-        return newModuleJvmArgsArgumentProvider(project, Optional.of(extension), Optional.of(classpath), taskName);
-    }
-
-    private static ModuleJvmArgsArgumentProvider newModuleJvmArgsArgumentProvider(
-            Project project,
-            Optional<BaselineModuleJvmArgsExtension> useExportsOpensFromExtension,
-            Optional<ConfigurableFileCollection> useExportsOpensFromClasspath,
-            String taskName) {
         ModuleJvmArgsArgumentProvider provider = project.getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
-        useExportsOpensFromExtension.ifPresent(extension -> {
-            provider.getExports().set(extension.exports());
-            provider.getOpens().set(extension.opens());
+        Optional.of(extension).ifPresent(extension1 -> {
+            provider.getExports().set(extension1.exports());
+            provider.getOpens().set(extension1.opens());
         });
-        useExportsOpensFromClasspath.ifPresent(classpath -> {
-            provider.getClasspath().from(classpath);
+        Optional.of(classpath).ifPresent(classpath1 -> {
+            provider.getClasspath().from(classpath1);
         });
         provider.getProjectPath().set(project.getPath());
         provider.getTaskName().set(taskName);

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -115,14 +115,13 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
         project.getTasks().withType(Test.class).configureEach(test -> {
             test.getJvmArgumentProviders()
-                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtensionExportOpens(test, test::getClasspath));
+                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtension(test, test::getClasspath));
             setTaskInputsFromExtension(test, extension);
         });
 
         project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
             javaExec.getJvmArgumentProviders()
-                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtensionExportOpens(
-                            javaExec, javaExec::getClasspath));
+                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtension(javaExec, javaExec::getClasspath));
             setTaskInputsFromExtension(javaExec, extension);
         });
 
@@ -221,7 +220,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         javaCompile
                 .getOptions()
                 .getCompilerArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionExportsOpens(javaCompile));
+                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javaCompile));
 
         setTaskInputsFromExtension(javaCompile, extension);
     }
@@ -402,13 +401,19 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return create(task).configureWithClasspath(classpathCallable);
         }
 
-        public static CommandLineArgumentProvider fromJustExtensionExportsOpens(Task task) {
-            return create(task).configureWithExtension(task);
+        public static CommandLineArgumentProvider fromJustExtensionForCompilation(Task task) {
+            ModuleJvmArgsArgumentProvider argumentProvider = create(task);
+            argumentProvider.getExports().addAll(extension(task).exports());
+            argumentProvider.getExports().addAll(extension(task).opens());
+            return argumentProvider;
         }
 
-        public static CommandLineArgumentProvider fromClasspathAndExtensionExportOpens(
+        public static CommandLineArgumentProvider fromClasspathAndExtension(
                 Task task, Callable<FileCollection> classpathCallable) {
-            return create(task).configureWithClasspath(classpathCallable).configureWithExtension(task);
+            ModuleJvmArgsArgumentProvider argumentProvider = create(task).configureWithClasspath(classpathCallable);
+            argumentProvider.getExports().addAll(extension(task).exports());
+            argumentProvider.getExports().addAll(extension(task).opens());
+            return argumentProvider;
         }
 
         private static ModuleJvmArgsArgumentProvider create(Task task) {
@@ -420,12 +425,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return provider;
         }
 
-        private ModuleJvmArgsArgumentProvider configureWithExtension(Task task) {
-            BaselineModuleJvmArgsExtension extension =
-                    task.getProject().getExtensions().getByType(BaselineModuleJvmArgsExtension.class);
-            getExports().set(extension.exports());
-            getOpens().set(extension.opens());
-            return this;
+        private static BaselineModuleJvmArgsExtension extension(Task task) {
+            return task.getProject().getExtensions().getByType(BaselineModuleJvmArgsExtension.class);
         }
 
         // The `getClasspath()` methods on many task types are not as lazy as you'd hope.

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -20,6 +20,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import com.palantir.baseline.extensions.BaselineModuleJvmArgsExtension;
 import com.palantir.baseline.plugins.javaversions.BaselineJavaVersion;
 import com.palantir.baseline.plugins.javaversions.BaselineJavaVersionExtension;
@@ -33,7 +34,6 @@ import java.util.function.Function;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.gradle.api.Action;
@@ -270,28 +270,27 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                         return;
                     }
 
-                    Iterable<String> addExportsAndOpensArgs =
-                            ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javadoc)
-                                    // Technically this will have `--add-opens` which are not used in compilation
-                                    // (they need to changed to --add-exports), but we're going to strip out
-                                    // `--add-opens`/`-add-exports` in the next step anyway due to Javadoc
-                                    // task's weird `addMultilineStringsOption` method, so they will all
-                                    // effectively become --add-exports
-                                    .configureWithClasspath(sourceSet::getAnnotationProcessorPath)
-                                    .asArguments();
+                    Set<String> exportValuesRaw = ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javadoc)
+                            .configureWithClasspath(sourceSet::getAnnotationProcessorPath)
+                            // Javadoc runs as *compilation* which means that everything that is normall an
+                            // opens at runtime needs to be exports. Since we need to use the horrible
+                            // addMultilineStringsOption, we just get all the arg fragments eg
+                            // jdk.compiler/some.package=ALL-UNNAMED
+                            .allModulesPackagePairUnnamed();
 
-                    List<String> exportValues = StreamSupport.stream(addExportsAndOpensArgs.spliterator(), false)
-                            .filter(option -> !option.startsWith("--add"))
-                            .distinct()
-                            .sorted()
-                            .toList();
+                    List<String> exportValuesSorted =
+                            exportValuesRaw.stream().sorted().toList();
 
-                    log.debug("BaselineModuleJvmArgs building {} with exports: {}", javadoc.getPath(), exportValues);
-                    if (!exportValues.isEmpty()) {
+                    log.debug(
+                            "BaselineModuleJvmArgs building {} with exports: {}",
+                            javadoc.getPath(),
+                            exportValuesSorted);
+
+                    if (!exportValuesSorted.isEmpty()) {
                         coreOptions
                                 // options are automatically prefixed with '-' internally
                                 .addMultilineStringsOption("-add-exports")
-                                .setValue(exportValues);
+                                .setValue(exportValuesSorted);
                     }
                 }
             });
@@ -420,12 +419,22 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return args;
         }
 
+        public final Set<String> allModulesPackagePairUnnamed() {
+            return Sets.union(getExports().get(), getOpens().get()).stream()
+                    .map(ModuleJvmArgsArgumentProvider::appendAllUnnamed)
+                    .collect(Collectors.toSet());
+        }
+
         private static Stream<String> addExportArg(String modulePackagePair) {
-            return Stream.of("--add-exports", modulePackagePair + "=ALL-UNNAMED");
+            return Stream.of("--add-exports", appendAllUnnamed(modulePackagePair));
         }
 
         private static Stream<String> addOpensArg(String modulePackagePair) {
-            return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
+            return Stream.of("--add-opens", appendAllUnnamed(modulePackagePair));
+        }
+
+        private static String appendAllUnnamed(String modulePackagePair) {
+            return modulePackagePair + "=ALL-UNNAMED";
         }
 
         public static ModuleJvmArgsArgumentProvider fromJustClasspath(

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -454,6 +454,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             };
 
             argumentProvider.getExports().addAll(extension(task).exports().map(handleJavaVersionsNotBeingApplied));
+            // For compilation, `--add-opens` does nothing at all. Instead, each of the `opens` needs to
+            // become an export for compilation to work.
             argumentProvider.getExports().addAll(extension(task).opens().map(handleJavaVersionsNotBeingApplied));
 
             return argumentProvider;

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -115,14 +115,13 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
         project.getTasks().withType(Test.class).configureEach(test -> {
             test.getJvmArgumentProviders()
-                    .add(ModuleJvmArgsArgumentProvider.forRuntimeUsingExtensionWithClasspath(test, test::getClasspath));
+                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtension(test, test::getClasspath));
             setTaskInputsFromExtension(test, extension);
         });
 
         project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
             javaExec.getJvmArgumentProviders()
-                    .add(ModuleJvmArgsArgumentProvider.forRuntimeUsingExtensionWithClasspath(
-                            javaExec, javaExec::getClasspath));
+                    .add(ModuleJvmArgsArgumentProvider.fromClasspathAndExtension(javaExec, javaExec::getClasspath));
             setTaskInputsFromExtension(javaExec, extension);
         });
 
@@ -231,8 +230,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 .getOptions()
                 .getForkOptions()
                 .getJvmArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.forRuntime(javaCompile)
-                        .withClasspath(sourceSet::getAnnotationProcessorPath));
+                .add(ModuleJvmArgsArgumentProvider.fromJustClasspath(
+                        javaCompile, sourceSet::getAnnotationProcessorPath));
 
         // For the compiler args, we do not want any --add-exports/--add-opens:
         //   1. From the annotationProcessor classpath. These are for *compiler plugins* like errorprone,
@@ -244,7 +243,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         javaCompile
                 .getOptions()
                 .getCompilerArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.forCompilation(javaCompile).usingExtensionFor(javaCompile));
+                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javaCompile));
 
         setTaskInputsFromExtension(javaCompile, extension);
     }
@@ -271,14 +270,15 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                         return;
                     }
 
-                    Iterable<String> addExportsAndOpensArgs = ModuleJvmArgsArgumentProvider.forCompilation(javadoc)
-                            // Technically this will have `--add-opens` which are not used in compilation
-                            // (they need to changed to --add-exports), but we're going to strip out
-                            // `--add-opens`/`-add-exports` in the next step anyway due to Javadoc
-                            // task's weird `addMultilineStringsOption` method, so they will all
-                            // effectively become --add-exports
-                            .withClasspath(sourceSet::getAnnotationProcessorPath)
-                            .asArguments();
+                    Iterable<String> addExportsAndOpensArgs =
+                            ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javadoc)
+                                    // Technically this will have `--add-opens` which are not used in compilation
+                                    // (they need to changed to --add-exports), but we're going to strip out
+                                    // `--add-opens`/`-add-exports` in the next step anyway due to Javadoc
+                                    // task's weird `addMultilineStringsOption` method, so they will all
+                                    // effectively become --add-exports
+                                    .configureWithClasspath(sourceSet::getAnnotationProcessorPath)
+                                    .asArguments();
 
                     List<String> exportValues = StreamSupport.stream(addExportsAndOpensArgs.spliterator(), false)
                             .filter(option -> !option.startsWith("--add"))
@@ -397,23 +397,20 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         @Internal
         public abstract Property<String> getTaskPath();
 
-        @Internal
-        public abstract Property<Boolean> getForCompilation();
-
         @Inject
         protected abstract ProviderFactory getProviderFactory();
 
         @Override
         public final Iterable<String> asArguments() {
-            List<String> exportsArgs = getExports().get().stream()
+            Stream<String> exportsArgs = getExports().get().stream()
                     .distinct()
                     .sorted()
-                    .flatMap(ModuleJvmArgsArgumentProvider::addExportArg).toList();
+                    .flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
 
-            List<String> opensArgs =
-                    getOpens().get().stream().distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg).toList();
+            Stream<String> opensArgs =
+                    getOpens().get().stream().distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
 
-            List<String> args = Stream.concat(exportsArgs, getForCompilation().get() ? opensArgs).toList();
+            List<String> args = Stream.concat(exportsArgs, opensArgs).toList();
 
             log.debug(
                     "BaselineModuleJvmArgs configuring {} with exports: {}",
@@ -431,20 +428,27 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
         }
 
-        public static ModuleJvmArgsArgumentProvider forRuntimeUsingExtensionWithClasspath(
+        public static ModuleJvmArgsArgumentProvider fromJustClasspath(
                 Task task, Callable<FileCollection> classpathCallable) {
-            return forRuntime(task).usingExtensionFor(task).withClasspath(classpathCallable);
+            return create(task).configureWithClasspath(classpathCallable);
         }
 
-        public static ModuleJvmArgsArgumentProvider forRuntime(Task task) {
+        public static ModuleJvmArgsArgumentProvider fromJustExtensionForCompilation(Task task) {
             ModuleJvmArgsArgumentProvider argumentProvider = create(task);
-            argumentProvider.getForCompilation().set(false);
+
+            argumentProvider.getExports().addAll(extension(task).exports());
+            // For compilation, `--add-opens` does nothing at all. Instead, each of the `opens` needs to
+            // become an export for compilation to work.
+            argumentProvider.getExports().addAll(extension(task).opens());
+
             return argumentProvider;
         }
 
-        public static ModuleJvmArgsArgumentProvider forCompilation(Task task) {
-            ModuleJvmArgsArgumentProvider argumentProvider = create(task);
-            argumentProvider.getForCompilation().set(true);
+        public static ModuleJvmArgsArgumentProvider fromClasspathAndExtension(
+                Task task, Callable<FileCollection> classpathCallable) {
+            ModuleJvmArgsArgumentProvider argumentProvider = create(task).configureWithClasspath(classpathCallable);
+            argumentProvider.getExports().addAll(extension(task).exports());
+            argumentProvider.getOpens().addAll(extension(task).opens());
             return argumentProvider;
         }
 
@@ -457,18 +461,11 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return provider;
         }
 
-        public final ModuleJvmArgsArgumentProvider usingExtensionFor(Task task) {
-            getExports().addAll(extension(task).exports());
-            getOpens().addAll(extension(task).opens());
-
-            return this;
-        }
-
         /**
          * The `getClasspath()` methods on many task types are not as lazy as you'd hope.
          * Taking a Callable prevents the mistake of forcing the classpath too early.
          */
-        public final ModuleJvmArgsArgumentProvider withClasspath(Callable<FileCollection> classpathCallable) {
+        private ModuleJvmArgsArgumentProvider configureWithClasspath(Callable<FileCollection> classpathCallable) {
             Provider<List<JarManifestModuleInfo>> jarManifestModuleInfos =
                     getProviderFactory().provider(classpathCallable).map(BaselineModuleJvmArgs::collectClasspathInfo);
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -113,18 +113,13 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         });
 
         project.getTasks().withType(Test.class).configureEach(test -> {
-            ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                    project, extension, project.files((Callable<FileCollection>) test::getClasspath), test.getName());
+            RuntimeArgumentProvider provider = newModuleJvmArgsArgumentProvider(test, test::getClasspath);
             test.getJvmArgumentProviders().add(provider);
             setTaskInputsFromExtension(test, extension);
         });
 
         project.getTasks().withType(JavaExec.class).configureEach(javaExec -> {
-            ModuleJvmArgsArgumentProvider provider = newModuleJvmArgsArgumentProvider(
-                    project,
-                    extension,
-                    project.files((Callable<FileCollection>) javaExec::getClasspath),
-                    javaExec.getName());
+            RuntimeArgumentProvider provider = newModuleJvmArgsArgumentProvider(javaExec, javaExec::getClasspath);
             javaExec.getJvmArgumentProviders().add(provider);
             setTaskInputsFromExtension(javaExec, extension);
         });
@@ -214,10 +209,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         //              *even if* we've specified them in forkOptions. Forking stops this from happening.
         javaCompile.getOptions().setFork(true);
 
-        CompilerForkArgsArgumentProvider forkOptionsArgProvider =
-                project.getObjects().newInstance(CompilerForkArgsArgumentProvider.class);
-        forkOptionsArgProvider.getProjectPath().set(project.getPath());
-        forkOptionsArgProvider.getTaskName().set(javaCompile.getName());
+        RuntimeArgumentProvider forkOptionsArgProvider =
+                project.getObjects().newInstance(RuntimeArgumentProvider.class);
+        forkOptionsArgProvider.getTaskPath().set(javaCompile.getPath());
         forkOptionsArgProvider
                 .getClasspath()
                 .from(project.files(
@@ -229,8 +223,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 project.getObjects().newInstance(CompilerArgsArgumentProvider.class);
         compilerArgsProvider.getExports().set(extension.exports());
         compilerArgsProvider.getOpens().set(extension.opens());
-        compilerArgsProvider.getProjectPath().set(project.getPath());
-        compilerArgsProvider.getTaskName().set(javaCompile.getName());
+        compilerArgsProvider.getTaskPath().set(javaCompile.getPath());
         compilerArgsProvider.getBaselineJavaVersionEnabled().set(project.provider(() -> project.getPlugins()
                 .hasPlugin(BaselineJavaVersion.class)));
 
@@ -302,17 +295,22 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         }
     }
 
-    private static ModuleJvmArgsArgumentProvider newModuleJvmArgsArgumentProvider(
-            Project project,
-            BaselineModuleJvmArgsExtension extension,
-            ConfigurableFileCollection classpath,
-            String taskName) {
-        ModuleJvmArgsArgumentProvider provider = project.getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
+    /**
+     * @param classpathCallable The `getClasspath()` methods on many task types are not as lazy as you'd hope.
+     *                          Taking a Callable prevents the mistake of forcing the classpath too early.
+     */
+    private static RuntimeArgumentProvider newModuleJvmArgsArgumentProvider(
+            Task task, Callable<FileCollection> classpathCallable) {
+
+        BaselineModuleJvmArgsExtension extension =
+                task.getProject().getExtensions().getByType(BaselineModuleJvmArgsExtension.class);
+
+        RuntimeArgumentProvider provider = task.getProject().getObjects().newInstance(RuntimeArgumentProvider.class);
         provider.getExports().set(extension.exports());
         provider.getOpens().set(extension.opens());
-        provider.getClasspath().from(classpath);
-        provider.getProjectPath().set(project.getPath());
-        provider.getTaskName().set(taskName);
+        provider.getClasspath().from(task.getProject().files(classpathCallable));
+        provider.getTaskPath().set(task.getPath());
+
         return provider;
     }
 
@@ -406,8 +404,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         class Builder extends ImmutableJarManifestModuleInfo.Builder {}
     }
 
-    public abstract static class ModuleJvmArgsArgumentProvider implements CommandLineArgumentProvider {
-        private static final Logger log = Logging.getLogger(ModuleJvmArgsArgumentProvider.class);
+    public abstract static class RuntimeArgumentProvider implements CommandLineArgumentProvider {
+        private static final Logger log = Logging.getLogger(RuntimeArgumentProvider.class);
 
         @Internal
         public abstract SetProperty<String> getExports();
@@ -419,79 +417,30 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         public abstract ConfigurableFileCollection getClasspath();
 
         @Internal
-        public abstract Property<String> getProjectPath();
-
-        @Internal
-        public abstract Property<String> getTaskName();
+        public abstract Property<String> getTaskPath();
 
         @Override
         public final Iterable<String> asArguments() {
-            ImmutableList<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
+            List<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
             Stream<String> allExports = Stream.concat(
                     getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
             Stream<String> allOpens = Stream.concat(
                     getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
 
-            ImmutableList<String> args = runtimeArgs(allExports, allOpens);
+            List<String> args = runtimeArgs(allExports, allOpens);
 
             log.debug(
-                    "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
-                    getTaskName().getOrNull(),
-                    getProjectPath().getOrNull(),
+                    "BaselineModuleJvmArgs configuring {} with exports: {}",
+                    getTaskPath().get(),
                     args);
+
             return args;
         }
 
-        private static ImmutableList<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
-            Stream<String> exportsArgs =
-                    allExports.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
-            Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
-            return Stream.concat(exportsArgs, opensArgs).collect(ImmutableList.toImmutableList());
-        }
-
-        private static Stream<String> addExportArg(String modulePackagePair) {
-            return Stream.of("--add-exports", modulePackagePair + "=ALL-UNNAMED");
-        }
-
-        private static Stream<String> addOpensArg(String modulePackagePair) {
-            return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
-        }
-    }
-
-    public abstract static class CompilerForkArgsArgumentProvider implements CommandLineArgumentProvider {
-        private static final Logger log = Logging.getLogger(ModuleJvmArgsArgumentProvider.class);
-
-        @Internal
-        public abstract ConfigurableFileCollection getClasspath();
-
-        @Internal
-        public abstract Property<String> getProjectPath();
-
-        @Internal
-        public abstract Property<String> getTaskName();
-
-        @Override
-        public final Iterable<String> asArguments() {
-            ImmutableList<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
-            Stream<String> allExports = classpathInfo.stream().flatMap(info -> info.exports().stream());
-            Stream<String> allOpens = classpathInfo.stream().flatMap(info -> info.opens().stream());
-
-            ImmutableList<String> args = runtimeArgs(allExports, allOpens);
-
-            log.debug(
-                    "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
-                    getTaskName().getOrNull(),
-                    getProjectPath().getOrNull(),
-                    args);
-            return args;
-        }
-
-        private static ImmutableList<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
-            Stream<String> exportsArgs =
-                    allExports.distinct().sorted().flatMap(CompilerForkArgsArgumentProvider::addExportArg);
-            Stream<String> opensArgs =
-                    allOpens.distinct().sorted().flatMap(CompilerForkArgsArgumentProvider::addOpensArg);
-            return Stream.concat(exportsArgs, opensArgs).collect(ImmutableList.toImmutableList());
+        private static List<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
+            Stream<String> exportsArgs = allExports.distinct().sorted().flatMap(RuntimeArgumentProvider::addExportArg);
+            Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(RuntimeArgumentProvider::addOpensArg);
+            return Stream.concat(exportsArgs, opensArgs).toList();
         }
 
         private static Stream<String> addExportArg(String modulePackagePair) {
@@ -504,7 +453,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     }
 
     public abstract static class CompilerArgsArgumentProvider implements CommandLineArgumentProvider {
-        private static final Logger log = Logging.getLogger(ModuleJvmArgsArgumentProvider.class);
+        private static final Logger log = Logging.getLogger(RuntimeArgumentProvider.class);
 
         @Internal
         public abstract SetProperty<String> getExports();
@@ -513,13 +462,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         public abstract SetProperty<String> getOpens();
 
         @Internal
-        public abstract Property<String> getProjectPath();
-
-        @Internal
         public abstract Property<Boolean> getBaselineJavaVersionEnabled();
 
         @Internal
-        public abstract Property<String> getTaskName();
+        public abstract Property<String> getTaskPath();
 
         @Override
         public final Iterable<String> asArguments() {
@@ -528,29 +474,26 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
             if (!isBaselineJavaVersionEnabled) {
                 log.debug(
-                        "BaselineModuleJvmArgs not applying args to compilation task {} on project {} due to lack of "
+                        "BaselineModuleJvmArgs not applying args to compilation task {} due to lack of "
                                 + "BaselineJavaVersion",
-                        getTaskName().get(),
-                        getProjectPath().get());
+                        getTaskPath().get());
                 return ImmutableList.of();
             }
 
-            ImmutableList<String> args = compilationArgs(getExports().get().stream(), getOpens().get().stream());
-
-            log.debug(
-                    "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
-                    getTaskName().getOrNull(),
-                    getProjectPath().getOrNull(),
-                    args);
-            return args;
-        }
-
-        private static ImmutableList<String> compilationArgs(Stream<String> allExports, Stream<String> allOpens) {
-            return Stream.concat(allExports, allOpens)
+            // For compilation, `--add-opens` does nothing at all. Instead, each of the `opens` needs to
+            // become an export for compilation to work
+            List<String> args = Stream.concat(getExports().get().stream(), getOpens().get().stream())
                     .distinct()
                     .sorted()
                     .flatMap(CompilerArgsArgumentProvider::addExportArg)
-                    .collect(ImmutableList.toImmutableList());
+                    .toList();
+
+            log.debug(
+                    "BaselineModuleJvmArgs configuring {} with exports: {}",
+                    getTaskPath().get(),
+                    args);
+
+            return args;
         }
 
         private static Stream<String> addExportArg(String modulePackagePair) {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -214,7 +214,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         //              Gradle will just use the current daemon. However, if the main Gradle daemon is
         //              running with a different JDK Gradle will fork off a worker daemon to do the compilation.
         //              There are material differences in behaviour when it is forked vs not forked, so
-        //              we always for consistency.
+        //              we always fork for consistency.
         // Correctness: If fork=false and Gradle thinks it can reuse the main Gradle daemon as it's running
         //              with the correct JDK major version, the main daemon will not necessarily have
         //              the required --add-exports/--add-opens set on the process running the compilations,
@@ -447,8 +447,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             ModuleJvmArgsArgumentProvider argumentProvider = create(task);
 
             argumentProvider.getExports().addAll(extension(task).exports());
-            // For compilation, `--add-opens` does nothing at all. Instead, each of the `opens` needs to
-            // become an export for compilation to work.
+            // At runtime, `--add-opens` implies `--add-exports`. But during compilation `--add-opens` does nothing
+            // at all and is ignored (`--add-opens` is for reflectively changing code in a module, which makes no
+            // sense during compilation). People may still use the types in the module that is `--add-opens`d, so
+            // we need to convert all `--add-opens` to `--add-exports` just for compilation.
             argumentProvider.getExports().addAll(extension(task).opens());
 
             return argumentProvider;
@@ -477,8 +479,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         }
 
         /**
-         * The `getClasspath()` methods on many task types are not as lazy as you'd hope.
-         * Taking a Callable prevents the mistake of forcing the classpath too early.
+         * The {@code getClasspath()} methods on many task types are not as lazy as you'd hope.
+         * Taking a {@link Callable} prevents the mistake of forcing the classpath too early.
          */
         private ModuleJvmArgsArgumentProvider configureWithClasspath(Callable<FileCollection> classpathCallable) {
             Provider<List<JarManifestModuleInfo>> jarManifestModuleInfos =

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -308,13 +308,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             ConfigurableFileCollection classpath,
             String taskName) {
         ModuleJvmArgsArgumentProvider provider = project.getObjects().newInstance(ModuleJvmArgsArgumentProvider.class);
-        Optional.of(extension).ifPresent(extension1 -> {
-            provider.getExports().set(extension1.exports());
-            provider.getOpens().set(extension1.opens());
-        });
-        Optional.of(classpath).ifPresent(classpath1 -> {
-            provider.getClasspath().from(classpath1);
-        });
+        provider.getExports().set(extension.exports());
+        provider.getOpens().set(extension.opens());
+        provider.getClasspath().from(classpath);
         provider.getProjectPath().set(project.getPath());
         provider.getTaskName().set(taskName);
         return provider;

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -232,6 +232,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         }
 
         project.getTasks().named(sourceSet.getJavadocTaskName(), Javadoc.class, javadoc -> {
+            // Javadoc task is horrible. There's no lazy properties/CommandLineArgumentProviders, so we have to
+            // resort to this fresh hell of changing its configuration in a task action before it runs. Once
+            // Gradle have made this lazy, this should be rewritten.
             javadoc.doFirst(new Action<Task>() {
                 @Override
                 public void execute(Task _task) {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Callable;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.gradle.api.Action;
@@ -39,7 +40,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.Transformer;
-import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -54,7 +54,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
@@ -227,66 +226,60 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     }
 
     private void configureJavadoc(Project project, SourceSet sourceSet, BaselineModuleJvmArgsExtension extension) {
-        TaskProvider<Task> javadocTaskProvider = null;
-        try {
-            javadocTaskProvider = project.getTasks().named(sourceSet.getJavadocTaskName());
-        } catch (UnknownTaskException e) {
-            // skip
+        if (!project.getTasks().getNames().contains(sourceSet.getJavadocTaskName())) {
+            // If there's no javadoc we can't configure it
+            return;
         }
-        if (javadocTaskProvider != null) {
-            javadocTaskProvider.configure(javadocTask -> {
-                javadocTask.doFirst(new Action<Task>() {
-                    @Override
-                    public void execute(Task task) {
-                        // The '--release' flag is set when BaselineJavaVersion is not used.
-                        if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
-                            log.debug(
-                                    "BaselineModuleJvmArgs not applying args to compilation task {} on {} "
-                                            + "due to lack of BaselineJavaVersion",
-                                    task.getName(),
-                                    project.getPath());
-                            return;
-                        }
 
-                        Javadoc javadoc = (Javadoc) task;
-
-                        MinimalJavadocOptions options = javadoc.getOptions();
-                        if (options instanceof CoreJavadocOptions coreOptions) {
-                            ImmutableList<JarManifestModuleInfo> info = collectClasspathInfoForSourceSet(sourceSet);
-                            List<String> exportValues = Stream.concat(
-                                            // Compilation only supports exports, so we union with opens.
-                                            Stream.concat(
-                                                    extension.exports().get().stream(),
-                                                    extension.opens().get().stream()),
-                                            info.stream()
-                                                    .flatMap(item -> Stream.concat(
-                                                            item.exports().stream(), item.opens().stream())))
-                                    .distinct()
-                                    .sorted()
-                                    .map(item -> item + "=ALL-UNNAMED")
-                                    .collect(ImmutableList.toImmutableList());
-                            log.debug(
-                                    "BaselineModuleJvmArgs building {} on {} with exports: {}",
-                                    javadoc.getName(),
-                                    project.getPath(),
-                                    exportValues);
-                            if (!exportValues.isEmpty()) {
-                                coreOptions
-                                        // options are automatically prefixed with '-' internally
-                                        .addMultilineStringsOption("-add-exports")
-                                        .setValue(exportValues);
-                            }
-                        } else {
-                            log.error(
-                                    "MinimalJavadocOptions implementation was " + "not CoreJavadocOptions, rather '{}'",
-                                    options.getClass().getName());
-                        }
+        project.getTasks().named(sourceSet.getJavadocTaskName(), Javadoc.class, javadoc -> {
+            javadoc.doFirst(new Action<Task>() {
+                @Override
+                public void execute(Task _task) {
+                    // The '--release' flag is set when BaselineJavaVersion is not used.
+                    if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
+                        log.debug(
+                                "BaselineModuleJvmArgs not applying args to compilation task {} "
+                                        + "due to lack of BaselineJavaVersion",
+                                javadoc.getPath());
+                        return;
                     }
-                });
 
-                setTaskInputsFromExtension(javadocTask, extension);
+                    MinimalJavadocOptions options = javadoc.getOptions();
+                    if (!(options instanceof CoreJavadocOptions coreOptions)) {
+                        log.error(
+                                "MinimalJavadocOptions implementation on '{}' was not CoreJavadocOptions, rather '{}'",
+                                javadoc.getPath(),
+                                options.getClass().getName());
+                        return;
+                    }
+
+                    Iterable<String> addExportsAndOpensArgs =
+                            ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javadoc)
+                                    // Technically this will have `--add-opens` which are not used in compilation
+                                    // (they need to changed to --add-exports), but we're going to strip out
+                                    // `--add-opens`/`-add-exports` in the next step anyway due to Javadoc
+                                    // task's weird `addMultilineStringsOption` method.
+                                    .configureWithClasspath(sourceSet::getAnnotationProcessorPath)
+                                    .asArguments();
+
+                    List<String> exportValues = StreamSupport.stream(addExportsAndOpensArgs.spliterator(), false)
+                            .filter(option -> !option.startsWith("--add"))
+                            .distinct()
+                            .sorted()
+                            .toList();
+
+                    log.debug("BaselineModuleJvmArgs building {} with exports: {}", javadoc.getPath(), exportValues);
+                    if (!exportValues.isEmpty()) {
+                        coreOptions
+                                // options are automatically prefixed with '-' internally
+                                .addMultilineStringsOption("-add-exports")
+                                .setValue(exportValues);
+                    }
+                }
             });
-        }
+
+            setTaskInputsFromExtension(javadoc, extension);
+        });
     }
 
     private static void setTaskInputsFromExtension(Task task, BaselineModuleJvmArgsExtension extension) {
@@ -315,12 +308,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         }
     }
 
-    private ImmutableList<JarManifestModuleInfo> collectClasspathInfoForSourceSet(SourceSet sourceSet) {
-        FileCollection classpath = getConfigurations().getByName(sourceSet.getAnnotationProcessorConfigurationName());
-        return collectClasspathInfo(classpath);
-    }
-
-    private static ImmutableList<JarManifestModuleInfo> collectClasspathInfo(FileCollection classpath) {
+    private static List<JarManifestModuleInfo> collectClasspathInfo(FileCollection classpath) {
         return classpath.getFiles().stream()
                 .map(file -> {
                     try {
@@ -430,12 +418,12 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
         }
 
-        public static CommandLineArgumentProvider fromJustClasspath(
+        public static ModuleJvmArgsArgumentProvider fromJustClasspath(
                 Task task, Callable<FileCollection> classpathCallable) {
             return create(task).configureWithClasspath(classpathCallable);
         }
 
-        public static CommandLineArgumentProvider fromJustExtensionForCompilation(Task task) {
+        public static ModuleJvmArgsArgumentProvider fromJustExtensionForCompilation(Task task) {
             ModuleJvmArgsArgumentProvider argumentProvider = create(task);
 
             // javac isn't provided `--add-exports` args for the time being due to
@@ -461,7 +449,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return argumentProvider;
         }
 
-        public static CommandLineArgumentProvider fromClasspathAndExtension(
+        public static ModuleJvmArgsArgumentProvider fromClasspathAndExtension(
                 Task task, Callable<FileCollection> classpathCallable) {
             ModuleJvmArgsArgumentProvider argumentProvider = create(task).configureWithClasspath(classpathCallable);
             argumentProvider.getExports().addAll(extension(task).exports());

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -39,7 +39,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -261,15 +260,6 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             javadoc.doFirst(new Action<Task>() {
                 @Override
                 public void execute(Task _task) {
-                    // The '--release' flag is set when BaselineJavaVersion is not used.
-                    if (!project.getPlugins().hasPlugin(BaselineJavaVersion.class)) {
-                        log.debug(
-                                "BaselineModuleJvmArgs not applying args to compilation task {} "
-                                        + "due to lack of BaselineJavaVersion",
-                                javadoc.getPath());
-                        return;
-                    }
-
                     MinimalJavadocOptions options = javadoc.getOptions();
                     if (!(options instanceof CoreJavadocOptions coreOptions)) {
                         log.error(
@@ -453,25 +443,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         public static ModuleJvmArgsArgumentProvider fromJustExtensionForCompilation(Task task) {
             ModuleJvmArgsArgumentProvider argumentProvider = create(task);
 
-            // javac isn't provided `--add-exports` args for the time being due to
-            // https://github.com/gradle/gradle/issues/18824
-            // However, we set sourceCompatibility in BaselineJavaVersion to opt out of the '--release' flag.
-            Transformer<Set<String>, Set<String>> handleJavaVersionsNotBeingApplied = inputs -> {
-                if (!task.getProject().getPlugins().hasPlugin(BaselineJavaVersion.class)) {
-                    log.debug(
-                            "BaselineModuleJvmArgs not applying args to compilation task {} due to lack of "
-                                    + "BaselineJavaVersion",
-                            task.getPath());
-                    return Set.of();
-                }
-
-                return inputs;
-            };
-
-            argumentProvider.getExports().addAll(extension(task).exports().map(handleJavaVersionsNotBeingApplied));
+            argumentProvider.getExports().addAll(extension(task).exports());
             // For compilation, `--add-opens` does nothing at all. Instead, each of the `opens` needs to
             // become an export for compilation to work.
-            argumentProvider.getExports().addAll(extension(task).opens().map(handleJavaVersionsNotBeingApplied));
+            argumentProvider.getExports().addAll(extension(task).opens());
 
             return argumentProvider;
         }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -38,6 +38,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.Transformer;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -403,8 +404,25 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
         public static CommandLineArgumentProvider fromJustExtensionForCompilation(Task task) {
             ModuleJvmArgsArgumentProvider argumentProvider = create(task);
-            argumentProvider.getExports().addAll(extension(task).exports());
-            argumentProvider.getExports().addAll(extension(task).opens());
+
+            // javac isn't provided `--add-exports` args for the time being due to
+            // https://github.com/gradle/gradle/issues/18824
+            // However, we set sourceCompatibility in BaselineJavaVersion to opt out of the '--release' flag.
+            Transformer<Set<String>, Set<String>> handleJavaVersionsNotBeingApplied = inputs -> {
+                if (!task.getProject().getPlugins().hasPlugin(BaselineJavaVersion.class)) {
+                    log.debug(
+                            "BaselineModuleJvmArgs not applying args to compilation task {} due to lack of "
+                                    + "BaselineJavaVersion",
+                            task.getPath());
+                    return Set.of();
+                }
+
+                return inputs;
+            };
+
+            argumentProvider.getExports().addAll(extension(task).exports().map(handleJavaVersionsNotBeingApplied));
+            argumentProvider.getExports().addAll(extension(task).opens().map(handleJavaVersionsNotBeingApplied));
+
             return argumentProvider;
         }
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -157,6 +157,17 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
     }
 
     private void addReleaseAndAddExportsArgsFixingCompilerPlugin(Project project) {
+        // There is more info about the plugin in its implementation class.
+        // The gist is we change the compiler internals using reflection to allow the `--release`
+        // and `--add-exports` args to be used together with compiler errors.
+
+        // We always apply the plugin even if it's not necessary for two reasons:
+        //   1. There's no way to lazily add an arg based on the values of other args without forcing
+        //      the arg values, which might be too early.
+        //   2. I think it's better to always apply the plugin, so when it starts going wrong on a JDK
+        //      update, it fails very obviously everywhere and forces us to fix it rather than silently
+        //      failing on the low percentage of repos that add exports/opens.
+
         String version = Optional.ofNullable(
                         (String) project.findProperty("baselineModuleJvmArgsCompilerPluginsVersion"))
                 .or(() -> Optional.ofNullable(
@@ -188,14 +199,14 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         project.getTasks()
                 .named(sourceSet.getCompileJavaTaskName(), JavaCompile.class)
                 .configure(javaCompile -> {
-                    configureJavaCompile(project, sourceSet, extension, javaCompile);
+                    configureJavaCompile(sourceSet, extension, javaCompile);
                 });
 
         configureJavadoc(project, sourceSet, extension);
     }
 
     private static void configureJavaCompile(
-            Project project, SourceSet sourceSet, BaselineModuleJvmArgsExtension extension, JavaCompile javaCompile) {
+            SourceSet sourceSet, BaselineModuleJvmArgsExtension extension, JavaCompile javaCompile) {
 
         // We will *always* fork the compiler - for both consistency and correctness:
         // Consistency: when fork=false, Gradle will sometimes still make a forked Gradle worker daemon
@@ -210,6 +221,11 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         //              *even if* we've specified them in forkOptions. Forking stops this from happening.
         javaCompile.getOptions().setFork(true);
 
+        // For the fork options, we want just the --add-exports/--add-opens from the annotationProcessor
+        // classpath. These are to enable compiler plugins like errorprone and other code that runs inside
+        // the compiler to run in a process with the correct jvm args. We explicitly *do not want* the
+        // exports/opens from the extension; these are for the code actually being compiled, not for
+        // compiler plugins!
         javaCompile
                 .getOptions()
                 .getForkOptions()
@@ -217,6 +233,13 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 .add(ModuleJvmArgsArgumentProvider.fromJustClasspath(
                         javaCompile, sourceSet::getAnnotationProcessorPath));
 
+        // For the compiler args, we do not want any --add-exports/--add-opens:
+        //   1. From the annotationProcessor classpath. These are for *compiler plugins* like errorprone,
+        //      not for the code actually being compiled.
+        //   2. From the dependencies of the code being compiled - these have already been compiled and
+        //      we don't need to have the compiler --add-exports for them
+        // We just need the exports/opens from the extension. --add-opens does nothing during compilation
+        // so the argument provider below will change them to --add-exports.
         javaCompile
                 .getOptions()
                 .getCompilerArgumentProviders()
@@ -261,7 +284,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                                     // Technically this will have `--add-opens` which are not used in compilation
                                     // (they need to changed to --add-exports), but we're going to strip out
                                     // `--add-opens`/`-add-exports` in the next step anyway due to Javadoc
-                                    // task's weird `addMultilineStringsOption` method.
+                                    // task's weird `addMultilineStringsOption` method, so they will all
+                                    // effectively become --add-exports
                                     .configureWithClasspath(sourceSet::getAnnotationProcessorPath)
                                     .asArguments();
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.function.Function;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,8 +39,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.java.archives.Manifest;
@@ -49,7 +48,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.JavaExec;
@@ -231,11 +229,8 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                 .getOptions()
                 .getForkOptions()
                 .getJvmArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.create(javaCompile)
-                        .configureWithClasspath(javaCompile
-                                .getProject()
-                                .getConfigurations()
-                                .named(sourceSet.getAnnotationProcessorConfigurationName())));
+                .add(ModuleJvmArgsArgumentProvider.fromJustClasspath(
+                        javaCompile, sourceSet::getAnnotationProcessorPath));
 
         // For the compiler args, we do not want any --add-exports/--add-opens:
         //   1. From the annotationProcessor classpath. These are for *compiler plugins* like errorprone,
@@ -247,9 +242,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         javaCompile
                 .getOptions()
                 .getCompilerArgumentProviders()
-                .add(ModuleJvmArgsArgumentProvider.create(javaCompile)
-                        .
-                );
+                .add(ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javaCompile));
 
         setTaskInputsFromExtension(javaCompile, extension);
     }
@@ -401,7 +394,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         public abstract SetProperty<String> getOpens();
 
         @Internal
-        public abstract Property<Boolean> getForCompilation();
+        public abstract ConfigurableFileCollection getClasspath();
 
         @Internal
         public abstract Property<String> getTaskPath();
@@ -409,23 +402,15 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         @Inject
         protected abstract ProjectLayout getProjectLayout();
 
-        @Inject
-        protected abstract ProviderFactory getProviderFactory();
-
         @Override
         public final Iterable<String> asArguments() {
+            List<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
             Stream<String> allExports = Stream.concat(
                     getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
             Stream<String> allOpens = Stream.concat(
                     getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
 
-            List<Arg> args = blah(allExports, allOpens);
-
-            if (getForCompilation().get()) {
-                args = args.stream().map(Arg::forceToBeExports).toList();
-            }
-
-            return args;
+            List<String> args = runtimeArgs(allExports, allOpens);
 
             log.debug(
                     "BaselineModuleJvmArgs configuring {} with exports: {}",
@@ -435,45 +420,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return args;
         }
 
-        private List<Arg> args() {
-            List<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
-            Stream<String> allExports = Stream.concat(
-                    getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
-            Stream<String> allOpens = Stream.concat(
-                    getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
-
-            List<Arg> args = blah(allExports, allOpens);
-
-            if (getForCompilation().get()) {
-                args = args.stream().map(Arg::forceToBeExports).toList();
-            }
-
-            return args;
-        }
-
-        public final List<String> argsForJavadoc() {}
-
-        private enum ArgType {
-            EXPORTS,
-            OPENS;
-        }
-
-        private record Arg(ArgType argType, String module) {
-            public Arg forceToBeExports() {
-                return new Arg(ArgType.EXPORTS, module);
-            }
-        }
-
         private static List<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
             Stream<String> exportsArgs =
                     allExports.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addExportArg);
             Stream<String> opensArgs = allOpens.distinct().sorted().flatMap(ModuleJvmArgsArgumentProvider::addOpensArg);
-            return Stream.concat(exportsArgs, opensArgs).toList();
-        }
-
-        private static List<Arg> blah(Stream<String> allExports, Stream<String> allOpens) {
-            Stream<Arg> exportsArgs = allExports.distinct().sorted().map(module -> new Arg(ArgType.EXPORTS, module));
-            Stream<Arg> opensArgs = allOpens.distinct().sorted().map(module -> new Arg(ArgType.OPENS, module));
             return Stream.concat(exportsArgs, opensArgs).toList();
         }
 
@@ -522,26 +472,9 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
          * The `getClasspath()` methods on many task types are not as lazy as you'd hope.
          * Taking a Callable prevents the mistake of forcing the classpath too early.
          */
-        private ModuleJvmArgsArgumentProvider configureWithClasspath(Provider<Configuration> classpathCallable) {
-            Provider<List<JarManifestModuleInfo>> listProperty =
-                    classpathCallable.map(classpath -> collectClasspathInfo(classpath.resolve()));
-
-            getExports().addAll(extract(listProperty, JarManifestModuleInfo::exports));
-            getOpens().addAll(extract(listProperty, JarManifestModuleInfo::opens));
+        private ModuleJvmArgsArgumentProvider configureWithClasspath(Callable<FileCollection> classpathCallable) {
+            getClasspath().from(getProjectLayout().files(classpathCallable));
             return this;
-        }
-
-        private ModuleJvmArgsArgumentProvider forCompilation() {
-            getForCompilation().set(true);
-            return this;
-        }
-
-        private Provider<List<String>> extract(
-                Provider<List<JarManifestModuleInfo>> jarManifestModuleInfosProvider,
-                Function<JarManifestModuleInfo, List<String>> extractor) {
-            return jarManifestModuleInfosProvider.map(jarManifestModuleInfos -> jarManifestModuleInfos.stream()
-                    .flatMap(info -> extractor.apply(info).stream())
-                    .toList());
         }
 
         private static BaselineModuleJvmArgsExtension extension(Task task) {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -272,7 +272,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
                     Set<String> exportValuesRaw = ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javadoc)
                             .configureWithClasspath(sourceSet::getAnnotationProcessorPath)
-                            // Javadoc runs as *compilation* which means that everything that is normall an
+                            // Javadoc runs as *compilation* which means that everything that is normally an
                             // opens at runtime needs to be exports. Since we need to use the horrible
                             // addMultilineStringsOption, we just get all the arg fragments eg
                             // jdk.compiler/some.package=ALL-UNNAMED

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -90,14 +90,33 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             BaselineModuleJvmArgsExtension extension =
                     project.getExtensions().create(EXTENSION_NAME, BaselineModuleJvmArgsExtension.class, project);
 
-            // javac isn't provided `--add-exports` args for the time being due to
-            // https://github.com/gradle/gradle/issues/18824
-            // However, we set sourceCompatibility in BaselineJavaVersion to opt out of the '--release' flag.
+            String version = Optional.ofNullable(
+                            (String) project.findProperty("baselineModuleJvmArgsCompilerPluginsVersion"))
+                    .or(() -> Optional.ofNullable(
+                            BaselineErrorProne.class.getPackage().getImplementationVersion()))
+                    .orElseThrow(() -> new RuntimeException(
+                            "baseline-module-jvm-args-compiler-plugins implementation version not found"));
+
             project.getExtensions().getByType(SourceSetContainer.class).configureEach(sourceSet -> {
+                project.getDependencies()
+                        .add(
+                                sourceSet.getAnnotationProcessorConfigurationName(),
+                                "com.palantir.baseline:baseline-module-jvm-args-compiler-plugins:" + version);
+
                 TaskProvider<JavaCompile> javaCompileProvider =
                         project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
 
                 javaCompileProvider.configure(javaCompile -> {
+                    javaCompile.getOptions().getCompilerArgumentProviders().add(new CommandLineArgumentProvider() {
+                        private static final String COMPILER_PLUGIN_NAME = "-Xplugin:"
+                                + "AllowReleaseAndAddExportsToBeUsedTogetherByChangingCompilerInternalsUsingReflection";
+
+                        @Override
+                        public Iterable<String> asArguments() {
+                            return List.of(COMPILER_PLUGIN_NAME);
+                        }
+                    });
+
                     Provider<Boolean> baselineJavaVersionsEnabled =
                             project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class));
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -214,24 +214,25 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         //              *even if* we've specified them in forkOptions. Forking stops this from happening.
         javaCompile.getOptions().setFork(true);
 
-        Provider<Boolean> baselineJavaVersionsEnabled =
-                project.provider(() -> project.getPlugins().hasPlugin(BaselineJavaVersion.class));
-
-        ModuleJvmArgsArgumentProvider forkOptionsArgProvider = newModuleJvmArgsArgumentProvider(
-                project,
-                Optional.empty(),
-                Optional.of(project.files(
-                        project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName()))),
-                javaCompile.getName());
-
-        forkOptionsArgProvider.getBaselineJavaVersionEnabled().set(baselineJavaVersionsEnabled);
+        CompilerForkArgsArgumentProvider forkOptionsArgProvider =
+                project.getObjects().newInstance(CompilerForkArgsArgumentProvider.class);
+        forkOptionsArgProvider.getProjectPath().set(project.getPath());
+        forkOptionsArgProvider.getTaskName().set(javaCompile.getName());
+        forkOptionsArgProvider
+                .getClasspath()
+                .from(project.files(
+                        project.getConfigurations().named(sourceSet.getAnnotationProcessorConfigurationName())));
 
         javaCompile.getOptions().getForkOptions().getJvmArgumentProviders().add(forkOptionsArgProvider);
 
-        ModuleJvmArgsArgumentProvider compilerArgsProvider = newModuleJvmArgsArgumentProvider(
-                project, Optional.of(extension), Optional.empty(), javaCompile.getName());
-
-        compilerArgsProvider.getBaselineJavaVersionEnabled().set(baselineJavaVersionsEnabled);
+        CompilerArgsArgumentProvider compilerArgsProvider =
+                project.getObjects().newInstance(CompilerArgsArgumentProvider.class);
+        compilerArgsProvider.getExports().set(extension.exports());
+        compilerArgsProvider.getOpens().set(extension.opens());
+        compilerArgsProvider.getProjectPath().set(project.getPath());
+        compilerArgsProvider.getTaskName().set(javaCompile.getName());
+        compilerArgsProvider.getBaselineJavaVersionEnabled().set(project.provider(() -> project.getPlugins()
+                .hasPlugin(BaselineJavaVersion.class)));
 
         javaCompile.getOptions().getCompilerArgumentProviders().add(compilerArgsProvider);
 
@@ -433,34 +434,17 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
         public abstract Property<String> getProjectPath();
 
         @Internal
-        public abstract Property<Boolean> getBaselineJavaVersionEnabled();
-
-        @Internal
         public abstract Property<String> getTaskName();
 
         @Override
         public final Iterable<String> asArguments() {
-            boolean isCompilation = getBaselineJavaVersionEnabled().isPresent();
-            boolean isBaselineJavaVersionEnabled =
-                    getBaselineJavaVersionEnabled().getOrElse(false);
-
-            if (isCompilation && !isBaselineJavaVersionEnabled) {
-                log.debug(
-                        "BaselineModuleJvmArgs not applying args to compilation task {} on project {} due to lack of "
-                                + "BaselineJavaVersion",
-                        getTaskName().get(),
-                        getProjectPath().get());
-                return ImmutableList.of();
-            }
-
             ImmutableList<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
             Stream<String> allExports = Stream.concat(
                     getExports().get().stream(), classpathInfo.stream().flatMap(info -> info.exports().stream()));
             Stream<String> allOpens = Stream.concat(
                     getOpens().get().stream(), classpathInfo.stream().flatMap(info -> info.opens().stream()));
 
-            ImmutableList<String> args =
-                    isCompilation ? compilationArgs(allExports, allOpens) : runtimeArgs(allExports, allOpens);
+            ImmutableList<String> args = runtimeArgs(allExports, allOpens);
 
             log.debug(
                     "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
@@ -468,14 +452,6 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                     getProjectPath().getOrNull(),
                     args);
             return args;
-        }
-
-        private static ImmutableList<String> compilationArgs(Stream<String> allExports, Stream<String> allOpens) {
-            return Stream.concat(allExports, allOpens)
-                    .distinct()
-                    .sorted()
-                    .flatMap(ModuleJvmArgsArgumentProvider::addExportArg)
-                    .collect(ImmutableList.toImmutableList());
         }
 
         private static ImmutableList<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
@@ -491,6 +467,106 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
 
         private static Stream<String> addOpensArg(String modulePackagePair) {
             return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
+        }
+    }
+
+    public abstract static class CompilerForkArgsArgumentProvider implements CommandLineArgumentProvider {
+        private static final Logger log = Logging.getLogger(ModuleJvmArgsArgumentProvider.class);
+
+        @Internal
+        public abstract ConfigurableFileCollection getClasspath();
+
+        @Internal
+        public abstract Property<String> getProjectPath();
+
+        @Internal
+        public abstract Property<String> getTaskName();
+
+        @Override
+        public final Iterable<String> asArguments() {
+            ImmutableList<JarManifestModuleInfo> classpathInfo = collectClasspathInfo(getClasspath());
+            Stream<String> allExports = classpathInfo.stream().flatMap(info -> info.exports().stream());
+            Stream<String> allOpens = classpathInfo.stream().flatMap(info -> info.opens().stream());
+
+            ImmutableList<String> args = runtimeArgs(allExports, allOpens);
+
+            log.debug(
+                    "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
+                    getTaskName().getOrNull(),
+                    getProjectPath().getOrNull(),
+                    args);
+            return args;
+        }
+
+        private static ImmutableList<String> runtimeArgs(Stream<String> allExports, Stream<String> allOpens) {
+            Stream<String> exportsArgs =
+                    allExports.distinct().sorted().flatMap(CompilerForkArgsArgumentProvider::addExportArg);
+            Stream<String> opensArgs =
+                    allOpens.distinct().sorted().flatMap(CompilerForkArgsArgumentProvider::addOpensArg);
+            return Stream.concat(exportsArgs, opensArgs).collect(ImmutableList.toImmutableList());
+        }
+
+        private static Stream<String> addExportArg(String modulePackagePair) {
+            return Stream.of("--add-exports", modulePackagePair + "=ALL-UNNAMED");
+        }
+
+        private static Stream<String> addOpensArg(String modulePackagePair) {
+            return Stream.of("--add-opens", modulePackagePair + "=ALL-UNNAMED");
+        }
+    }
+
+    public abstract static class CompilerArgsArgumentProvider implements CommandLineArgumentProvider {
+        private static final Logger log = Logging.getLogger(ModuleJvmArgsArgumentProvider.class);
+
+        @Internal
+        public abstract SetProperty<String> getExports();
+
+        @Internal
+        public abstract SetProperty<String> getOpens();
+
+        @Internal
+        public abstract Property<String> getProjectPath();
+
+        @Internal
+        public abstract Property<Boolean> getBaselineJavaVersionEnabled();
+
+        @Internal
+        public abstract Property<String> getTaskName();
+
+        @Override
+        public final Iterable<String> asArguments() {
+            boolean isBaselineJavaVersionEnabled =
+                    getBaselineJavaVersionEnabled().getOrElse(false);
+
+            if (!isBaselineJavaVersionEnabled) {
+                log.debug(
+                        "BaselineModuleJvmArgs not applying args to compilation task {} on project {} due to lack of "
+                                + "BaselineJavaVersion",
+                        getTaskName().get(),
+                        getProjectPath().get());
+                return ImmutableList.of();
+            }
+
+            ImmutableList<String> args = compilationArgs(getExports().get().stream(), getOpens().get().stream());
+
+            log.debug(
+                    "BaselineModuleJvmArgs executing {} on project {} with exports: {}",
+                    getTaskName().getOrNull(),
+                    getProjectPath().getOrNull(),
+                    args);
+            return args;
+        }
+
+        private static ImmutableList<String> compilationArgs(Stream<String> allExports, Stream<String> allOpens) {
+            return Stream.concat(allExports, allOpens)
+                    .distinct()
+                    .sorted()
+                    .flatMap(CompilerArgsArgumentProvider::addExportArg)
+                    .collect(ImmutableList.toImmutableList());
+        }
+
+        private static Stream<String> addExportArg(String modulePackagePair) {
+            return Stream.of("--add-exports", modulePackagePair + "=ALL-UNNAMED");
         }
     }
 }

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
@@ -23,6 +23,7 @@ import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.SubProject;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -58,8 +59,10 @@ class BaselineModuleJvmArgsIntegrationTest {
                 libraryTarget = Runtime.version().version().get(0)
             }
 
-            repositories {
-                mavenCentral()
+            allprojects {
+                repositories {
+                    mavenCentral()
+                }
             }
             """);
     }
@@ -151,6 +154,62 @@ class BaselineModuleJvmArgsIntegrationTest {
                     assertThat(line).startsWith("compilerArgs:");
                     assertThat(line).contains("--add-exports, java.management/sun.management");
                 });
+    }
+
+    @Test
+    void can_use_a_compiler_plugin_that_requires_access_to_system_modules_at_the_same_time_as_the_release_args(
+            GradleInvoker gradle, RootProject rootProject, SubProject compilerPlugin) {
+
+        compilerPlugin.buildGradle().append("""
+                plugins {
+                    id 'java-library'
+                    id 'com.palantir.baseline-module-jvm-args'
+                }
+
+                dependencies {
+                    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+                    compileOnly 'com.google.auto.service:auto-service:1.1.1'
+                }
+
+                moduleJvmArgs {
+                    exports = ['jdk.compiler/com.sun.tools.javac.code']
+                }
+            """);
+
+        compilerPlugin.mainSourceSet().java().writeClass("""
+            package com;
+            import com.sun.source.util.JavacTask;
+            import com.sun.source.util.Plugin;
+            import com.google.auto.service.AutoService;
+
+            @AutoService(Plugin.class)
+            public final class SomePlugin implements Plugin {
+                public String getName() {
+                    return "SomePlugin";
+                }
+
+                public void init(JavacTask task, String... args) {
+                    com.sun.tools.javac.code.Symbol.class.toString();
+                }
+            }
+            """);
+
+        rootProject.buildGradle().append("""
+            dependencies {
+                annotationProcessor project(':compilerPlugin')
+            }
+
+            tasks.named('compileJava', JavaCompile) {
+                // The compiler plugin requires --add-exports to access types in the compiler module
+                // Previously, this plugin incorrectly put --add-exports on the compilerArgs (rather than
+                // the forkOptions that would apply to the compiler plugin in the compiler context).
+                // --add-exports is by default incompatible with `--release`.
+                options.compilerArgumentProviders.add({ ['--release', '11'] })
+                options.compilerArgumentProviders.add({ ['-Xplugin:SomePlugin'] })
+            }
+            """);
+
+        gradle.withArgs("compileJava").buildsSuccessfully();
     }
 
     @Test

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
@@ -226,7 +226,7 @@ class BaselineModuleJvmArgsIntegrationTest {
                 }
                 tasks.named('compileJava', JavaCompile) {
                     options.fork = true
-                    options.compilerArgumentProviders.add({ ['--release', '11'] } as CommandLineArgumentProvider)
+                    options.compilerArgumentProviders.add({ ['--release', '17'] } as CommandLineArgumentProvider)
                     doFirst {
                         println "Fork args: ${options.forkOptions.allJvmArgs}"
                         println "Compiler args: ${options.allCompilerArgs}"

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
@@ -62,6 +62,7 @@ class BaselineModuleJvmArgsIntegrationTest {
             allprojects {
                 repositories {
                     mavenCentral()
+                    mavenLocal()
                 }
             }
             """);
@@ -216,21 +217,28 @@ class BaselineModuleJvmArgsIntegrationTest {
     void compiling_using_the_release_and_add_exports_compiler_args_at_the_same_time_works(
             GradleInvoker gradle, RootProject rootProject) {
 
+        // By default, using the `--release` (added here in the test) and `--add-exports` (added by the
+        // plugin under test because we've added asked for a module export in moduleJvmArgs) arguments
+        // in compilerArgs will cause a compiler error as it stops you using them together for no real reason.
+        //
+        // The error we're trying to avoid is:
+        //     error: exporting a package from system module jdk.compiler is not allowed with --release
+        //
+        // This test is checking that we can use them together, with the application of some hackery.
+
         rootProject.buildGradle().append("""
             moduleJvmArgs {
                exports = ['jdk.compiler/com.sun.tools.javac.code']
             }
 
             tasks.named('compileJava', JavaCompile) {
-                // By default, using the `--release` (added here in the test) and `--add-exports` (added by the
-                // plugin under test because we've added asked for a module export in moduleJvmArgs) arguments
-                // in compilerArgs will cause a compiler error as it stops you using them together for no real reason.
-                //
-                // The error we're trying to avoid is:
-                //     error: exporting a package from system module jdk.compiler is not allowed with --release
-                //
-                // This test is checking that we can use them together, with the application of some hackery.
+                options.fork = true
                 options.compilerArgumentProviders.add({ ['--release', '11'] } as CommandLineArgumentProvider)
+
+                doFirst {
+                    println "Fork args: ${options.forkOptions.allJvmArgs}"
+                    println "Compiler args: ${options.allCompilerArgs}"
+                }
             }
             """);
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
@@ -105,6 +105,55 @@ class BaselineModuleJvmArgsIntegrationTest {
     }
 
     @Test
+    void externally_defined_exports_on_annotationProcessor_path_end_up_in_fork_options_not_compiler_options(
+            GradleInvoker gradle, RootProject rootProject) {
+
+        createJarWithExport(rootProject, "test.jar");
+
+        rootProject.buildGradle().append("""
+            dependencies {
+                annotationProcessor files('test.jar')
+            }
+
+            tasks.register('printCompilerArgs') {
+                TaskProvider<JavaCompile> compileJava = tasks.named('compileJava', JavaCompile)
+
+                mustRunAfter compileJava
+
+                inputs.property('forkJvmArgs', compileJava.map { it.options.forkOptions.allJvmArgs })
+                inputs.property('compilerArgs', compileJava.map { it.options.allCompilerArgs })
+
+                doLast {
+                    println "forkJvmArgs: ${inputs.properties.forkJvmArgs}"
+                    println "compilerArgs: ${inputs.properties.compilerArgs}"
+                }
+            }
+            """);
+
+        InvocationResult invocationResult =
+                gradle.withArgs("compileJava", "printCompilerArgs").buildsSuccessfully();
+
+        assertThat(invocationResult.output().lines())
+                .as("Expected the export to be on forkOptions args but it was not. The "
+                        + "annotationProcessor dep is code running in the compiler, so the *compiler process* "
+                        + "needs the --add-exports.")
+                .anySatisfy(line -> {
+                    assertThat(line).startsWith("forkJvmArgs:");
+                    assertThat(line).contains("--add-exports, java.management/sun.management");
+                });
+
+        assertThat(invocationResult.output().lines())
+                .as("Expected the export to not be on the compilerArgs but it was. The "
+                        + "annotationProcessor dep is code running in the compiler, where as exports on "
+                        + "compilerArgs change which modules the code under compilation can access. "
+                        + "tl;dr it's the wrong place for annotationProcessor deps.")
+                .noneSatisfy(line -> {
+                    assertThat(line).startsWith("compilerArgs:");
+                    assertThat(line).contains("--add-exports, java.management/sun.management");
+                });
+    }
+
+    @Test
     void builds_javadoc_with_locally_defined_exports(GradleInvoker gradle, RootProject rootProject) {
         rootProject.buildGradle().append("""
             moduleJvmArgs {

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
@@ -157,7 +157,7 @@ class BaselineModuleJvmArgsIntegrationTest {
     }
 
     @Test
-    void can_use_a_compiler_plugin_that_requires_access_to_system_modules_at_the_same_time_as_the_release_args(
+    void compiles_using_a_compiler_plugin_that_requires_access_to_system_modules_at_the_same_time_as_the_release_args(
             GradleInvoker gradle, RootProject rootProject, SubProject compilerPlugin) {
 
         compilerPlugin.buildGradle().append("""
@@ -204,8 +204,42 @@ class BaselineModuleJvmArgsIntegrationTest {
                 // Previously, this plugin incorrectly put --add-exports on the compilerArgs (rather than
                 // the forkOptions that would apply to the compiler plugin in the compiler context).
                 // --add-exports is by default incompatible with `--release`.
-                options.compilerArgumentProviders.add({ ['--release', '11'] })
-                options.compilerArgumentProviders.add({ ['-Xplugin:SomePlugin'] })
+                options.compilerArgumentProviders.add({ ['--release', '11'] } as CommandLineArgumentProvider)
+                options.compilerArgumentProviders.add({ ['-Xplugin:SomePlugin'] } as CommandLineArgumentProvider)
+            }
+            """);
+
+        gradle.withArgs("compileJava").buildsSuccessfully();
+    }
+
+    @Test
+    void compiling_using_the_release_and_add_exports_compiler_args_at_the_same_time_works(
+            GradleInvoker gradle, RootProject rootProject) {
+
+        rootProject.buildGradle().append("""
+            moduleJvmArgs {
+               exports = ['jdk.compiler/com.sun.tools.javac.code']
+            }
+
+            tasks.named('compileJava', JavaCompile) {
+                // By default, using the `--release` (added here in the test) and `--add-exports` (added by the
+                // plugin under test because we've added asked for a module export in moduleJvmArgs) arguments
+                // in compilerArgs will cause a compiler error as it stops you using them together for no real reason.
+                //
+                // The error we're trying to avoid is:
+                //     error: exporting a package from system module jdk.compiler is not allowed with --release
+                //
+                // This test is checking that we can use them together, with the application of some hackery.
+                options.compilerArgumentProviders.add({ ['--release', '11'] } as CommandLineArgumentProvider)
+            }
+            """);
+
+        rootProject.mainSourceSet().java().writeClass("""
+            package com;
+            public class Example {
+                public static void main(String[] args) {
+                    com.sun.tools.javac.code.Symbol.class.toString();
+                }
             }
             """);
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
@@ -23,6 +23,7 @@ import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.SubProject;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -59,8 +60,11 @@ class BaselineModuleJvmArgsIntegrationTest {
                 libraryTarget = Runtime.version().version().get(0)
             }
 
-            repositories {
-                mavenCentral()
+            allprojects {
+                repositories {
+                    mavenCentral()
+                    mavenLocal()
+                }
             }
             """);
     }
@@ -92,6 +96,141 @@ class BaselineModuleJvmArgsIntegrationTest {
             rootProject.buildGradle().append("""
                 moduleJvmArgs {
                    opens = ['jdk.compiler/com.sun.tools.javac.code']
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass("""
+                package com;
+                public class Example {
+                    public static void main(String[] args) {
+                        com.sun.tools.javac.code.Symbol.class.toString();
+                    }
+                }
+                """);
+
+            gradle.withArgs("compileJava").buildsSuccessfully();
+        }
+
+        @Test
+        void externally_defined_exports_on_annotationProcessor_path_end_up_in_fork_options_not_compiler_options(
+                GradleInvoker gradle, RootProject rootProject) {
+
+            createJarWithExport(rootProject, "test.jar");
+
+            rootProject.buildGradle().append("""
+                dependencies {
+                    annotationProcessor files('test.jar')
+                }
+                tasks.register('printCompilerArgs') {
+                    TaskProvider<JavaCompile> compileJava = tasks.named('compileJava', JavaCompile)
+                    mustRunAfter compileJava
+                    inputs.property('forkJvmArgs', compileJava.map { it.options.forkOptions.allJvmArgs })
+                    inputs.property('compilerArgs', compileJava.map { it.options.allCompilerArgs })
+                    doLast {
+                        println "forkJvmArgs: ${inputs.properties.forkJvmArgs}"
+                        println "compilerArgs: ${inputs.properties.compilerArgs}"
+                    }
+                }
+                """);
+
+            InvocationResult invocationResult =
+                    gradle.withArgs("compileJava", "printCompilerArgs").buildsSuccessfully();
+
+            assertThat(invocationResult.output().lines())
+                    .as("Expected the export to be on forkOptions args but it was not. The "
+                            + "annotationProcessor dep is code running in the compiler, so the *compiler process* "
+                            + "needs the --add-exports.")
+                    .anySatisfy(line -> {
+                        assertThat(line).startsWith("forkJvmArgs:");
+                        assertThat(line).contains("--add-exports, java.management/sun.management");
+                    });
+
+            assertThat(invocationResult.output().lines())
+                    .as("Expected the export to not be on the compilerArgs but it was. The "
+                            + "annotationProcessor dep is code running in the compiler, where as exports on "
+                            + "compilerArgs change which modules the code under compilation can access. "
+                            + "tl;dr it's the wrong place for annotationProcessor deps.")
+                    .noneSatisfy(line -> {
+                        assertThat(line).startsWith("compilerArgs:");
+                        assertThat(line).contains("--add-exports, java.management/sun.management");
+                    });
+        }
+
+        @Test
+        void compiles_with_a_compiler_plugin_requiring_access_to_system_modules_at_the_same_time_as_the_release_args(
+                GradleInvoker gradle, RootProject rootProject, SubProject compilerPlugin) {
+
+            compilerPlugin.buildGradle().append("""
+                    plugins {
+                        id 'java-library'
+                        id 'com.palantir.baseline-module-jvm-args'
+                    }
+                    dependencies {
+                        annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+                        compileOnly 'com.google.auto.service:auto-service:1.1.1'
+                    }
+                    moduleJvmArgs {
+                        exports = ['jdk.compiler/com.sun.tools.javac.code']
+                    }
+                """);
+
+            compilerPlugin.mainSourceSet().java().writeClass("""
+                package com;
+                import com.sun.source.util.JavacTask;
+                import com.sun.source.util.Plugin;
+                import com.google.auto.service.AutoService;
+                @AutoService(Plugin.class)
+                public final class SomePlugin implements Plugin {
+                    public String getName() {
+                        return "SomePlugin";
+                    }
+                    public void init(JavacTask task, String... args) {
+                        com.sun.tools.javac.code.Symbol.class.toString();
+                    }
+                }
+                """);
+
+            rootProject.buildGradle().append("""
+                dependencies {
+                    annotationProcessor project(':compilerPlugin')
+                }
+                tasks.named('compileJava', JavaCompile) {
+                    // The compiler plugin requires --add-exports to access types in the compiler module
+                    // Previously, this plugin incorrectly put --add-exports on the compilerArgs (rather than
+                    // the forkOptions that would apply to the compiler plugin in the compiler context).
+                    // --add-exports is by default incompatible with `--release`.
+                    options.compilerArgumentProviders.add({ ['--release', '11'] } as CommandLineArgumentProvider)
+                    options.compilerArgumentProviders.add({ ['-Xplugin:SomePlugin'] } as CommandLineArgumentProvider)
+                }
+                """);
+
+            gradle.withArgs("compileJava").buildsSuccessfully();
+        }
+
+        @Test
+        void compiling_using_the_release_and_add_exports_compiler_args_at_the_same_time_works(
+                GradleInvoker gradle, RootProject rootProject) {
+
+            // By default, using the `--release` (added here in the test) and `--add-exports` (added by the
+            // plugin under test because we've added asked for a module export in moduleJvmArgs) arguments
+            // in compilerArgs will cause a compiler error as it stops you using them together for no real reason.
+            //
+            // The error we're trying to avoid is:
+            //     error: exporting a package from system module jdk.compiler is not allowed with --release
+            //
+            // This test is checking that we can use them together, with the application of some hackery.
+
+            rootProject.buildGradle().append("""
+                moduleJvmArgs {
+                   exports = ['jdk.compiler/com.sun.tools.javac.code']
+                }
+                tasks.named('compileJava', JavaCompile) {
+                    options.fork = true
+                    options.compilerArgumentProviders.add({ ['--release', '11'] } as CommandLineArgumentProvider)
+                    doFirst {
+                        println "Fork args: ${options.forkOptions.allJvmArgs}"
+                        println "Compiler args: ${options.allCompilerArgs}"
+                    }
                 }
                 """);
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,7 @@ apply plugin: 'com.palantir.jdks.settings'
 rootProject.name = "gradle-baseline"
 
 include "baseline-error-prone"
+include 'baseline-module-jvm-args-compiler-plugins'
 include "baseline-null-away"
 include "gradle-baseline-java"
 include "gradle-baseline-java-config"


### PR DESCRIPTION
## Before this PR
[Error Prone 2.43.0](https://github.com/google/error-prone/releases/tag/v2.43.0) has [made JDK 21 the minimum required JDK that Error Prone is run in](https://github.com/google/error-prone/issues/4867). The recommendation is to use `--release` so a higher version JDK can safely output java classes at a lower language level.

This is problematic for us:
* Currently, if we want to compile Java 17 code, we use a 17 JDK without the `--release` arg. We do not use a higher version (eg 21) JDK using `--release` as it is not compatible with `--add-exports` for system modules (ie modules shipped with the JDK). A decent amount of our code requires compiling with `--add-exports` (especially compiler plugins, more stuff internally).
* We have not yet moved to Java 21 for published libraries, because a couple of the (ever increasing) ecosystems where we use Java as part of the product we sell do not support 21 runtime yet. So we're stuck needing to compile our published libraries with Java 17
* Under this current setup, we cannot upgrade Error Prone. Unfortunately, open source libraries are updating their version of `error_prone_annotations` which is forcing our Error Prone to upgrade as we [force the Error Prone jar versions to be the same](https://github.com/palantir/suppressible-error-prone/pull/97). These OSS library upgrades are being blocked. Unfortunately, Error Prone regularly has breaking changes, even in the annotation jars, so skewing is not going to be safe for long. We also need to upgrade Error Prone to take bug fixes.

There is a bug in the existing implementation of `baseline-module-jvm-args`: it will currently put the `--add-exports` that are meant for the compiler process (ie used for running compiler plugins like Error Prone) in the `compilerArgs` that are meant for the code _being compiled_. This immediately causes every use of `--release` to break, as there is an `--add-exports` next to it.

Unfortunately, even with that bugfix, there is still a problem with using `--release`. We may need to have `--add-exports` compiler args at the same time as using `--release` (eg for jar containing custom error prone BugCheckers), which causes the javac error:
```
error: exporting a package from system module jdk.compiler is not allowed with --release
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
baseline-module-jvm-args: Fix bug where compiler plugin `--add-exports` are added to `compilerArgs` instead of `forkArgs`; allow `--release` and `--add-exports` compiler args to be used together
==COMMIT_MSG==

This is only a prerequisite for using the `--release` arg and a higher JDK, which will in a later PR.

### Fixed the `compilerArgs`/`forkOptions` bug

I've fixed the bug so that we put the `--add-exports` compiler plugin in the `forkOptions` rather than the `compilerOptions`.

### Compiler plugin

I've made a compiler plugin that works around the `--add-exports` + `--release` not used together built in check using reflection. It's a very simple plugin (change one single field).

Now we should be able to compile code with `--add-exports` + `--release` and hopefully never need to worry about this issue again (at least, unless our hack in the plugin breaks).

### **Always** fork the compiler

Previously, we had fork defaulted to false, so there was this horrible inconsistency and bug:

* If the requested java compiler was the _same_ major version as the JDK running the Gradle daemon: it would run the compilation tasks inside the main Gradle daemon, likely without the right `--add-exports` args, even if configured in `forkOptions`.
* If the requested java compiler was a _different_ major version as the JDK running the Gradle daemon: it would spin up a new worker daemon and actually apply the correct JVM args listed in `forkOptions`

Now we always fork the compiler so changing the compiler or daemon JDK do not have the behaviour change

## Possible downsides?
* Fixing the bug around `forkArgs` vs `compilerArgs` may break some repos where projects had not specified the exports they need, because there were `--add-exports` added spuriously into the compiler args. For example: https://github.com/palantir/suppressible-error-prone/pull/225.
  * We will just need to fix these as we go. Will mostly affect error prone check sources, mostly owned by the infra team.
* The compiler plugin is 100% crimes. Changing the compiler internals to get around (an even pretty silly) restriction may add maintenance if the compiler ever changes. It also adds to the WTF/confusing factor as our tooling behaves differently to "normal" java tooling.
  * Fortunately, the code we need to reflectively change has not changed since it was introduced 8 years ago. It should hopefully not change again.
  * I've given the compiler plugin a name that should instil fear and make it very obvious what it's doing if anyone looks at the compiler args

## Alternatives considered

### Just used `--source` and `--target` and not use `--release`

A refresher:
* `--source`: Sets the source language level, eg can you use `sealed interface` or other source features?
* `--target`: Sets the level of the outputted bytecode in classfiles, eg can the compiler output some JVM instruction? Also sets the class files' major version.
* `--release N`: Sets `--source N` and `--target N` **and** the bootstrap classpath that is used, ie use major version N standard library. If you set `--release 17`, it will stop you using any standard library methods that are introduced after JDK 17.

So we could use a higher version JDK and just set `--source` and `--target` and not `--release`, and not face the issue with `--add-exports` used at the same time. However, this would allow devs to use a higher versioned standard library at compile time, which would then explode at runtime. This is not acceptable in my eyes. As an infra team, I'd rather go through a little pain to make our devex better and prevent production issues.

We could have had extra checks to the apis used (eg use animal sniffer), but this is more complexity and infra I'd like to avoid.

### Run Error Prone as a separate task

We could use a different task to run errorprones that can run with a different compiler version. There are benefits and downside to this that we have been thinking about. But this a big change that will delay fixing the blocked upgrades.