### PR TITLE
drop nullaway to 0.12.10 

### DIFF
--- a/versions.lock
+++ b/versions.lock
@@ -94,7 +94,7 @@ com.squareup.okio:okio:3.6.0 (1 constraints: 530c38fd)
 
 com.squareup.okio:okio-jvm:3.6.0 (1 constraints: 500ad3b9)
 
-com.uber.nullaway:nullaway:0.12.12 (1 constraints: 68059240)
+com.uber.nullaway:nullaway:0.12.10 (1 constraints: 66059040)
 
 commons-codec:commons-codec:1.17.1 (2 constraints: 1b1ee786)
 

--- a/versions.props
+++ b/versions.props
@@ -18,7 +18,7 @@ com.google.errorprone:error_prone_* = 2.41.0
 com.googlecode.java-diff-utils:diffutils = 1.3.0
 com.puppycrawl.tools:checkstyle = 12.1.2
 com.palantir.gradle.utils:* = 0.21.0
-com.uber.nullaway:nullaway = 0.12.12
+com.uber.nullaway:nullaway = 0.12.10
 com.palantir.gradle.failure-reports:* = 1.2.0
 com.palantir.gradle.idea-configuration:gradle-idea-configuration = 0.4.0
 


### PR DESCRIPTION
## Before this PR
In nullaway 0.12.12 there is a bug - https://github.com/uber/NullAway/issues/1351 - which can cause build failures
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Drop to working version until fixed
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

