### PR TITLE
Don't run annoying error-prones during local-development-iteration cycles

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/extensions/BaselineErrorProneExtension.java
@@ -22,6 +22,9 @@ import org.gradle.api.provider.SetProperty;
 
 public abstract class BaselineErrorProneExtension {
 
+    // Checks which only run with `check`, but not `compileJava`
+    public static final Set<String> ANNOYING_CHECKS = Set.of("StrictUnusedVariable");
+
     /*
      * Do not add SUGGESTION checks here. Instead either increase the severity to WARNING or do not apply them by
      * default.

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineErrorProne.java
@@ -27,6 +27,7 @@ import net.ltgt.gradle.errorprone.ErrorProneOptions;
 import net.ltgt.gradle.errorprone.ErrorPronePlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.process.CommandLineArgumentProvider;
 
@@ -47,6 +48,14 @@ public final class BaselineErrorProne implements Plugin<Project> {
 
         project.getExtensions()
                 .create(EXTENSION_NAME, BaselineErrorProneExtension.class, suppressibleErrorProneExtension);
+        project.getGradle().getTaskGraph().whenReady(taskGraph -> {
+            Task check = project.getTasks().named("check").get();
+            if (!taskGraph.hasTask(check)) {
+                suppressibleErrorProneExtension.configureEachErrorProneOptions(errorProneOptions -> {
+                    BaselineErrorProneExtension.ANNOYING_CHECKS.forEach(errorProneOptions::disable);
+                });
+            }
+        });
 
         String version = Optional.ofNullable((String) project.findProperty("baselineErrorProneVersion"))
                 .or(() -> Optional.ofNullable(

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -332,6 +332,34 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         '''.stripIndent()
     }
 
+    def 'compileJava by itself does not run annoying error-prones'() {
+        given: 'A java file which violates StrictUnusedVariable'
+        buildFile << standardBuildFile
+        file('src/main/java/foo/Foo.java') << '''
+            package foo;
+
+            public class Foo {
+                void foo() {
+                    int x = 5;
+                }
+            }
+        '''.stripIndent(true)
+
+        when: 'Running compileJava by itself'
+        BuildResult compileJavaResult = with('compileJava').build()
+
+        then: 'StrictUnusedVariable does not fire'
+        compileJavaResult.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        !compileJavaResult.output.contains('error: [StrictUnusedVariable]')
+
+        when: 'Running compileJava via check'
+        BuildResult checkResult = with('check').buildAndFail()
+
+        then: 'StrictUnusedVariable fires'
+        checkResult.task(":compileJava").outcome == TaskOutcome.FAILED
+        checkResult.output.contains('error: [StrictUnusedVariable]')
+    }
+
     def 'compileJava applies patches when errorProneApply contains specific checks'() {
         when:
         buildFile << standardBuildFile


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Most error-prones give valuable pointers during the development process. Some error-prones just bog us down during development, but are valuable to prevent code quality regressions in a repo — let's call these annoying error-prones.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Don't run annoying error-prones during local-development-iteration cycles
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

