### PR TITLE
Stop adding suppressions as autofixes in `ImmutablesStyle`

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesStyle.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ImmutablesStyle.java
@@ -75,10 +75,7 @@ public final class ImmutablesStyle extends BugChecker implements BugChecker.Clas
         if (ASTHelpers.enclosingClass(ASTHelpers.getSymbol(tree)) == null) {
             // Top level class, we cannot create new files with suggested fixes, nor should we create
             // additional top-level classes.
-            return buildDescription(tree)
-                    .addFix(SuggestedFixes.addSuppressWarnings(
-                            state, canonicalName(), "Automatically suppressed to unblock enforcement in new code"))
-                    .build();
+            return buildDescription(tree).build();
         }
         SuggestedFix.Builder fix = SuggestedFix.builder();
         String qualifiedTarget = SuggestedFixes.qualifyType(state, fix, Target.class.getName());

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesStyleTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/ImmutablesStyleTest.java
@@ -32,49 +32,6 @@ public class ImmutablesStyleTest {
     }
 
     @Test
-    public void fixInlineAnnotation_topLevel() {
-        fix().addInputLines(
-                        "Person.java",
-                        "import org.immutables.value.Value;",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "public interface Person {}")
-                .addOutputLines(
-                        "Person.java",
-                        "import org.immutables.value.Value;",
-                        "@SuppressWarnings(\"ImmutablesStyle\")",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "public interface Person {}")
-                .doTest();
-    }
-
-    @Test
-    public void fixInlineAnnotation_enclosed() {
-        fix().addInputLines(
-                        "Enclosing.java",
-                        "import org.immutables.value.Value;",
-                        "public class Enclosing {",
-                        "  @Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "  public interface Person {}",
-                        "}")
-                .addOutputLines(
-                        "Enclosing.java",
-                        "import java.lang.annotation.ElementType;",
-                        "import java.lang.annotation.Retention;",
-                        "import java.lang.annotation.RetentionPolicy;",
-                        "import java.lang.annotation.Target;",
-                        "import org.immutables.value.Value;",
-                        "public class Enclosing {",
-                        "  @Target(ElementType.TYPE)",
-                        "  @Retention(RetentionPolicy.SOURCE)",
-                        "  @Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "  @interface PersonStyle {}",
-                        "  @PersonStyle",
-                        "  public interface Person {}",
-                        "}")
-                .doTest();
-    }
-
-    @Test
     public void testMetaAnnotation_defaultRetention() {
         helper().addSourceLines(
                         "MyMetaAnnotation.java",
@@ -86,30 +43,6 @@ public class ImmutablesStyleTest {
                         "// BUG: Diagnostic contains: ImmutablesStyle",
                         "public @interface MyMetaAnnotation {}")
                 .addSourceLines("Person.java", "@MyMetaAnnotation", "public interface Person {}")
-                .doTest();
-    }
-
-    @Test
-    public void fixMetaAnnotation_defaultRetention() {
-        fix().addInputLines(
-                        "MyMetaAnnotation.java",
-                        "import java.lang.annotation.ElementType;",
-                        "import java.lang.annotation.Target;",
-                        "import org.immutables.value.Value;",
-                        "@Target({ElementType.PACKAGE, ElementType.TYPE})\n",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)\n",
-                        "public @interface MyMetaAnnotation {}")
-                .addOutputLines(
-                        "MyMetaAnnotation.java",
-                        "import java.lang.annotation.ElementType;",
-                        "import java.lang.annotation.Retention;",
-                        "import java.lang.annotation.RetentionPolicy;",
-                        "import java.lang.annotation.Target;",
-                        "import org.immutables.value.Value;",
-                        "@Retention(RetentionPolicy.SOURCE)",
-                        "@Target({ElementType.PACKAGE, ElementType.TYPE})\n",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)\n",
-                        "public @interface MyMetaAnnotation {}")
                 .doTest();
     }
 
@@ -132,33 +65,6 @@ public class ImmutablesStyleTest {
     }
 
     @Test
-    public void fixMetaAnnotation_classRetention() {
-        fix().addInputLines(
-                        "MyMetaAnnotation.java",
-                        "import java.lang.annotation.ElementType;",
-                        "import java.lang.annotation.Retention;",
-                        "import java.lang.annotation.RetentionPolicy;",
-                        "import java.lang.annotation.Target;",
-                        "import org.immutables.value.Value;",
-                        "@Target({ElementType.PACKAGE, ElementType.TYPE})",
-                        "@Retention(RetentionPolicy.CLASS)",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "public @interface MyMetaAnnotation {}")
-                .addOutputLines(
-                        "MyMetaAnnotation.java",
-                        "import java.lang.annotation.ElementType;",
-                        "import java.lang.annotation.Retention;",
-                        "import java.lang.annotation.RetentionPolicy;",
-                        "import java.lang.annotation.Target;",
-                        "import org.immutables.value.Value;",
-                        "@Target({ElementType.PACKAGE, ElementType.TYPE})",
-                        "@Retention(RetentionPolicy.SOURCE)",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "public @interface MyMetaAnnotation {}")
-                .doTest();
-    }
-
-    @Test
     public void testMetaAnnotation_runtimeRetention() {
         helper().addSourceLines(
                         "MyMetaAnnotation.java",
@@ -173,33 +79,6 @@ public class ImmutablesStyleTest {
                         "// BUG: Diagnostic contains: ImmutablesStyle",
                         "public @interface MyMetaAnnotation {}")
                 .addSourceLines("Person.java", "@MyMetaAnnotation", "public interface Person {}")
-                .doTest();
-    }
-
-    @Test
-    public void fixMetaAnnotation_runtimeRetention() {
-        fix().addInputLines(
-                        "MyMetaAnnotation.java",
-                        "import java.lang.annotation.ElementType;",
-                        "import java.lang.annotation.Retention;",
-                        "import java.lang.annotation.RetentionPolicy;",
-                        "import java.lang.annotation.Target;",
-                        "import org.immutables.value.Value;",
-                        "@Target({ElementType.PACKAGE, ElementType.TYPE})",
-                        "@Retention(value = RetentionPolicy.RUNTIME)",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "public @interface MyMetaAnnotation {}")
-                .addOutputLines(
-                        "MyMetaAnnotation.java",
-                        "import java.lang.annotation.ElementType;",
-                        "import java.lang.annotation.Retention;",
-                        "import java.lang.annotation.RetentionPolicy;",
-                        "import java.lang.annotation.Target;",
-                        "import org.immutables.value.Value;",
-                        "@Target({ElementType.PACKAGE, ElementType.TYPE})",
-                        "@Retention(value = RetentionPolicy.SOURCE)",
-                        "@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)",
-                        "public @interface MyMetaAnnotation {}")
                 .doTest();
     }
 
@@ -229,9 +108,5 @@ public class ImmutablesStyleTest {
 
     private CompilationTestHelper helper() {
         return CompilationTestHelper.newInstance(ImmutablesStyle.class, getClass());
-    }
-
-    private RefactoringValidator fix() {
-        return RefactoringValidator.of(ImmutablesStyle.class, getClass());
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Using suppressible-error-prone with `-PerrorProneRemoveUnused` causes

```
@SuppressWarnings("ImmutablesStyle")
public abstract class SomeTask {
                          ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.41.0
     BugPattern: ImmutablesStyle
     Stack Trace:
     java.lang.IllegalArgumentException: Couldn't find a node to attach @SuppressWarnings.
  	at com.google.errorprone.fixes.SuggestedFixes.addSuppressWarnings(SuggestedFixes.java:964)
```

Error is caused by
1. remove unused mode ignores suppressions
2. the autofix for ImmutablesStyle adds a suppression
3. since the suppression already exists, error-prone concludes "nothing was done" and mistakenly errors out "couldn't suppress!!!"

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Stop doing suppressions as autofixes. Let suppressible-error-prone do suppressions. 

==COMMIT_MSG==
Stop adding suppressions as autofixes in `ImmutablesStyle`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

