### PR TITLE
Mark `ExplicitDependency` as public

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -170,6 +170,7 @@ public abstract class CheckUnusedDependenciesTask extends DefaultTask {
         }));
     }
 
+    // public because it needs to be able to be accessed by Gradle when Configuration Cache is enabled.
     public record ExplicitDependency(
             String group,
             String name,

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckUnusedDependenciesTask.java
@@ -170,7 +170,7 @@ public abstract class CheckUnusedDependenciesTask extends DefaultTask {
         }));
     }
 
-    protected record ExplicitDependency(
+    public record ExplicitDependency(
             String group,
             String name,
             @Nullable String classifier,


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When configuration cache was enabled for `checkUnusedDepedency` we would get an error of the format: 

```
Could not load the value of field `__explicitDependencies__` of task `:test-security:checkUnusedDependenciesMain` of type `com.palantir.baseline.tasks.CheckUnusedDependenciesTask`.
> Failed to create instance of com.palantir.baseline.tasks.CheckUnusedDependenciesTask$ExplicitDependency with args [com.google.code.findbugs, jsr305, null, jar]
Caused by: java.lang.NoSuchMethodException: com.palantir.baseline.tasks.CheckUnusedDependenciesTask$ExplicitDependency.<init>(java.lang.String,java.lang.String,java.lang.String,java.lang.String)
```

initial thread [here](https://pl.ntr/2yn)

## After this PR
Make `ExplicitDependency` public such that it can be instantiated by gradle. 

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Mark `ExplicitDependency` as public
==COMMIT_MSG==


FLUPs: Add an errorProne for these cases. 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

