### PR TITLE
StrictUnusedVariable should respect -XoptIgnoreSuppressionAnnotations; @SuppressWarnings("UnusedVariable") no longer suppresses StrictUnusedVariable

### DIFF
--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -67,10 +67,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.UnusedVariable;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
-import com.google.errorprone.matchers.ChildMultiMatcher.MatchType;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
@@ -95,7 +92,6 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.VariableTree;
@@ -132,6 +128,7 @@ import javax.lang.model.element.Name;
         linkType = BugPattern.LinkType.CUSTOM,
         summary = "Unused.",
         severity = ERROR,
+        altNames = {"unused"},
         documentSuppression = false)
 public final class StrictUnusedVariable extends BugChecker implements BugChecker.CompilationUnitTreeMatcher {
     private static final ImmutableSet<String> EXEMPT_PREFIXES = ImmutableSet.of("_");
@@ -164,21 +161,6 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             "TAG");
     private static final String UNUSED = "unused";
 
-    private static final Matcher<Tree> ALTERNATIVE_SUPPRESSED = Matchers.allOf(
-            // Matchers.annotations will throw given a tree that doesn't support annotations, so we must enumerate
-            // supported types.
-            Matchers.kindAnyOf(Set.of(
-                    Kind.CLASS, Kind.VARIABLE, Kind.METHOD, Kind.ANNOTATED_TYPE, Kind.PACKAGE, Kind.COMPILATION_UNIT)),
-            Matchers.annotations(
-                    MatchType.AT_LEAST_ONE,
-                    Matchers.allOf(
-                            Matchers.isType("java.lang.SuppressWarnings"),
-                            Matchers.hasArgumentWithValue(
-                                    "value",
-                                    Matchers.anyOf(
-                                            Matchers.stringLiteral("UnusedVariable"),
-                                            Matchers.stringLiteral(UNUSED))))));
-
     @Override
     public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
         // We will skip reporting on the whole compilation if there are any native methods found.
@@ -207,7 +189,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
         // appropriate fixes for them.
         ListMultimap<Symbol, TreePath> usageSites = variableFinder.usageSites;
 
-        FilterUsedVariables filterUsedVariables = new FilterUsedVariables(unusedElements, usageSites);
+        FilterUsedVariables filterUsedVariables = new FilterUsedVariables(unusedElements, usageSites, state);
         filterUsedVariables.scan(state.getPath(), null);
 
         // Keeps track of whether a symbol was _ever_ used (between reassignments).
@@ -294,14 +276,6 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                     .addFix(constructUsedVariableSuggestedFix(usageSites, state))
                     .build());
         });
-    }
-
-    @Override
-    public boolean isSuppressed(Tree tree, VisitorState state) {
-        if (state.errorProneOptions().isIgnoreSuppressionAnnotations()) {
-            return false;
-        }
-        return super.isSuppressed(tree, state) || ALTERNATIVE_SUPPRESSED.matches(tree, state);
     }
 
     private static SuggestedFix constructUsedVariableSuggestedFix(List<TreePath> usagePaths, VisitorState state) {
@@ -682,7 +656,7 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
                 .anyMatch(prefix -> Ascii.toLowerCase(name.toString()).startsWith(prefix));
     }
 
-    private final class VariableFinder extends TreePathScanner<Void, Void> {
+    private final class VariableFinder extends SuppressibleTreePathScanner<Void, Void> {
         private final Map<Symbol, TreePath> unusedElements = new HashMap<>();
 
         private final Set<Symbol> onlyCheckForReassignments = new HashSet<>();
@@ -691,18 +665,13 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
         private final Map<Symbol, VariableTree> exemptedVariables = new HashMap<>();
 
-        private final VisitorState state;
-
         private VariableFinder(VisitorState state) {
-            this.state = state;
+            super(state);
         }
 
         @Override
         @SuppressWarnings("SwitchStatementDefaultCase")
         public Void visitVariable(VariableTree variableTree, Void unused) {
-            if (isSuppressed(variableTree, state)) {
-                return null;
-            }
             Symbol.VarSymbol symbol = getSymbol(variableTree);
             if (symbol == null) {
                 return null;
@@ -777,9 +746,6 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
         @Override
         public Void visitClass(ClassTree tree, Void unused) {
-            if (isSuppressed(tree, state)) {
-                return null;
-            }
             if (EXEMPTING_SUPER_TYPES.stream()
                     .anyMatch(t ->
                             isSubtype(getType(tree), Suppliers.typeFromString(t).get(state), state))) {
@@ -794,14 +760,9 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
             scan(node.getParameters(), null);
             return null;
         }
-
-        @Override
-        public Void visitMethod(MethodTree tree, Void unused) {
-            return isSuppressed(tree, state) ? null : super.visitMethod(tree, null);
-        }
     }
 
-    private static final class FilterUsedVariables extends TreePathScanner<Void, Void> {
+    private final class FilterUsedVariables extends SuppressibleTreePathScanner<Void, Void> {
         private boolean leftHandSideAssignment = false;
         // When this greater than zero, the usage of identifiers are real.
         private int inArrayAccess = 0;
@@ -827,7 +788,9 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
         private final ImmutableMap<Symbol, TreePath> declarationSites;
 
-        private FilterUsedVariables(Map<Symbol, TreePath> unusedElements, ListMultimap<Symbol, TreePath> usageSites) {
+        private FilterUsedVariables(
+                Map<Symbol, TreePath> unusedElements, ListMultimap<Symbol, TreePath> usageSites, VisitorState state) {
+            super(state);
             this.unusedElements = unusedElements;
             this.usageSites = usageSites;
             this.declarationSites = ImmutableMap.copyOf(unusedElements);

--- a/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
+++ b/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java
@@ -298,6 +298,9 @@ public final class StrictUnusedVariable extends BugChecker implements BugChecker
 
     @Override
     public boolean isSuppressed(Tree tree, VisitorState state) {
+        if (state.errorProneOptions().isIgnoreSuppressionAnnotations()) {
+            return false;
+        }
         return super.isSuppressed(tree, state) || ALTERNATIVE_SUPPRESSED.matches(tree, state);
     }
 

--- a/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
+++ b/baseline-error-prone/src/test/java/com/palantir/baseline/errorprone/StrictUnusedVariableTest.java
@@ -328,9 +328,8 @@ public class StrictUnusedVariableTest {
                         "Test.java",
                         "class Test {",
                         "  public static void a(@SuppressWarnings(\"StrictUnusedVariable\") int val) {}",
-                        "  public static void b(@SuppressWarnings(\"UnusedVariable\") int val) {}",
-                        "  public static void c(@SuppressWarnings(\"unused\") int val) {}",
-                        "  public static void d(int _val) {}",
+                        "  public static void b(@SuppressWarnings(\"unused\") int val) {}",
+                        "  public static void c(int _val) {}",
                         "}")
                 .expectUnchanged()
                 .doTest(TestMode.TEXT_MATCH);
@@ -344,11 +343,9 @@ public class StrictUnusedVariableTest {
                         "class Test {",
                         "  @SuppressWarnings(\"StrictUnusedVariable\")",
                         "  public static void a(int val) {}",
-                        "  @SuppressWarnings(\"UnusedVariable\")",
-                        "  public static void b(int val) {}",
                         "  @SuppressWarnings(\"unused\")",
-                        "  public static void c(int val) {}",
-                        "  public static void d(int _val) {}",
+                        "  public static void b(int val) {}",
+                        "  public static void c(int _val) {}",
                         "}")
                 .expectUnchanged()
                 .doTest(TestMode.TEXT_MATCH);
@@ -364,12 +361,8 @@ public class StrictUnusedVariableTest {
                         "  class Test1 {",
                         "    public static void a(int val) {}",
                         "  }",
-                        "  @SuppressWarnings(\"UnusedVariable\")",
-                        "  class Test2 {",
-                        "    public static void a(int val) {}",
-                        "  }",
                         "  @SuppressWarnings(\"unused\")",
-                        "  class Test3 {",
+                        "  class Test2 {",
                         "    public static void a(int val) {}",
                         "  }",
                         "}")


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

1. StrictUnusedVariable opts out of SuppressibleTreePathScanner's suppression mechanism, and checks for suppressions manually. This interferes with suppressible-error-prone's removeUnused mode, which relies on [modifying SuppressibleTreePathScanner](https://github.com/palantir/suppressible-error-prone/blob/develop/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/transform/SuppressibleTreePathScannerClassVisitor.java). 
2. StrictUnusedVariable has a [quirky setup to deal with alt-names](https://github.com/palantir/gradle-baseline/pull/2599), so that`@SuppressWarnings("UnusedVariable")` suppresses it, but `errorProneOpotions.disable("UnusedVariable")` does not disable it. This also interferes with RemoveUnused mode, as it doesn't know `@SuppressWarnings("UnusedVariable")` is a suppression for StrictUnusedVariable

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

1. I think UnusedVariable (from which StrictUnusedVariable is mostly copied from) didn't use SuppressibleTreePathScanner because the class was new at the time (2022), but now we can switch to using SuppressibleTreePathScanner to [get our modifications](https://github.com/palantir/suppressible-error-prone/blob/develop/gradle-suppressible-error-prone/src/main/java/com/palantir/gradle/suppressibleerrorprone/transform/SuppressibleTreePathScannerClassVisitor.java)
2. It is reasonable that `@SuppressWarnings("UnusedVariable")` should only suppress UnusedVariable, `@SuppressWarnings("StrictUnusedVariable")` should only suppress StrictUnusedVariable, and `SuppressWarnings("unused")` is the catch-all suppression for all unused checks (including UnusedMethod). Let's implement this behavior so removeUnused mode can work with StrictUnusedVariable.

==COMMIT_MSG==
StrictUnusedVariable should respect `-XoptIgnoreSuppressionAnnotations`; `@SuppressWarnings("UnusedVariable")` no longer suppresses StrictUnusedVariable
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

