### PR TITLE
Improve baseline-java-versions tests by separating out different plugins into their own test classes

### DIFF
--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     gradlePluginForTesting 'com.palantir.sls-packaging:gradle-sls-packaging'
     testRuntimeOnly 'com.palantir.gradle.jdkslatest:gradle-jdks-latest'
     gradlePluginForTesting 'com.palantir.gradle.jdkslatest:gradle-jdks-latest'
+    gradlePluginForTesting 'com.palantir.gradle.jdks:gradle-jdks'
     testRuntimeOnly 'org.unbroken-dome.gradle-plugins:gradle-testsets-plugin'
     gradlePluginForTesting 'org.unbroken-dome.gradle-plugins:gradle-testsets-plugin'
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -29,26 +29,16 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @GradlePluginTests
 class BaselineJavaVersionIntegrationTest {
-    private static final int JAVA_8_BYTECODE = 52;
     private static final int JAVA_11_BYTECODE = 55;
     private static final int JAVA_17_BYTECODE = 61;
     private static final int ENABLE_PREVIEW_BYTECODE = 65535;
     private static final int NOT_ENABLE_PREVIEW_BYTECODE = 0;
-
-    private static final String JAVA_8_COMPATIBLE_CODE = """
-        public class Main {
-            public static void main(String[] args) {
-                System.out.println("jdk8 features on runtime " + System.getProperty("java.specification.version"));
-            }
-        }
-        """;
 
     private static final String JAVA_11_COMPATIBLE_CODE = """
         import java.util.Optional;
@@ -57,6 +47,17 @@ class BaselineJavaVersionIntegrationTest {
             public static void main(String[] args) {
                 Optional.of(args).isEmpty();
                 System.out.println("jdk11 features on runtime " + System.getProperty("java.specification.version"));
+            }
+        }
+        """;
+
+    private static final String JAVA_17_COMPATIBLE_CODE = """
+        public class Main {
+            sealed interface SealedInterface permits Implementation {}
+            record Implementation() implements SealedInterface {}
+
+            public static void main(String[] args) {
+                System.out.println("jdk17 features on runtime " + System.getProperty("java.specification.version"));
             }
         }
         """;
@@ -101,29 +102,29 @@ class BaselineJavaVersionIntegrationTest {
     @Nested
     class JavaCompilation {
         @Test
-        void java_11_compilation_fails_targeting_java_8(GradleInvoker gradle, RootProject rootProject) {
+        void java_17_compilation_fails_targeting_java_11(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
                 javaVersion {
-                    target = 8
-                    runtime = 11
+                    target = 11
+                    runtime = 17
                 }
                 """);
 
-            rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_17_COMPATIBLE_CODE);
 
             gradle.withArgs("compileJava").buildsWithFailure();
         }
 
         @Test
-        void java_11_compilation_succeeds_targeting_java_11(GradleInvoker gradle, RootProject rootProject) {
+        void java_17_compilation_succeeds_targeting_java_17(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
                 javaVersion {
-                    target = '11'
-                    runtime = '11'
+                    target = '17'
+                    runtime = '17'
                 }
                 """);
 
-            rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_17_COMPATIBLE_CODE);
 
             gradle.withArgs("compileJava").buildsSuccessfully();
 
@@ -132,7 +133,7 @@ class BaselineJavaVersionIntegrationTest {
                     .path()
                     .resolve("classes/java/main/Main.class")
                     .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_11_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
         }
     }
 
@@ -185,53 +186,42 @@ class BaselineJavaVersionIntegrationTest {
         }
 
         @Test
-        void java_8_execution_succeeds_on_java_8(GradleInvoker gradle, RootProject rootProject) {
-            Assumptions.assumeThat(System.getProperty("os.arch"))
-                    .describedAs(
-                            "On an M1 mac, this test will fail to download"
-                                + " https://api.adoptopenjdk.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/adoptopenjdk")
-                    .isNotEqualTo("aarch64");
-
+        void java_17_execution_succeeds_on_java_17(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
                 javaVersion {
-                    target = 8
+                    target = 17
+                    runtime = 17
                 }
                 """);
 
-            rootProject.mainSourceSet().java().writeClass(JAVA_8_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_17_COMPATIBLE_CODE);
 
             InvocationResult result = gradle.withArgs("runMainClass").buildsSuccessfully();
 
-            assertThat(result).output().contains("jdk8 features on runtime 1.8");
+            assertThat(result).output().contains("jdk17 features on runtime 17");
         }
 
         @Test
-        void java_8_execution_succeeds_on_java_11(GradleInvoker gradle, RootProject rootProject) {
-            Assumptions.assumeThat(System.getProperty("os.arch"))
-                    .describedAs(
-                            "On an M1 mac, this test will fail to download"
-                                + " https://api.adoptopenjdk.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/adoptopenjdk")
-                    .isNotEqualTo("aarch64");
-
+        void java_17_execution_succeeds_on_java_21(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
                 javaVersion {
-                    target = 8
-                    runtime = 11
+                    target = 17
+                    runtime = 21
                 }
                 """);
 
-            rootProject.mainSourceSet().java().writeClass(JAVA_8_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_17_COMPATIBLE_CODE);
 
             InvocationResult result = gradle.withArgs("runMainClass").buildsSuccessfully();
 
-            assertThat(result).output().contains("jdk8 features on runtime 11");
+            assertThat(result).output().contains("jdk17 features on runtime 21");
 
             File compiledClass = rootProject
                     .buildDir()
                     .path()
                     .resolve("classes/java/main/Main.class")
                     .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_8_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
         }
     }
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -30,8 +30,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -101,10 +99,6 @@ class BaselineJavaVersionIntegrationTest {
                 classpath = sourceSets.main.runtimeClasspath
             }
             """);
-
-        // Fork needed or build fails on circleci with "SystemInfo is not supported on this operating system."
-        // Comment out locally in order to get debugging to work
-        rootProject.gradlePropertiesFile().append("org.gradle.jvmargs=-Xmx2g\norg.gradle.daemon=true\n");
 
         mainJava = rootProject.mainSourceSet().java().fileByClassName("Main");
     }
@@ -517,23 +511,5 @@ class BaselineJavaVersionIntegrationTest {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    private static String extractCompileToolchain(String output) {
-        Matcher compileMatcher = Pattern.compile("^Compiling with toolchain '([^']*)'", Pattern.MULTILINE)
-                .matcher(output);
-        if (!compileMatcher.find()) {
-            throw new IllegalStateException("Could not find compile toolchain in output");
-        }
-        return compileMatcher.group(1);
-    }
-
-    private static String extractRunJavaCommand(String output) {
-        Matcher matcher = Pattern.compile("^Starting process 'command '([^']*)/bin/java''.*Main", Pattern.MULTILINE)
-                .matcher(output);
-        if (!matcher.find()) {
-            throw new IllegalStateException("Could not find run java command in output");
-        }
-        return matcher.group(1);
     }
 }

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -103,8 +103,8 @@ class BaselineJavaVersionIntegrationTest {
         @Test
         void java_11_compilation_fails_targeting_java_8(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 8
+                javaVersion {
+                    target = 8
                     runtime = 11
                 }
                 """);
@@ -117,8 +117,9 @@ class BaselineJavaVersionIntegrationTest {
         @Test
         void java_11_compilation_succeeds_targeting_java_11(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = '11'
+                javaVersion {
+                    target = '11'
+                    runtime = '11'
                 }
                 """);
 
@@ -140,8 +141,9 @@ class BaselineJavaVersionIntegrationTest {
         @Test
         void java_11_execution_succeeds_on_java_11(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
+                javaVersion {
+                    target = 11
+                    runtime = 11
                 }
                 """);
 
@@ -162,8 +164,8 @@ class BaselineJavaVersionIntegrationTest {
         @Test
         void java_11_execution_succeeds_on_java_17(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
+                javaVersion {
+                    target = 11
                     runtime = 17
                 }
                 """);
@@ -191,8 +193,8 @@ class BaselineJavaVersionIntegrationTest {
                     .isNotEqualTo("aarch64");
 
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 8
+                javaVersion {
+                    target = 8
                 }
                 """);
 
@@ -212,8 +214,8 @@ class BaselineJavaVersionIntegrationTest {
                     .isNotEqualTo("aarch64");
 
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 8
+                javaVersion {
+                    target = 8
                     runtime = 11
                 }
                 """);
@@ -240,8 +242,8 @@ class BaselineJavaVersionIntegrationTest {
                 GradleInvoker gradle, RootProject rootProject) {
 
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
+                javaVersion {
+                    target = 11
                     runtime = 17
                 }
                 task printTargetCompatibility() {
@@ -265,30 +267,9 @@ class BaselineJavaVersionIntegrationTest {
         @Test
         void java_17_preview_compilation_works(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
-                    distributionTarget = '17_PREVIEW'
-                }
-                """);
-
-            rootProject.mainSourceSet().java().writeClass(JAVA_17_PREVIEW_CODE);
-
-            gradle.withArgs("compileJava", "-i").buildsSuccessfully();
-
-            File compiledClass = rootProject
-                    .buildDir()
-                    .path()
-                    .resolve("classes/java/main/Main.class")
-                    .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, ENABLE_PREVIEW_BYTECODE);
-        }
-
-        @Test
-        void java_17_preview_on_single_project_works(GradleInvoker gradle, RootProject rootProject) {
-            rootProject.buildGradle().append("""
                 javaVersion {
-                    runtime = '17_PREVIEW'
                     target = '17_PREVIEW'
+                    runtime = '17_PREVIEW'
                 }
                 """);
 
@@ -307,30 +288,14 @@ class BaselineJavaVersionIntegrationTest {
         @Test
         void java_17_preview_javadoc_works(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
-                    distributionTarget = '17_PREVIEW'
+                javaVersion {
+                    target = '17_PREVIEW'
                 }
                 """);
 
             rootProject.mainSourceSet().java().writeClass(JAVA_17_PREVIEW_CODE);
 
             gradle.withArgs("javadoc", "-i").buildsSuccessfully();
-        }
-
-        @Test
-        void setting_library_target_to_preview_version_fails(GradleInvoker gradle, RootProject rootProject) {
-            rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = '17_PREVIEW'
-                }
-                """);
-
-            rootProject.mainSourceSet().java().writeClass(JAVA_17_PREVIEW_CODE);
-
-            InvocationResult result = gradle.withArgs("compileJava", "-i").buildsWithFailure();
-
-            assertThat(result).output().contains("cannot be run on newer JVMs");
         }
     }
 
@@ -341,8 +306,8 @@ class BaselineJavaVersionIntegrationTest {
                 GradleInvoker gradle, RootProject rootProject) {
 
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 17
+                javaVersion {
+                    target = 17
                     runtime = 11
                 }
                 """);
@@ -357,8 +322,8 @@ class BaselineJavaVersionIntegrationTest {
                 GradleInvoker gradle, RootProject rootProject) {
 
             rootProject.buildGradle().append("""
-                javaVersions {
-                    distributionTarget = '11_PREVIEW'
+                javaVersion {
+                    target = '11_PREVIEW'
                     runtime = '15_PREVIEW'
                 }
                 """);
@@ -376,8 +341,8 @@ class BaselineJavaVersionIntegrationTest {
                 GradleInvoker gradle, RootProject rootProject) {
 
             rootProject.buildGradle().append("""
-                javaVersions {
-                    distributionTarget = '17_PREVIEW'
+                javaVersion {
+                    target = '17_PREVIEW'
                     runtime = '17'
                 }
                 """);
@@ -395,8 +360,8 @@ class BaselineJavaVersionIntegrationTest {
                 GradleInvoker gradle, RootProject rootProject) {
 
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 17
+                javaVersion {
+                    target = 17
                     runtime = 17
                 }
                 """);
@@ -412,8 +377,8 @@ class BaselineJavaVersionIntegrationTest {
                 GradleInvoker gradle, RootProject rootProject) {
 
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
+                javaVersion {
+                    target = 11
                     runtime = 11
                 }
 
@@ -438,10 +403,9 @@ class BaselineJavaVersionIntegrationTest {
 
         @Test
         void succeeds_when_all_runtimeClasspath_jars_are_compatible(GradleInvoker gradle, RootProject rootProject) {
-
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 8
+                javaVersion {
+                    target = 8
                     runtime = 8
                 }
 
@@ -456,8 +420,8 @@ class BaselineJavaVersionIntegrationTest {
         @Test
         void handles_gradleApi(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 8
+                javaVersion {
+                    target = 8
                     runtime = 8
                 }
 
@@ -475,8 +439,8 @@ class BaselineJavaVersionIntegrationTest {
         @Test
         void is_a_dependency_of_check(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
+                javaVersion {
+                    target = 11
                     runtime = 11
                 }
                 """);

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
-import com.palantir.gradle.testing.files.java.JavaFile;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import java.io.DataInputStream;
@@ -42,8 +41,6 @@ class BaselineJavaVersionIntegrationTest {
     private static final int JAVA_17_BYTECODE = 61;
     private static final int ENABLE_PREVIEW_BYTECODE = 65535;
     private static final int NOT_ENABLE_PREVIEW_BYTECODE = 0;
-
-    private JavaFile mainJava;
 
     private static final String JAVA_8_COMPATIBLE_CODE = """
         public class Main {
@@ -99,8 +96,6 @@ class BaselineJavaVersionIntegrationTest {
                 classpath = sourceSets.main.runtimeClasspath
             }
             """);
-
-        mainJava = rootProject.mainSourceSet().java().fileByClassName("Main");
     }
 
     @Nested
@@ -114,7 +109,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
 
             gradle.withArgs("compileJava").buildsWithFailure();
         }
@@ -127,7 +122,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
 
             gradle.withArgs("compileJava").buildsSuccessfully();
 
@@ -150,7 +145,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
 
             InvocationResult result = gradle.withArgs("runMainClass").buildsSuccessfully();
 
@@ -173,7 +168,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
 
             InvocationResult result = gradle.withArgs("runMainClass").buildsSuccessfully();
 
@@ -201,7 +196,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_8_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_8_COMPATIBLE_CODE);
 
             InvocationResult result = gradle.withArgs("runMainClass").buildsSuccessfully();
 
@@ -223,7 +218,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_8_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_8_COMPATIBLE_CODE);
 
             InvocationResult result = gradle.withArgs("runMainClass").buildsSuccessfully();
 
@@ -276,7 +271,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_17_PREVIEW_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_17_PREVIEW_CODE);
 
             gradle.withArgs("compileJava", "-i").buildsSuccessfully();
 
@@ -297,7 +292,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_17_PREVIEW_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_17_PREVIEW_CODE);
 
             gradle.withArgs("compileJava", "-i").buildsSuccessfully();
 
@@ -318,7 +313,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_17_PREVIEW_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_17_PREVIEW_CODE);
 
             gradle.withArgs("javadoc", "-i").buildsSuccessfully();
         }
@@ -331,7 +326,7 @@ class BaselineJavaVersionIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_17_PREVIEW_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_17_PREVIEW_CODE);
 
             InvocationResult result = gradle.withArgs("compileJava", "-i").buildsWithFailure();
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -30,9 +30,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.assertj.core.api.Assumptions;
@@ -275,79 +272,6 @@ class BaselineJavaVersionIntegrationTest {
     }
 
     @Nested
-    class LibraryVsDistributionDetection {
-        @Test
-        void distribution_target_is_used_when_no_artifacts_are_published(
-                GradleInvoker gradle, RootProject rootProject) {
-            rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
-                    distributionTarget = 17
-                }
-                """);
-
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
-
-            gradle.withArgs("compileJava").buildsSuccessfully();
-
-            File compiledClass = rootProject
-                    .buildDir()
-                    .path()
-                    .resolve("classes/java/main/Main.class")
-                    .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
-        }
-
-        @Test
-        void library_target_is_used_when_no_artifacts_are_published_but_project_is_overridden_as_a_library(
-                GradleInvoker gradle, RootProject rootProject) {
-
-            rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
-                    distributionTarget = 17
-                }
-                javaVersion {
-                    library()
-                }
-                """);
-
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
-
-            gradle.withArgs("compileJava").buildsSuccessfully();
-
-            File compiledClass = rootProject
-                    .buildDir()
-                    .path()
-                    .resolve("classes/java/main/Main.class")
-                    .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_11_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
-        }
-
-        @Test
-        void distribution_target_is_used_when_sls_packaging_is_used(GradleInvoker gradle, RootProject rootProject) {
-            rootProject.buildGradle().append("""
-                apply plugin: 'com.palantir.sls-java-service-distribution'
-                javaVersions {
-                    libraryTarget = 11
-                    distributionTarget = 17
-                }
-                """);
-
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
-
-            gradle.withArgs("compileJava").buildsSuccessfully();
-
-            File compiledClass = rootProject
-                    .buildDir()
-                    .path()
-                    .resolve("classes/java/main/Main.class")
-                    .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
-        }
-    }
-
-    @Nested
     class Preview {
         @Test
         void java_17_preview_compilation_works(GradleInvoker gradle, RootProject rootProject) {
@@ -418,149 +342,6 @@ class BaselineJavaVersionIntegrationTest {
             InvocationResult result = gradle.withArgs("compileJava", "-i").buildsWithFailure();
 
             assertThat(result).output().contains("cannot be run on newer JVMs");
-        }
-    }
-
-    @Nested
-    class Toolchains {
-        @Test
-        void when_setupJdkToolchains_true_toolchains_are_configured_by_jdks_latest(
-                GradleInvoker gradle, RootProject rootProject) {
-
-            rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
-                    runtime = 21
-                    setupJdkToolchains = true
-                }
-                java {
-                    toolchain {
-                        languageVersion = JavaLanguageVersion.of(11)
-                        vendor = JvmVendorSpec.ADOPTIUM
-                    }
-                    toolchain {
-                        languageVersion = JavaLanguageVersion.of(21)
-                        vendor = JvmVendorSpec.ADOPTIUM
-                    }
-                }
-                """);
-
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
-
-            InvocationResult compileJavaResult =
-                    gradle.withArgs("compileJava", "--info").buildsSuccessfully();
-
-            assertThat(extractCompileToolchain(compileJavaResult.output())).contains("amazon-corretto-11");
-
-            File compiledClass = rootProject
-                    .buildDir()
-                    .path()
-                    .resolve("classes/java/main/Main.class")
-                    .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_11_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
-
-            InvocationResult runResult =
-                    gradle.withArgs("runMainClass", "--info").buildsSuccessfully();
-
-            assertThat(runResult).task(":compileJava").upToDate();
-            assertThat(extractRunJavaCommand(runResult.output())).contains("amazon-corretto-21.");
-
-            gradle.withArgs(
-                            "compileJava",
-                            "run",
-                            "-Porg.gradle.java.installations.auto-detect=false",
-                            "-Porg.gradle.java.installations.auto-download=false")
-                    .buildsSuccessfully();
-        }
-
-        @Test
-        void when_setupJdkToolchains_false_no_toolchains_are_configured_by_gradle_baseline(
-                GradleInvoker gradle, RootProject rootProject) {
-
-            rootProject.buildGradle().append("""
-                apply plugin: 'com.palantir.jdks.latest'
-
-                javaVersions {
-                    libraryTarget = 11
-                    runtime = 21
-                    setupJdkToolchains = false
-                }
-
-                java {
-                    toolchain {
-                        languageVersion = JavaLanguageVersion.of(11)
-                        vendor = JvmVendorSpec.ADOPTIUM
-                    }
-                    toolchain {
-                        languageVersion = JavaLanguageVersion.of(21)
-                        vendor = JvmVendorSpec.ADOPTIUM
-                    }
-                }
-                """);
-
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
-
-            gradle.withArgs(
-                            "compileJava",
-                            "run",
-                            "-Porg.gradle.java.installations.auto-detect=false",
-                            "-Porg.gradle.java.installations.auto-download=false")
-                    .buildsWithFailure();
-        }
-
-        @Test
-        void can_configure_a_jdk_path_to_be_used(GradleInvoker gradle, RootProject rootProject) {
-            Assumptions.assumeThat(System.getenv("CI"))
-                    .describedAs("This test deletes a directory locally, you don't want to run it on your mac")
-                    .isNotNull();
-
-            Path newJavaHome;
-            try {
-                newJavaHome = Files.createSymbolicLink(
-                        rootProject.path().resolve("jdk"), Paths.get(System.getProperty("java.home")));
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-
-            rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
-
-                    jdk JavaLanguageVersion.of(11), new JavaInstallationMetadata() {
-                        @Override
-                        JavaLanguageVersion getLanguageVersion() {
-                            return JavaLanguageVersion.of(11)
-                        }
-                        @Override
-                        String getJavaRuntimeVersion() {
-                            return '11.0.222'
-                        }
-                        @Override
-                        String getJvmVersion() {
-                            return '11.33.44'
-                        }
-                        @Override
-                        String getVendor() {
-                            return 'vendor'
-                        }
-                        @Override
-                        Directory getInstallationPath() {
-                            return layout.dir(provider { new File('%s') }).get()
-                        }
-                        @Override
-                        boolean isCurrentJvm() {
-                            return false
-                        }
-                    }
-                }
-                """, newJavaHome);
-
-            rootProject.mainSourceSet().java().fileByPath("Main.java").overwrite(JAVA_11_COMPATIBLE_CODE);
-
-            InvocationResult result =
-                    gradle.withArgs("compileJava", "--stacktrace", "--info").buildsSuccessfully();
-
-            assertThat(result).output().contains(newJavaHome.toString());
         }
     }
 
@@ -714,25 +495,6 @@ class BaselineJavaVersionIntegrationTest {
             InvocationResult result = gradle.withArgs("check", "--dry-run").buildsSuccessfully();
 
             assertThat(result).output().contains(":checkRuntimeClasspathCompatible");
-        }
-    }
-
-    @Nested
-    class ExplainJavaVersions {
-        @Test
-        void explainJavaVersions_prints_the_java_version_used(GradleInvoker gradle, RootProject rootProject) {
-            rootProject.buildGradle().append("""
-                javaVersions {
-                    libraryTarget = 11
-                    runtime = 17
-                }
-                """);
-
-            InvocationResult result = gradle.withArgs("explainJavaVersions").buildsSuccessfully();
-
-            assertThat(result).output().contains("target  = 11");
-            assertThat(result).output().contains("runtime = 17");
-            assertThat(result).output().contains("Reason:");
         }
     }
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -318,6 +318,22 @@ class BaselineJavaVersionsIntegrationTest {
         }
     }
 
+    @Nested
+    class Verification {
+        @Test
+        void setting_library_target_to_preview_version_fails(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = '17_PREVIEW'
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("compileJava").buildsWithFailure();
+
+            assertThat(result).output().contains("cannot be run on newer JVMs");
+        }
+    }
+
     private static final int BYTECODE_IDENTIFIER = 0xCAFEBABE;
 
     // See http://illegalargumentexception.blogspot.com/2009/07/java-finding-class-versions.html

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -24,6 +24,7 @@ import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.files.java.JavaFile;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.SubProject;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -85,7 +86,7 @@ class BaselineJavaVersionsIntegrationTest {
         """;
 
     @BeforeEach
-    void beforeEach(RootProject rootProject) {
+    void beforeEach(RootProject rootProject, SubProject subProject) {
         rootProject.buildGradle().append("""
             plugins {
                 id 'java'
@@ -105,6 +106,23 @@ class BaselineJavaVersionsIntegrationTest {
             }
             """);
 
+        subProject.buildGradle().append("""
+            plugins {
+                id 'java'
+            }
+
+            tasks.register('printJavaVersionExtension') {
+                def extension = project.extensions.javaVersion
+                inputs.property 'target', extension.target()
+                inputs.property 'runtime', extension.runtime()
+
+                doFirst {
+                    println "javaVersion target: ${inputs.properties.target}"
+                    println "javaVersion runtime: ${inputs.properties.runtime}"
+                }
+            }
+            """);
+
         mainJava = rootProject.mainSourceSet().java().fileByClassName("Main");
     }
 
@@ -113,71 +131,70 @@ class BaselineJavaVersionsIntegrationTest {
         @Test
         void distribution_target_is_used_when_no_artifacts_are_published(
                 GradleInvoker gradle, RootProject rootProject) {
+
             rootProject.buildGradle().append("""
                 javaVersions {
                     libraryTarget = 11
                     distributionTarget = 17
+                    runtime = 21
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            InvocationResult result =
+                    gradle.withArgs("printJavaVersionExtension").buildsSuccessfully();
 
-            gradle.withArgs("compileJava").buildsSuccessfully();
-
-            File compiledClass = rootProject
-                    .buildDir()
-                    .path()
-                    .resolve("classes/java/main/Main.class")
-                    .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+            result.assertThat().output().contains("javaVersion target: 17");
+            result.assertThat().output().contains("javaVersion runtime: 21");
         }
 
         @Test
         void library_target_is_used_when_no_artifacts_are_published_but_project_is_overridden_as_a_library(
-                GradleInvoker gradle, RootProject rootProject) {
+                GradleInvoker gradle, RootProject rootProject, SubProject subProject) {
 
             rootProject.buildGradle().append("""
                 javaVersions {
                     libraryTarget = 11
                     distributionTarget = 17
+                    runtime = 21
                 }
+                """);
+
+            subProject.buildGradle().append("""
                 javaVersion {
                     library()
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            InvocationResult result =
+                    gradle.withArgs("printJavaVersionExtension").buildsSuccessfully();
 
-            gradle.withArgs("compileJava").buildsSuccessfully();
-
-            File compiledClass = rootProject
-                    .buildDir()
-                    .path()
-                    .resolve("classes/java/main/Main.class")
-                    .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_11_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+            result.assertThat().output().contains("javaVersion target: 11");
+            result.assertThat().output().contains("javaVersion runtime: 21");
         }
 
         @Test
-        void distribution_target_is_used_when_sls_packaging_is_used(GradleInvoker gradle, RootProject rootProject) {
+        void distribution_target_is_used_when_sls_packaging_is_used(
+                GradleInvoker gradle, RootProject rootProject, SubProject subProject) {
+
             rootProject.buildGradle().append("""
-                apply plugin: 'com.palantir.sls-java-service-distribution'
                 javaVersions {
                     libraryTarget = 11
                     distributionTarget = 17
+                    runtime = 21
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            subProject.buildGradle().prepend("""
+                plugins {
+                    id 'com.palantir.sls-java-service-distribution'
+                }
+                """);
 
-            gradle.withArgs("compileJava").buildsSuccessfully();
+            InvocationResult result =
+                    gradle.withArgs("printJavaVersionExtension").buildsSuccessfully();
 
-            File compiledClass = rootProject
-                    .buildDir()
-                    .path()
-                    .resolve("classes/java/main/Main.class")
-                    .toFile();
-            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+            result.assertThat().output().contains("javaVersion target: 17");
+            result.assertThat().output().contains("javaVersion runtime: 21");
         }
     }
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -105,10 +105,6 @@ class BaselineJavaVersionsIntegrationTest {
             }
             """);
 
-        // Fork needed or build fails on circleci with "SystemInfo is not supported on this operating system."
-        // Comment out locally in order to get debugging to work
-        rootProject.gradlePropertiesFile().append("org.gradle.jvmargs=-Xmx2g\norg.gradle.daemon=true\n");
-
         mainJava = rootProject.mainSourceSet().java().fileByClassName("Main");
     }
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
-import com.palantir.gradle.testing.files.java.JavaFile;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.gradle.testing.project.SubProject;
@@ -43,21 +42,8 @@ import org.junit.jupiter.api.Test;
 
 @GradlePluginTests
 class BaselineJavaVersionsIntegrationTest {
-    private static final int JAVA_8_BYTECODE = 52;
     private static final int JAVA_11_BYTECODE = 55;
-    private static final int JAVA_17_BYTECODE = 61;
-    private static final int ENABLE_PREVIEW_BYTECODE = 65535;
     private static final int NOT_ENABLE_PREVIEW_BYTECODE = 0;
-
-    private JavaFile mainJava;
-
-    private static final String JAVA_8_COMPATIBLE_CODE = """
-        public class Main {
-            public static void main(String[] args) {
-                System.out.println("jdk8 features on runtime " + System.getProperty("java.specification.version"));
-            }
-        }
-        """;
 
     private static final String JAVA_11_COMPATIBLE_CODE = """
         import java.util.Optional;
@@ -66,21 +52,6 @@ class BaselineJavaVersionsIntegrationTest {
             public static void main(String[] args) {
                 Optional.of(args).isEmpty();
                 System.out.println("jdk11 features on runtime " + System.getProperty("java.specification.version"));
-            }
-        }
-        """;
-
-    private static final String JAVA_17_PREVIEW_CODE = """
-        public class Main {
-            sealed interface MyUnion {
-                record Foo(int number) implements MyUnion {}
-            }
-
-            public static void main(String[] args) {
-                MyUnion myUnion = new MyUnion.Foo(1234);
-                switch (myUnion) {
-                    case MyUnion.Foo foo -> System.out.println("Java 17 pattern matching switch: " + foo.number);
-                }
             }
         }
         """;
@@ -122,8 +93,6 @@ class BaselineJavaVersionsIntegrationTest {
                 }
             }
             """);
-
-        mainJava = rootProject.mainSourceSet().java().fileByClassName("Main");
     }
 
     @Nested
@@ -208,21 +177,10 @@ class BaselineJavaVersionsIntegrationTest {
                 javaVersions {
                     libraryTarget = 11
                     runtime = 21
-                    setupJdkToolchains = true
-                }
-                java {
-                    toolchain {
-                        languageVersion = JavaLanguageVersion.of(11)
-                        vendor = JvmVendorSpec.ADOPTIUM
-                    }
-                    toolchain {
-                        languageVersion = JavaLanguageVersion.of(21)
-                        vendor = JvmVendorSpec.ADOPTIUM
-                    }
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
 
             InvocationResult compileJavaResult =
                     gradle.withArgs("compileJava", "--info").buildsSuccessfully();
@@ -275,7 +233,7 @@ class BaselineJavaVersionsIntegrationTest {
                 }
                 """);
 
-            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+            rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
 
             gradle.withArgs(
                             "compileJava",

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -1,0 +1,388 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline;
+
+import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.execution.InvocationResult;
+import com.palantir.gradle.testing.files.java.JavaFile;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.RootProject;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+class BaselineJavaVersionsIntegrationTest {
+    private static final int JAVA_8_BYTECODE = 52;
+    private static final int JAVA_11_BYTECODE = 55;
+    private static final int JAVA_17_BYTECODE = 61;
+    private static final int ENABLE_PREVIEW_BYTECODE = 65535;
+    private static final int NOT_ENABLE_PREVIEW_BYTECODE = 0;
+
+    private JavaFile mainJava;
+
+    private static final String JAVA_8_COMPATIBLE_CODE = """
+        public class Main {
+            public static void main(String[] args) {
+                System.out.println("jdk8 features on runtime " + System.getProperty("java.specification.version"));
+            }
+        }
+        """;
+
+    private static final String JAVA_11_COMPATIBLE_CODE = """
+        import java.util.Optional;
+
+        public class Main {
+            public static void main(String[] args) {
+                Optional.of(args).isEmpty();
+                System.out.println("jdk11 features on runtime " + System.getProperty("java.specification.version"));
+            }
+        }
+        """;
+
+    private static final String JAVA_17_PREVIEW_CODE = """
+        public class Main {
+            sealed interface MyUnion {
+                record Foo(int number) implements MyUnion {}
+            }
+
+            public static void main(String[] args) {
+                MyUnion myUnion = new MyUnion.Foo(1234);
+                switch (myUnion) {
+                    case MyUnion.Foo foo -> System.out.println("Java 17 pattern matching switch: " + foo.number);
+                }
+            }
+        }
+        """;
+
+    @BeforeEach
+    void beforeEach(RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            plugins {
+                id 'java'
+                id 'com.palantir.baseline-java-versions'
+                id 'com.palantir.jdks.latest'
+            }
+
+            allprojects {
+                repositories {
+                    mavenCentral()
+                }
+            }
+
+            task runMainClass(type: JavaExec) {
+                mainClass = 'Main'
+                classpath = sourceSets.main.runtimeClasspath
+            }
+            """);
+
+        // Fork needed or build fails on circleci with "SystemInfo is not supported on this operating system."
+        // Comment out locally in order to get debugging to work
+        rootProject.gradlePropertiesFile().append("org.gradle.jvmargs=-Xmx2g\norg.gradle.daemon=true\n");
+
+        mainJava = rootProject.mainSourceSet().java().fileByClassName("Main");
+    }
+
+    @Nested
+    class LibraryVsDistributionDetection {
+        @Test
+        void distribution_target_is_used_when_no_artifacts_are_published(
+                GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+                    distributionTarget = 17
+                }
+                """);
+
+            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+
+            gradle.withArgs("compileJava").buildsSuccessfully();
+
+            File compiledClass = rootProject
+                    .buildDir()
+                    .path()
+                    .resolve("classes/java/main/Main.class")
+                    .toFile();
+            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+        }
+
+        @Test
+        void library_target_is_used_when_no_artifacts_are_published_but_project_is_overridden_as_a_library(
+                GradleInvoker gradle, RootProject rootProject) {
+
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+                    distributionTarget = 17
+                }
+                javaVersion {
+                    library()
+                }
+                """);
+
+            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+
+            gradle.withArgs("compileJava").buildsSuccessfully();
+
+            File compiledClass = rootProject
+                    .buildDir()
+                    .path()
+                    .resolve("classes/java/main/Main.class")
+                    .toFile();
+            assertBytecodeVersion(compiledClass, JAVA_11_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+        }
+
+        @Test
+        void distribution_target_is_used_when_sls_packaging_is_used(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                apply plugin: 'com.palantir.sls-java-service-distribution'
+                javaVersions {
+                    libraryTarget = 11
+                    distributionTarget = 17
+                }
+                """);
+
+            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+
+            gradle.withArgs("compileJava").buildsSuccessfully();
+
+            File compiledClass = rootProject
+                    .buildDir()
+                    .path()
+                    .resolve("classes/java/main/Main.class")
+                    .toFile();
+            assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+        }
+    }
+
+    @Nested
+    class Toolchains {
+        @Test
+        void when_setupJdkToolchains_true_toolchains_are_configured_by_jdks_latest(
+                GradleInvoker gradle, RootProject rootProject) {
+
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+                    runtime = 21
+                    setupJdkToolchains = true
+                }
+                java {
+                    toolchain {
+                        languageVersion = JavaLanguageVersion.of(11)
+                        vendor = JvmVendorSpec.ADOPTIUM
+                    }
+                    toolchain {
+                        languageVersion = JavaLanguageVersion.of(21)
+                        vendor = JvmVendorSpec.ADOPTIUM
+                    }
+                }
+                """);
+
+            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+
+            InvocationResult compileJavaResult =
+                    gradle.withArgs("compileJava", "--info").buildsSuccessfully();
+
+            assertThat(extractCompileToolchain(compileJavaResult.output())).contains("amazon-corretto-11");
+
+            File compiledClass = rootProject
+                    .buildDir()
+                    .path()
+                    .resolve("classes/java/main/Main.class")
+                    .toFile();
+            assertBytecodeVersion(compiledClass, JAVA_11_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+
+            InvocationResult runResult =
+                    gradle.withArgs("runMainClass", "--info").buildsSuccessfully();
+
+            assertThat(runResult).task(":compileJava").upToDate();
+            assertThat(extractRunJavaCommand(runResult.output())).contains("amazon-corretto-21.");
+
+            gradle.withArgs(
+                            "compileJava",
+                            "run",
+                            "-Porg.gradle.java.installations.auto-detect=false",
+                            "-Porg.gradle.java.installations.auto-download=false")
+                    .buildsSuccessfully();
+        }
+
+        @Test
+        void when_setupJdkToolchains_false_no_toolchains_are_configured_by_gradle_baseline(
+                GradleInvoker gradle, RootProject rootProject) {
+
+            rootProject.buildGradle().append("""
+                apply plugin: 'com.palantir.jdks.latest'
+
+                javaVersions {
+                    libraryTarget = 11
+                    runtime = 21
+                    setupJdkToolchains = false
+                }
+
+                java {
+                    toolchain {
+                        languageVersion = JavaLanguageVersion.of(11)
+                        vendor = JvmVendorSpec.ADOPTIUM
+                    }
+                    toolchain {
+                        languageVersion = JavaLanguageVersion.of(21)
+                        vendor = JvmVendorSpec.ADOPTIUM
+                    }
+                }
+                """);
+
+            mainJava.overwrite(JAVA_11_COMPATIBLE_CODE);
+
+            gradle.withArgs(
+                            "compileJava",
+                            "run",
+                            "-Porg.gradle.java.installations.auto-detect=false",
+                            "-Porg.gradle.java.installations.auto-download=false")
+                    .buildsWithFailure();
+        }
+
+        @Test
+        void can_configure_a_jdk_path_to_be_used(GradleInvoker gradle, RootProject rootProject) {
+            Assumptions.assumeThat(System.getenv("CI"))
+                    .describedAs("This test deletes a directory locally, you don't want to run it on your mac")
+                    .isNotNull();
+
+            Path newJavaHome;
+            try {
+                newJavaHome = Files.createSymbolicLink(
+                        rootProject.path().resolve("jdk"), Paths.get(System.getProperty("java.home")));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+
+                    jdk JavaLanguageVersion.of(11), new JavaInstallationMetadata() {
+                        @Override
+                        JavaLanguageVersion getLanguageVersion() {
+                            return JavaLanguageVersion.of(11)
+                        }
+                        @Override
+                        String getJavaRuntimeVersion() {
+                            return '11.0.222'
+                        }
+                        @Override
+                        String getJvmVersion() {
+                            return '11.33.44'
+                        }
+                        @Override
+                        String getVendor() {
+                            return 'vendor'
+                        }
+                        @Override
+                        Directory getInstallationPath() {
+                            return layout.dir(provider { new File('%s') }).get()
+                        }
+                        @Override
+                        boolean isCurrentJvm() {
+                            return false
+                        }
+                    }
+                }
+                """, newJavaHome);
+
+            rootProject.mainSourceSet().java().fileByPath("Main.java").overwrite(JAVA_11_COMPATIBLE_CODE);
+
+            InvocationResult result =
+                    gradle.withArgs("compileJava", "--stacktrace", "--info").buildsSuccessfully();
+
+            assertThat(result).output().contains(newJavaHome.toString());
+        }
+    }
+
+    @Nested
+    class ExplainJavaVersions {
+        @Test
+        void explainJavaVersions_prints_the_java_version_used(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+                    runtime = 17
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("explainJavaVersions").buildsSuccessfully();
+
+            assertThat(result).output().contains("target  = 11");
+            assertThat(result).output().contains("runtime = 17");
+            assertThat(result).output().contains("Reason:");
+        }
+    }
+
+    private static final int BYTECODE_IDENTIFIER = 0xCAFEBABE;
+
+    // See http://illegalargumentexception.blogspot.com/2009/07/java-finding-class-versions.html
+    private static void assertBytecodeVersion(
+            File file, int expectedMajorBytecodeVersion, int expectedMinorBytecodeVersion) {
+        try (InputStream stream = new FileInputStream(file);
+                DataInputStream dis = new DataInputStream(stream)) {
+            int magic = dis.readInt();
+            if (magic != BYTECODE_IDENTIFIER) {
+                throw new IllegalArgumentException("File " + file + " does not appear to be java bytecode");
+            }
+            int minorBytecodeVersion = 0xFFFF & dis.readShort();
+            int majorBytecodeVersion = 0xFFFF & dis.readShort();
+
+            assertThat(majorBytecodeVersion).isEqualTo(expectedMajorBytecodeVersion);
+            assertThat(minorBytecodeVersion).isEqualTo(expectedMinorBytecodeVersion);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String extractCompileToolchain(String output) {
+        Matcher compileMatcher = Pattern.compile("^Compiling with toolchain '([^']*)'", Pattern.MULTILINE)
+                .matcher(output);
+        if (!compileMatcher.find()) {
+            throw new IllegalStateException("Could not find compile toolchain in output");
+        }
+        return compileMatcher.group(1);
+    }
+
+    private static String extractRunJavaCommand(String output) {
+        Matcher matcher = Pattern.compile("^Starting process 'command '([^']*)/bin/java''.*Main", Pattern.MULTILINE)
+                .matcher(output);
+        if (!matcher.find()) {
+            throw new IllegalStateException("Could not find run java command in output");
+        }
+        return matcher.group(1);
+    }
+}

--- a/versions.lock
+++ b/versions.lock
@@ -16,11 +16,11 @@ com.diffplug.spotless:spotless-lib-extra:3.3.1 (1 constraints: 1713d42d)
 
 com.diffplug.spotless:spotless-plugin-gradle:7.2.1 (1 constraints: 0c051536)
 
-com.fasterxml.jackson.core:jackson-annotations:2.20 (11 constraints: b3b9dd6e)
+com.fasterxml.jackson.core:jackson-annotations:2.20 (11 constraints: b1b9cc6c)
 
 com.fasterxml.jackson.core:jackson-core:2.20.0 (6 constraints: 837ed097)
 
-com.fasterxml.jackson.core:jackson-databind:2.20.0 (13 constraints: 860dc2ad)
+com.fasterxml.jackson.core:jackson-databind:2.20.0 (13 constraints: 7e0db1a4)
 
 com.fasterxml.jackson.datatype:jackson-datatype-guava:2.20.0 (2 constraints: 73280293)
 
@@ -228,19 +228,19 @@ com.palantir.conjure.java.api:test-utils:2.65.0 (1 constraints: 3f05523b)
 
 com.palantir.conjure.java.runtime:conjure-java-annotations:8.25.0 (1 constraints: 4105663b)
 
-com.palantir.gradle.jdks:gradle-jdks:0.68.0 (1 constraints: de1441a2)
+com.palantir.gradle.jdks:gradle-jdks:0.69.0 (2 constraints: 1e1a7113)
 
-com.palantir.gradle.jdks:gradle-jdks-distributions:0.68.0 (2 constraints: 1421dc9c)
+com.palantir.gradle.jdks:gradle-jdks-distributions:0.69.0 (2 constraints: 1621159d)
 
-com.palantir.gradle.jdks:gradle-jdks-enablement:0.68.0 (1 constraints: 970f6092)
+com.palantir.gradle.jdks:gradle-jdks-enablement:0.69.0 (1 constraints: 980f6392)
 
-com.palantir.gradle.jdks:gradle-jdks-json:0.68.0 (1 constraints: 970f6092)
+com.palantir.gradle.jdks:gradle-jdks-json:0.69.0 (1 constraints: 980f6392)
 
-com.palantir.gradle.jdks:gradle-jdks-setup:0.68.0 (1 constraints: 970f6092)
+com.palantir.gradle.jdks:gradle-jdks-setup:0.69.0 (1 constraints: 980f6392)
 
-com.palantir.gradle.jdks:gradle-jdks-setup-common:0.68.0 (3 constraints: 293b3846)
+com.palantir.gradle.jdks:gradle-jdks-setup-common:0.69.0 (3 constraints: 2c3be246)
 
-com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.22.0 (1 constraints: 36052d3b)
+com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.24.0 (1 constraints: 3805333b)
 
 com.palantir.gradle.plugintesting:configuration-cache-spec:0.27.0 (1 constraints: 3b053c3b)
 

--- a/versions.props
+++ b/versions.props
@@ -47,7 +47,8 @@ org.junit.vintage:* = 5.13.4
 org.junit.platform:* = 1.13.4
 org.mockito:* = 5.20.0
 com.palantir.sls-packaging:gradle-sls-packaging = 7.79.0
-com.palantir.gradle.jdkslatest:gradle-jdks-latest = 0.22.0
+com.palantir.gradle.jdks:gradle-jdks = 0.69.0
+com.palantir.gradle.jdkslatest:gradle-jdks-latest = 0.24.0
 org.unbroken-dome.gradle-plugins:gradle-testsets-plugin = 4.1.0
 
 # dependency-upgrader:OFF


### PR DESCRIPTION
## Before this PR
Currently, there are two plugins:

* `baseline-java-version`: The allows you to set `target` and `runtime` on `javaVersion` in subprojects.
* `baseline-java-versions` (notice the plural `s`!): This allows configuration of the `libraryTarget` and `distributionTarget` properties on `javaVersions` in the root, and handles working out which subprojects are a library or a distribution.

These are currently all in one test file, which is confusing, especially as the logic for whether a project is a library or distribution is repeatedly tested.

## After this PR
* I move the JavaVersion**s** tests into their own test class, and changed some of them so rather than actually doing compiles we just check the `javaVersion` extension is setup correctly.
* The JavaVersion tests now only look at one project and are a bit more obvious.
* I've removed Java 8 testing as it's no longer supported by gradle-jdks, meaning tests don't work locally. Now testing against 17/21 instead.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

