### PR TITLE
Add a instanceof check for sealed unions

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConjureUnionExhaustiveSwitch.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConjureUnionExhaustiveSwitch.java
@@ -30,8 +30,6 @@ import com.sun.source.tree.SwitchTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Type;
 import java.util.List;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.Modifier;
 
 /**
  * Detects usage of {@code default} clauses in switch statements over Conjure unions (sealed types).
@@ -58,17 +56,18 @@ public final class ConjureUnionExhaustiveSwitch extends BugChecker
 
     @Override
     public Description matchSwitch(SwitchTree tree, VisitorState _state) {
-        return checkSwitchForSealedType(tree.getExpression(), tree.getCases(), tree);
+        return checkSwitchForConjureUnion(tree.getExpression(), tree.getCases(), tree);
     }
 
     @Override
     public Description matchSwitchExpression(SwitchExpressionTree tree, VisitorState _state) {
-        return checkSwitchForSealedType(tree.getExpression(), tree.getCases(), tree);
+        return checkSwitchForConjureUnion(tree.getExpression(), tree.getCases(), tree);
     }
 
-    private Description checkSwitchForSealedType(ExpressionTree expression, List<? extends CaseTree> cases, Tree tree) {
+    private Description checkSwitchForConjureUnion(
+            ExpressionTree expression, List<? extends CaseTree> cases, Tree tree) {
         Type switchType = ASTHelpers.getType(expression);
-        if (switchType == null || !isConjureUnion(switchType)) {
+        if (switchType == null || !ConjureUtils.isConjureUnion(switchType)) {
             return Description.NO_MATCH;
         }
 
@@ -77,20 +76,5 @@ public final class ConjureUnionExhaustiveSwitch extends BugChecker
         }
 
         return buildDescription(tree).build();
-    }
-
-    private boolean isConjureUnion(Type type) {
-        if (type.asElement() == null
-                || type.asElement().getKind() != ElementKind.CLASS
-                || !type.asElement().getModifiers().contains(Modifier.SEALED)) {
-            return false;
-        }
-
-        // Check if it has a nested interface called "Known"
-        // Empty conjure unions won't have a Known interface, but they won't be used in switches either by definition
-        return ASTHelpers.getEnclosedElements(type.asElement()).stream()
-                .anyMatch(element -> element.getKind() == ElementKind.INTERFACE
-                        && element.getModifiers().contains(Modifier.SEALED)
-                        && "Known".equals(element.getSimpleName().toString()));
     }
 }

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConjureUnionInstanceof.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConjureUnionInstanceof.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.InstanceOfTree;
+import com.sun.tools.javac.code.Type;
+
+/**
+ * Detects usage of {@code instanceof} checks on Conjure unions.
+ */
+@AutoService(BugChecker.class)
+@BugPattern(
+        link = "https://github.com/palantir/gradle-baseline#baseline-error-prone-checks",
+        linkType = BugPattern.LinkType.CUSTOM,
+        severity = SeverityLevel.WARNING,
+        summary = "Avoid using instanceof checks on Conjure unions. "
+                + "Use switch expressions/visitors instead to ensure all variants are handled explicitly.")
+public final class ConjureUnionInstanceof extends BugChecker implements BugChecker.InstanceOfTreeMatcher {
+
+    @Override
+    public Description matchInstanceOf(InstanceOfTree tree, VisitorState _state) {
+        Type expressionType = ASTHelpers.getType(tree.getExpression());
+        if (expressionType == null || !ConjureUtils.isConjureUnion(expressionType)) {
+            return Description.NO_MATCH;
+        }
+
+        return buildDescription(tree).build();
+    }
+}

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConjureUtils.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConjureUtils.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.tools.javac.code.Type;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+
+final class ConjureUtils {
+
+    static boolean isConjureUnion(Type type) {
+        // TODO(kkak): Update this to check for the presence of @ConjureGenerated
+        if (type.asElement() == null
+                || type.asElement().getKind() != ElementKind.CLASS
+                || !type.asElement().getModifiers().contains(Modifier.SEALED)) {
+            return false;
+        }
+
+        // Check if it has a nested interface called "Known"
+        return ASTHelpers.getEnclosedElements(type.asElement()).stream()
+                .anyMatch(element -> element.getKind() == ElementKind.INTERFACE
+                        && element.getModifiers().contains(Modifier.SEALED)
+                        && "Known".equals(element.getSimpleName().toString()));
+    }
+
+    private ConjureUtils() {}
+}

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ConjureUnionInstanceofTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ConjureUnionInstanceofTest.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.jupiter.api.Test;
+
+public class ConjureUnionInstanceofTest {
+
+    @Test
+    void testConjureUnionInstanceof() {
+        String source = """
+            sealed abstract class Shape permits Circle, Square, Unknown {
+                sealed interface Known permits Circle, Square {}
+            }
+            final class Circle extends Shape implements Shape.Known {}
+            final class Square extends Shape implements Shape.Known {}
+            final class Unknown extends Shape {}
+            public class Test {
+                public void test(Shape shape) {
+                    // BUG: Diagnostic contains: Avoid using instanceof checks
+                    if (shape instanceof Circle circle) {
+                        System.out.println("Circle: " + circle);
+                    }
+                }
+            }
+            """;
+        helper().addSourceLines("Test.java", source).doTest();
+    }
+
+    @Test
+    void testNonConjureUnionInstanceof() {
+        String source = """
+            sealed abstract class Shape permits Circle, Square {}
+            final class Circle extends Shape {}
+            final class Square extends Shape {}
+            public class Test {
+                public void test(Shape shape) {
+                    if (shape instanceof Circle) {
+                        System.out.println("Circle");
+                    }
+                }
+            }
+            """;
+        helper().addSourceLines("Test.java", source).doTest();
+    }
+
+    private CompilationTestHelper helper() {
+        return CompilationTestHelper.newInstance(ConjureUnionInstanceof.class, getClass());
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Add an errorprone check to steer developers away from using instanceof checks with sealed union types, instead pushing them towards switches and visitors, which are generally more efficient and also force exhaustive handling of all types.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds an errorprone check to flag instanceof check usage with sealed union types.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

