### PR TITLE
Inherit JDKs set up by gradle-jdks inside tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,4 +105,7 @@ javaVersions {
 
 jdks {
     daemonTarget = 21
+
+    // Tests need these JDK versions installed
+    jdkMajorVersionsToUse().addAll([11, 17, 21].collect { JavaLanguageVersion.of(it)})
 }

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     testRuntimeOnly 'com.palantir.gradle.jdkslatest:gradle-jdks-latest'
     gradlePluginForTesting 'com.palantir.gradle.jdkslatest:gradle-jdks-latest'
     gradlePluginForTesting 'com.palantir.gradle.jdks:gradle-jdks'
+    gradlePluginForTesting 'com.palantir.gradle.jdks:gradle-jdks-settings'
     testRuntimeOnly 'org.unbroken-dome.gradle-plugins:gradle-testsets-plugin'
     gradlePluginForTesting 'org.unbroken-dome.gradle-plugins:gradle-testsets-plugin'
 

--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -47,8 +47,6 @@ dependencies {
     }
     testRuntimeOnly 'com.palantir.sls-packaging:gradle-sls-packaging'
     gradlePluginForTesting 'com.palantir.sls-packaging:gradle-sls-packaging'
-    testRuntimeOnly 'com.palantir.gradle.jdkslatest:gradle-jdks-latest'
-    gradlePluginForTesting 'com.palantir.gradle.jdkslatest:gradle-jdks-latest'
     gradlePluginForTesting 'com.palantir.gradle.jdks:gradle-jdks'
     gradlePluginForTesting 'com.palantir.gradle.jdks:gradle-jdks-settings'
     testRuntimeOnly 'org.unbroken-dome.gradle-plugins:gradle-testsets-plugin'

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -395,8 +395,8 @@ class BaselineJavaVersionIntegrationTest {
         void succeeds_when_all_runtimeClasspath_jars_are_compatible(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
                 javaVersion {
-                    target = 8
-                    runtime = 8
+                    target = 11
+                    runtime = 11
                 }
 
                 dependencies {
@@ -411,8 +411,8 @@ class BaselineJavaVersionIntegrationTest {
         void handles_gradleApi(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
                 javaVersion {
-                    target = 8
-                    runtime = 8
+                    target = 11
+                    runtime = 11
                 }
 
                 dependencies {

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
+import com.palantir.gradle.testing.files.Directory;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import java.io.DataInputStream;
@@ -29,6 +30,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -78,7 +81,16 @@ class BaselineJavaVersionIntegrationTest {
         """;
 
     @BeforeEach
-    void beforeEach(RootProject rootProject) {
+    void beforeEach(RootProject rootProject) throws IOException {
+        rootProject.gradlePropertiesFile().appendProperty("palantir.jdk.setup.enabled", "true");
+        rootProject.settingsGradle().plugins().add("com.palantir.jdks.settings");
+        rootProject.buildGradle().plugins().add("com.palantir.jdks");
+        Directory jdksDir = rootProject.directory("gradle").createDirectories().directory("jdks");
+        Files.createSymbolicLink(jdksDir.path(), Path.of("../gradle/jdks").toAbsolutePath());
+
+        rootProject.buildGradle().plugins().add("java");
+        rootProject.buildGradle().plugins().add("com.palantir.baseline-java-versions");
+
         rootProject.buildGradle().append("""
             allprojects {
                 repositories {
@@ -91,12 +103,6 @@ class BaselineJavaVersionIntegrationTest {
                 classpath = sourceSets.main.runtimeClasspath
             }
             """);
-        rootProject
-                .buildGradle()
-                .plugins()
-                .add("java")
-                .add("com.palantir.baseline-java-versions")
-                .add("com.palantir.jdks.latest");
     }
 
     @Nested

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -19,9 +19,9 @@ package com.palantir.baseline;
 import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.baseline.gradlejdks.InheritGradleJdks;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
-import com.palantir.gradle.testing.files.Directory;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import java.io.DataInputStream;
@@ -30,8 +30,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -81,12 +79,8 @@ class BaselineJavaVersionIntegrationTest {
         """;
 
     @BeforeEach
-    void beforeEach(RootProject rootProject) throws IOException {
-        rootProject.gradlePropertiesFile().appendProperty("palantir.jdk.setup.enabled", "true");
-        rootProject.settingsGradle().plugins().add("com.palantir.jdks.settings");
-        rootProject.buildGradle().plugins().add("com.palantir.jdks");
-        Directory jdksDir = rootProject.directory("gradle").createDirectories().directory("jdks");
-        Files.createSymbolicLink(jdksDir.path(), Path.of("../gradle/jdks").toAbsolutePath());
+    void beforeEach(RootProject rootProject) {
+        InheritGradleJdks.beforeEach(rootProject);
 
         rootProject.buildGradle().plugins().add("java");
         rootProject.buildGradle().plugins().add("com.palantir.baseline-java-versions");

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -31,12 +31,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -233,62 +229,6 @@ class BaselineJavaVersionsIntegrationTest {
                             "-Porg.gradle.java.installations.auto-detect=false",
                             "-Porg.gradle.java.installations.auto-download=false")
                     .buildsWithFailure();
-        }
-
-        @Test
-        void can_configure_a_jdk_path_to_be_used(GradleInvoker gradle, RootProject rootProject) {
-            Assumptions.assumeThat(System.getenv("CI"))
-                    .describedAs("This test deletes a directory locally, you don't want to run it on your mac")
-                    .isNotNull();
-
-            Path newJavaHome;
-            try {
-                newJavaHome = Files.createSymbolicLink(
-                        rootProject.path().resolve("jdk"), Paths.get(System.getProperty("java.home")));
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-
-            rootProject.buildGradle().append("""
-                javaVersions {
-                    setupJdkToolchains = false
-                    libraryTarget = 11
-
-                    jdk JavaLanguageVersion.of(11), new JavaInstallationMetadata() {
-                        @Override
-                        JavaLanguageVersion getLanguageVersion() {
-                            return JavaLanguageVersion.of(11)
-                        }
-                        @Override
-                        String getJavaRuntimeVersion() {
-                            return '11.0.222'
-                        }
-                        @Override
-                        String getJvmVersion() {
-                            return '11.33.44'
-                        }
-                        @Override
-                        String getVendor() {
-                            return 'vendor'
-                        }
-                        @Override
-                        Directory getInstallationPath() {
-                            return layout.dir(provider { new File('%s') }).get()
-                        }
-                        @Override
-                        boolean isCurrentJvm() {
-                            return false
-                        }
-                    }
-                }
-                """, newJavaHome);
-
-            rootProject.mainSourceSet().java().fileByPath("Main.java").overwrite(JAVA_11_COMPATIBLE_CODE);
-
-            InvocationResult result =
-                    gradle.withArgs("compileJava", "--stacktrace", "--info").buildsSuccessfully();
-
-            assertThat(result).output().contains(newJavaHome.toString());
         }
     }
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -251,6 +251,7 @@ class BaselineJavaVersionsIntegrationTest {
 
             rootProject.buildGradle().append("""
                 javaVersions {
+                    setupJdkToolchains = false
                     libraryTarget = 11
 
                     jdk JavaLanguageVersion.of(11), new JavaInstallationMetadata() {

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -19,6 +19,7 @@ package com.palantir.baseline;
 import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.baseline.gradlejdks.InheritGradleJdks;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
@@ -58,6 +59,8 @@ class BaselineJavaVersionsIntegrationTest {
 
     @BeforeEach
     void beforeEach(RootProject rootProject, SubProject subProject) {
+        InheritGradleJdks.beforeEach(rootProject);
+
         rootProject.buildGradle().append("""
             allprojects {
                 repositories {
@@ -70,13 +73,11 @@ class BaselineJavaVersionsIntegrationTest {
                 classpath = sourceSets.main.runtimeClasspath
             }
             """);
-        rootProject
-                .buildGradle()
-                .plugins()
-                .add("java")
-                .add("com.palantir.baseline-java-versions")
-                .add("com.palantir.jdks.latest");
 
+        rootProject.buildGradle().plugins().add("java");
+        rootProject.buildGradle().plugins().add("com.palantir.baseline-java-versions");
+
+        subProject.buildGradle().plugins().add("java");
         subProject.buildGradle().append("""
             tasks.register('printJavaVersionExtension') {
                 def extension = project.extensions.javaVersion
@@ -89,7 +90,6 @@ class BaselineJavaVersionsIntegrationTest {
                 }
             }
             """);
-        subProject.buildGradle().plugins().add("java");
     }
 
     @Nested

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineModuleJvmArgsIntegrationTest.java
@@ -18,6 +18,7 @@ package com.palantir.baseline;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.baseline.gradlejdks.InheritGradleJdks;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
@@ -42,6 +43,16 @@ class BaselineModuleJvmArgsIntegrationTest {
 
     @BeforeEach
     void beforeEach(RootProject rootProject) {
+        InheritGradleJdks.beforeEach(rootProject);
+
+        rootProject
+                .buildGradle()
+                .plugins()
+                .add("java-library")
+                .add("application")
+                .add("com.palantir.baseline-java-versions")
+                .add("com.palantir.baseline-module-jvm-args");
+
         rootProject.buildGradle().append("""
             application {
                 mainClass = 'com.Example'
@@ -60,13 +71,6 @@ class BaselineModuleJvmArgsIntegrationTest {
                 }
             }
             """);
-        rootProject
-                .buildGradle()
-                .plugins()
-                .add("java-library")
-                .add("application")
-                .add("com.palantir.baseline-java-versions")
-                .add("com.palantir.baseline-module-jvm-args");
     }
 
     @Nested

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/gradlejdks/InheritGradleJdks.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/gradlejdks/InheritGradleJdks.java
@@ -29,6 +29,9 @@ public final class InheritGradleJdks {
     /// JDK info in `gradle/jdks` of gradle-baseline itself.
     /// Ideally this would be a Junit 5 extension (`BeforeEachCallback`) - but no way to get the RootProject from
     /// the gradle-plugin-testing ParameterResolver :(
+    /// This approach has downsides - DO NOT COPY AND PASTE IT ELSEWHERE. See the info at
+    ///    https://github.com/palantir/gradle-baseline/pull/3379#:~:text=Possible%20downsides
+    /// about what we should eventually do instead.
     public static void beforeEach(RootProject rootProject) {
         rootProject.gradlePropertiesFile().appendProperty("palantir.jdk.setup.enabled", "true");
         rootProject.settingsGradle().plugins().add("com.palantir.jdks.settings");

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/gradlejdks/InheritGradleJdks.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/gradlejdks/InheritGradleJdks.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.baseline.gradlejdks;
+
+import com.palantir.gradle.testing.files.Directory;
+import com.palantir.gradle.testing.project.RootProject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class InheritGradleJdks {
+
+    // Ideally this would be a Junit 5 extension (BeforeEachCallback) - but no way to get the RootProjet from the
+    // gradle-plugin-testing ParameterResolver :(
+    public static void beforeEach(RootProject rootProject) {
+        rootProject.gradlePropertiesFile().appendProperty("palantir.jdk.setup.enabled", "true");
+        rootProject.settingsGradle().plugins().add("com.palantir.jdks.settings");
+        rootProject.buildGradle().plugins().add("com.palantir.jdks");
+        Directory jdksDir = rootProject.directory("gradle").createDirectories().directory("jdks");
+
+        try {
+            Files.createSymbolicLink(jdksDir.path(), Path.of("../gradle/jdks").toAbsolutePath());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private InheritGradleJdks() {}
+}

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/gradlejdks/InheritGradleJdks.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/gradlejdks/InheritGradleJdks.java
@@ -25,12 +25,15 @@ import java.nio.file.Path;
 
 public final class InheritGradleJdks {
 
-    // Ideally this would be a Junit 5 extension (BeforeEachCallback) - but no way to get the RootProjet from the
-    // gradle-plugin-testing ParameterResolver :(
+    /// Sets up gradle-jdks to provide JDKs inside test Gradle invocations, which are discovered from the
+    /// JDK info in `gradle/jdks` of gradle-baseline itself.
+    /// Ideally this would be a Junit 5 extension (`BeforeEachCallback`) - but no way to get the RootProject from
+    /// the gradle-plugin-testing ParameterResolver :(
     public static void beforeEach(RootProject rootProject) {
         rootProject.gradlePropertiesFile().appendProperty("palantir.jdk.setup.enabled", "true");
         rootProject.settingsGradle().plugins().add("com.palantir.jdks.settings");
         rootProject.buildGradle().plugins().add("com.palantir.jdks");
+
         Directory jdksDir = rootProject.directory("gradle").createDirectories().directory("jdks");
 
         try {

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/plugins/BaselineImmutablesTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/plugins/BaselineImmutablesTest.java
@@ -18,11 +18,13 @@ package com.palantir.baseline.plugins;
 
 import static com.palantir.gradle.testing.assertion.GradlePluginTestAssertions.assertThat;
 
+import com.palantir.baseline.gradlejdks.InheritGradleJdks;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,12 +37,14 @@ class BaselineImmutablesTest {
 
     @BeforeEach
     void setup(RootProject rootProject) {
+        InheritGradleJdks.beforeEach(rootProject);
+
         rootProject
                 .buildGradle()
                 .plugins()
                 .add("org.unbroken-dome.test-sets")
                 .add("com.palantir.baseline-immutables")
-                .add("com.palantir.jdks.latest")
+                .add("com.palantir.baseline-java-versions")
                 .add("java-library");
 
         rootProject.buildGradle().append("""
@@ -119,8 +123,6 @@ class BaselineImmutablesTest {
     @MethodSource("javaVersions")
     void compatible_with_java(int javaVersion, GradleInvoker gradle, RootProject rootProject) {
         // Context: https://github.com/immutables/immutables/issues/1379#issuecomment-1254224741
-
-        rootProject.buildGradle().plugins().add("com.palantir.baseline-java-versions");
 
         rootProject.buildGradle().append("""
             tasks.withType(JavaCompile).configureEach({

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/plugins/BaselineImmutablesTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/plugins/BaselineImmutablesTest.java
@@ -92,18 +92,16 @@ class BaselineImmutablesTest {
             }
             """, IMMUTABLES, IMMUTABLES, IMMUTABLES, IMMUTABLES_ANNOTATIONS);
 
-        List.of(
+        Stream.of(
                         "main",
                         "hasImmutables",
                         "doesNotHaveImmutables",
                         "hasImmutablesAddedInAfterEvaluate",
                         "onlyHasImmutablesAnnotations")
                 .forEach(sourceSet -> {
-                    rootProject
-                            .file(String.format("src/%s/java/Foo.java", sourceSet))
-                            .overwrite("""
-                                public class Foo {}
-                                """);
+                    rootProject.sourceSet(sourceSet).java().writeClass("""
+                        public class Foo {}
+                        """);
                 });
 
         InvocationResult result = gradle.withArgs("compileAll").buildsSuccessfully();

--- a/gradle/jdks/11/linux-glibc/aarch64/download-url
+++ b/gradle/jdks/11/linux-glibc/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-linux-aarch64.tar.gz

--- a/gradle/jdks/11/linux-glibc/aarch64/local-path
+++ b/gradle/jdks/11/linux-glibc/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1-glibc

--- a/gradle/jdks/11/linux-glibc/x86-64/download-url
+++ b/gradle/jdks/11/linux-glibc/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-linux-x64.tar.gz

--- a/gradle/jdks/11/linux-glibc/x86-64/local-path
+++ b/gradle/jdks/11/linux-glibc/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1-glibc

--- a/gradle/jdks/11/linux-glibc/x86/download-url
+++ b/gradle/jdks/11/linux-glibc/x86/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-linux-i386.tar.gz

--- a/gradle/jdks/11/linux-glibc/x86/local-path
+++ b/gradle/jdks/11/linux-glibc/x86/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1-glibc

--- a/gradle/jdks/11/linux-musl/aarch64/download-url
+++ b/gradle/jdks/11/linux-musl/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-alpine-linux-aarch64.tar.gz

--- a/gradle/jdks/11/linux-musl/aarch64/local-path
+++ b/gradle/jdks/11/linux-musl/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1-musl

--- a/gradle/jdks/11/linux-musl/x86-64/download-url
+++ b/gradle/jdks/11/linux-musl/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-alpine-linux-x64.tar.gz

--- a/gradle/jdks/11/linux-musl/x86-64/local-path
+++ b/gradle/jdks/11/linux-musl/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1-musl

--- a/gradle/jdks/11/macos/aarch64/download-url
+++ b/gradle/jdks/11/macos/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-macosx-aarch64.tar.gz

--- a/gradle/jdks/11/macos/aarch64/local-path
+++ b/gradle/jdks/11/macos/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1

--- a/gradle/jdks/11/macos/x86-64/download-url
+++ b/gradle/jdks/11/macos/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-macosx-x64.tar.gz

--- a/gradle/jdks/11/macos/x86-64/local-path
+++ b/gradle/jdks/11/macos/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1

--- a/gradle/jdks/11/windows/x86-64/download-url
+++ b/gradle/jdks/11/windows/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-windows-x64-jdk.zip

--- a/gradle/jdks/11/windows/x86-64/local-path
+++ b/gradle/jdks/11/windows/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1

--- a/gradle/jdks/11/windows/x86/download-url
+++ b/gradle/jdks/11/windows/x86/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.29.7.1/amazon-corretto-11.0.29.7.1-windows-i386-jdk.zip

--- a/gradle/jdks/11/windows/x86/local-path
+++ b/gradle/jdks/11/windows/x86/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.29.7.1

--- a/versions.lock
+++ b/versions.lock
@@ -20,7 +20,7 @@ com.fasterxml.jackson.core:jackson-annotations:2.20 (11 constraints: 7fb8f5b6)
 
 com.fasterxml.jackson.core:jackson-core:2.20.0 (6 constraints: 797eb797)
 
-com.fasterxml.jackson.core:jackson-databind:2.20.0 (13 constraints: 6a0d9192)
+com.fasterxml.jackson.core:jackson-databind:2.20.0 (12 constraints: 88f84eb9)
 
 com.fasterxml.jackson.datatype:jackson-datatype-guava:2.20.0 (2 constraints: 73280293)
 
@@ -76,7 +76,7 @@ com.palantir.gradle.utils:exec:0.21.0 (1 constraints: 2e0f5e76)
 
 com.palantir.gradle.utils:lazily-configured-mapping:0.21.0 (2 constraints: c314d4bc)
 
-com.palantir.gradle.utils:platform:0.21.0 (6 constraints: 3c71c6ce)
+com.palantir.gradle.utils:platform:0.21.0 (5 constraints: 675c30e5)
 
 com.palantir.gradle.utils:providers:0.21.0 (1 constraints: 6e0dd731)
 
@@ -230,7 +230,7 @@ com.palantir.conjure.java.api:test-utils:2.65.0 (1 constraints: 3f05523b)
 
 com.palantir.conjure.java.runtime:conjure-java-annotations:8.27.0 (1 constraints: 43056c3b)
 
-com.palantir.gradle.jdks:gradle-jdks:0.69.0 (2 constraints: 1e1a7113)
+com.palantir.gradle.jdks:gradle-jdks:0.69.0 (1 constraints: 4105523b)
 
 com.palantir.gradle.jdks:gradle-jdks-distributions:0.69.0 (2 constraints: 1621159d)
 
@@ -243,8 +243,6 @@ com.palantir.gradle.jdks:gradle-jdks-settings:0.69.0 (1 constraints: 4105523b)
 com.palantir.gradle.jdks:gradle-jdks-setup:0.69.0 (1 constraints: 980f6392)
 
 com.palantir.gradle.jdks:gradle-jdks-setup-common:0.69.0 (3 constraints: 2c3be246)
-
-com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.24.0 (1 constraints: 3805333b)
 
 com.palantir.gradle.plugintesting:configuration-cache-spec:0.41.0 (1 constraints: 3705323b)
 

--- a/versions.lock
+++ b/versions.lock
@@ -238,6 +238,8 @@ com.palantir.gradle.jdks:gradle-jdks-enablement:0.69.0 (1 constraints: 980f6392)
 
 com.palantir.gradle.jdks:gradle-jdks-json:0.69.0 (1 constraints: 980f6392)
 
+com.palantir.gradle.jdks:gradle-jdks-settings:0.69.0 (1 constraints: 4105523b)
+
 com.palantir.gradle.jdks:gradle-jdks-setup:0.69.0 (1 constraints: 980f6392)
 
 com.palantir.gradle.jdks:gradle-jdks-setup-common:0.69.0 (3 constraints: 2c3be246)

--- a/versions.props
+++ b/versions.props
@@ -47,8 +47,8 @@ org.junit.vintage:* = 6.0.1
 org.junit.platform:* = 6.0.1
 org.mockito:* = 5.20.0
 com.palantir.sls-packaging:gradle-sls-packaging = 7.85.0
-com.palantir.gradle.jdks:gradle-jdks = 0.69.0
-com.palantir.gradle.jdkslatest:gradle-jdks-latest = 0.24.0
+com.palantir.gradle.jdks:* = 0.69.0
+com.palantir.gradle.jdkslatest:* = 0.24.0
 org.unbroken-dome.gradle-plugins:gradle-testsets-plugin = 4.1.0
 
 # dependency-upgrader:OFF

--- a/versions.props
+++ b/versions.props
@@ -48,7 +48,6 @@ org.junit.platform:* = 6.0.1
 org.mockito:* = 5.20.0
 com.palantir.sls-packaging:gradle-sls-packaging = 7.85.0
 com.palantir.gradle.jdks:* = 0.69.0
-com.palantir.gradle.jdkslatest:* = 0.24.0
 org.unbroken-dome.gradle-plugins:gradle-testsets-plugin = 4.1.0
 
 # dependency-upgrader:OFF


### PR DESCRIPTION
## Before this PR
Currently, the baseline tests that deal with java compilation and JDKs require certain JDKs to be installed on the machine they're running on. In #3342, I want to start using 21 JDKs. However, the public circle image does not have 21 JDKs, meaning the tests fail.

## After this PR
We configure the tests to run with `gradle-jdks`, which will tell Gradle where the appropriate JDKs are.

The nifty part of the approach is that the tests actually inherit the metadata about the JDKs from the enclosing repo, rather than having to run code in each and every test, via the use of a symlink of the `gradle/jdks` directory.

## Possible downsides?
As discussed with @felixdesouza, this is actually probably not optimal. Inheriting the JDKs from the enclosing repo has a couple of problems:
1. We have to manually list the JDKs required by the tests in the enclosing repo, which is an extra bit of [connascence](https://en.wikipedia.org/wiki/Connascence) that shouldn't be necessary.
2. The versions of gradle-jdks used in the tests and the enclosing repo are tied together. Every time we've done something like this before, we've regretted it as it has stopped upgrades progressing.

The ideal would probably be something built in to the `gradle-plugin-testing` framework, where each test setup has gradle-jdks applied, then sets up the jdks, then runs the `gradle/gradle-jdks-setup.sh` setup script before the first (or perhaps every) Gradle invocation. This would be fully decoupled and the most "realistic" solution we could achieve without forgoing testkit and running `./gradlew` directly. It may have a performance cost though.

That said, even with these downsides, I think this is a strict improvement and we should merge it in, as it will unblock reviewing the next part of #3342.