### PR TITLE
Introduce an `allJavaVersionsUsed()` method to `javaVersions` extension

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -58,7 +58,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
     public void apply(Project project) {
         @SuppressWarnings({"for-rollout:GradleTypesAsFields", "for-rollout:NonAbstractGradleType"})
         BaselineJavaVersionExtension extension =
-                project.getExtensions().create(EXTENSION_NAME, BaselineJavaVersionExtension.class, project);
+                project.getExtensions().create(EXTENSION_NAME, BaselineJavaVersionExtension.class);
 
         project.getPluginManager().withPlugin("java", unused -> {
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionExtension.java
@@ -16,15 +16,19 @@
 
 package com.palantir.baseline.plugins.javaversions;
 
+import java.util.Set;
 import javax.inject.Inject;
-import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 /**
  * Extension named {@code javaVersion} used to set the
  * target and runtime java versions used for a single project.
  */
-public class BaselineJavaVersionExtension {
+public abstract class BaselineJavaVersionExtension {
 
     private final Property<ChosenJavaVersion> target;
     private final Property<ChosenJavaVersion> runtime;
@@ -32,10 +36,13 @@ public class BaselineJavaVersionExtension {
     private final Property<Boolean> overrideLibraryAutoDetection;
 
     @Inject
-    public BaselineJavaVersionExtension(Project project) {
-        target = project.getObjects().property(ChosenJavaVersion.class);
-        runtime = project.getObjects().property(ChosenJavaVersion.class);
-        overrideLibraryAutoDetection = project.getObjects().property(Boolean.class);
+    protected abstract ObjectFactory getObjectFactory();
+
+    @Inject
+    public BaselineJavaVersionExtension() {
+        target = getObjectFactory().property(ChosenJavaVersion.class);
+        runtime = getObjectFactory().property(ChosenJavaVersion.class);
+        overrideLibraryAutoDetection = getObjectFactory().property(Boolean.class);
 
         target.finalizeValueOnRead();
         runtime.finalizeValueOnRead();
@@ -84,5 +91,15 @@ public class BaselineJavaVersionExtension {
 
     public final void library() {
         overrideLibraryAutoDetection.set(true);
+    }
+
+    public final Provider<Set<JavaLanguageVersion>> allJavaVersionsUsed() {
+        SetProperty<JavaLanguageVersion> allJavaVersionsUsed =
+                getObjectFactory().setProperty(JavaLanguageVersion.class);
+
+        allJavaVersionsUsed.add(target.map(ChosenJavaVersion::javaLanguageVersion));
+        allJavaVersionsUsed.add(runtime.map(ChosenJavaVersion::javaLanguageVersion));
+
+        return allJavaVersionsUsed;
     }
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionsExtension.java
@@ -18,11 +18,15 @@ package com.palantir.baseline.plugins.javaversions;
 
 import com.palantir.gradle.utils.lazilyconfiguredmapping.LazilyConfiguredMapping;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
@@ -30,7 +34,8 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion;
  * Extension named {@code javaVersions} on the root project used to configure all java modules
  * with consistent java toolchains.
  */
-public class BaselineJavaVersionsExtension implements BaselineJavaVersionsExtensionSetters {
+public abstract class BaselineJavaVersionsExtension implements BaselineJavaVersionsExtensionSetters {
+    private final Project rootProject;
     private final Property<JavaLanguageVersion> libraryTarget;
     private final Property<ChosenJavaVersion> distributionTarget;
     private final Property<ChosenJavaVersion> runtime;
@@ -39,11 +44,15 @@ public class BaselineJavaVersionsExtension implements BaselineJavaVersionsExtens
     private final Property<Boolean> setupJdkToolchains;
 
     @Inject
-    public BaselineJavaVersionsExtension(Project project) {
-        this.libraryTarget = project.getObjects().property(JavaLanguageVersion.class);
-        this.distributionTarget = project.getObjects().property(ChosenJavaVersion.class);
-        this.runtime = project.getObjects().property(ChosenJavaVersion.class);
-        this.setupJdkToolchains = project.getObjects().property(Boolean.class);
+    protected abstract ObjectFactory getObjectFactory();
+
+    @Inject
+    public BaselineJavaVersionsExtension(Project rootProject) {
+        this.rootProject = rootProject;
+        this.libraryTarget = getObjectFactory().property(JavaLanguageVersion.class);
+        this.distributionTarget = getObjectFactory().property(ChosenJavaVersion.class);
+        this.runtime = getObjectFactory().property(ChosenJavaVersion.class);
+        this.setupJdkToolchains = getObjectFactory().property(Boolean.class);
         this.setupJdkToolchains.convention(true);
 
         // distribution defaults to the library value
@@ -135,5 +144,24 @@ public class BaselineJavaVersionsExtension implements BaselineJavaVersionsExtens
      */
     public final Property<Boolean> getSetupJdkToolchains() {
         return setupJdkToolchains;
+    }
+
+    public final Provider<Set<JavaLanguageVersion>> allJavaVersionsUsed() {
+        SetProperty<JavaLanguageVersion> allJavaVersionsUsed =
+                getObjectFactory().setProperty(JavaLanguageVersion.class);
+
+        allJavaVersionsUsed.add(libraryTarget);
+        allJavaVersionsUsed.add(distributionTarget.map(ChosenJavaVersion::javaLanguageVersion));
+        allJavaVersionsUsed.add(runtime.map(ChosenJavaVersion::javaLanguageVersion));
+
+        rootProject.allprojects(proj -> {
+            proj.getPluginManager().withPlugin("com.palantir.baseline-java-version", unused -> {
+                BaselineJavaVersionExtension projectVersions =
+                        proj.getExtensions().getByType(BaselineJavaVersionExtension.class);
+                allJavaVersionsUsed.addAll(projectVersions.allJavaVersionsUsed());
+            });
+        });
+
+        return allJavaVersionsUsed;
     }
 }

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -441,6 +441,58 @@ class BaselineJavaVersionIntegrationTest {
         }
     }
 
+    @Nested
+    class AllJavaVersionsUsed {
+        @BeforeEach
+        void beforeEach(RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('printAllJavaVersionsUsed') {
+                    inputs.property('allJavaVersionsUsed', project.extensions.javaVersion.allJavaVersionsUsed())
+                    doLast {
+                        println "allJavaVersionsUsed: ${inputs.properties.allJavaVersionsUsed.stream().sorted().toList()}"
+                    }
+                }
+                """);
+        }
+
+        @Test
+        void gathers_target_and_runtime_values(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                javaVersion {
+                    target = 17
+                    runtime = 21
+                }
+                """);
+
+            InvocationResult result =
+                    gradle.withArgs("printAllJavaVersionsUsed").buildsSuccessfully();
+
+            result.assertThat().output().contains("allJavaVersionsUsed: [17, 21]");
+        }
+
+        @Test
+        void propagates_task_dependencies(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                    import com.palantir.baseline.plugins.javaversions.ChosenJavaVersion
+
+                    def generateTarget = tasks.register('generateTarget')
+                    def generateRuntime = tasks.register('generateRuntime')
+
+                    javaVersion {
+                        target().set(generateTarget.map { ChosenJavaVersion.of(17) })
+                        runtime().set(generateRuntime.map { ChosenJavaVersion.of(21) })
+                    }
+                """);
+
+            InvocationResult result =
+                    gradle.withArgs("printAllJavaVersionsUsed").buildsSuccessfully();
+
+            result.assertThat().output().contains("allJavaVersionsUsed: [17, 21]");
+            result.assertThat().task(":generateTarget").upToDate();
+            result.assertThat().task(":generateRuntime").upToDate();
+        }
+    }
+
     private static final int BYTECODE_IDENTIFIER = 0xCAFEBABE;
 
     // See http://illegalargumentexception.blogspot.com/2009/07/java-finding-class-versions.html

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -267,6 +267,101 @@ class BaselineJavaVersionsIntegrationTest {
         }
     }
 
+    @Nested
+    class AllJavaVersionsUsed {
+        @BeforeEach
+        void beforeEach(RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('printAllJavaVersionsUsed') {
+                    inputs.property('allJavaVersionsUsed', project.extensions.javaVersions.allJavaVersionsUsed())
+                    doLast {
+                        println "allJavaVersionsUsed: ${inputs.properties.allJavaVersionsUsed.stream().sorted().toList()}"
+                    }
+                }
+                """);
+        }
+
+        @Test
+        void gathers_values_from_top_level_javaVersions_extension(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+                    distributionTarget = 17
+                    runtime = 21
+                }
+                """);
+
+            InvocationResult result =
+                    gradle.withArgs("printAllJavaVersionsUsed").buildsSuccessfully();
+
+            result.assertThat().output().contains("allJavaVersionsUsed: [11, 17, 21]");
+        }
+
+        @Test
+        void gathers_values_from_javaVersion_extensions_in_all_projects_as_well(
+                GradleInvoker gradle, RootProject rootProject, SubProject subProject) {
+
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+                    distributionTarget = 17
+                    runtime = 21
+                }
+                """);
+
+            subProject.buildGradle().append("""
+                javaVersion {
+                    target = 23
+                    runtime = 24
+                }
+                """);
+
+            InvocationResult result =
+                    gradle.withArgs("printAllJavaVersionsUsed").buildsSuccessfully();
+
+            result.assertThat().output().contains("allJavaVersionsUsed: [11, 17, 21, 23, 24]");
+        }
+
+        @Test
+        void propagates_task_dependencies(GradleInvoker gradle, RootProject rootProject, SubProject subProject) {
+            rootProject.buildGradle().append("""
+                import com.palantir.baseline.plugins.javaversions.ChosenJavaVersion
+
+                def generateLibraryTarget = tasks.register('generateLibraryTarget')
+                def generateDistributionTarget = tasks.register('generateDistributionTarget')
+                def generateRuntime = tasks.register('generateRuntime')
+
+                javaVersions {
+                    libraryTarget().set(generateLibraryTarget.map { JavaLanguageVersion.of(11) })
+                    distributionTarget().set(generateDistributionTarget.map { ChosenJavaVersion.of(17) })
+                    runtime().set(generateRuntime.map { ChosenJavaVersion.of(21) })
+                }
+                """);
+
+            subProject.buildGradle().append("""
+                    import com.palantir.baseline.plugins.javaversions.ChosenJavaVersion
+
+                    def generateTarget = tasks.register('generateTarget')
+                    def generateRuntime = tasks.register('generateRuntime')
+
+                    javaVersion {
+                        target().set(generateTarget.map { ChosenJavaVersion.of(23) })
+                        runtime().set(generateRuntime.map { ChosenJavaVersion.of(24) })
+                    }
+                """);
+
+            InvocationResult result =
+                    gradle.withArgs("printAllJavaVersionsUsed").buildsSuccessfully();
+
+            result.assertThat().output().contains("allJavaVersionsUsed: [11, 17, 21, 23, 24]");
+            result.assertThat().task(":generateLibraryTarget").upToDate();
+            result.assertThat().task(":generateDistributionTarget").upToDate();
+            result.assertThat().task(":generateRuntime").upToDate();
+            result.assertThat().task(":subProject:generateTarget").upToDate();
+            result.assertThat().task(":subProject:generateRuntime").upToDate();
+        }
+    }
+
     private static final int BYTECODE_IDENTIFIER = 0xCAFEBABE;
 
     // See http://illegalargumentexception.blogspot.com/2009/07/java-finding-class-versions.html


### PR DESCRIPTION
## Before this PR
`gradle-jdks` needs to know what JDKs are being used in a build to work out which JDKs it should actually set up. It currently does this by [deeply inspecting all the values inside the `javaVersions` and `javaVersion` extensions](https://github.com/palantir/gradle-jdks/blob/19d1f68fc8b933df9536d00b5d1641ade134a830/gradle-jdks/src/main/java/com/palantir/gradle/jdks/ToolchainsPlugin.java#L83-L97).

This is problematic, as [I'm about to add a `javaCompiler` option to `javaVersions`](https://github.com/palantir/gradle-baseline/pull/3342) it will need to know about. Currently, `gradle-jdks` is tightly coupled as it needs to know the internal structure of `baseline-java-versions`. When we come to add `javaCompiler`, if we set it to a JDK not already in used in a project (eg `javaCompiler = 25`) then `gradle-jdks` will not know to install it without it's own logic being updated.

If the structure of `baseline-java-versions` ever changes again, `gradle-jdks` will need updating, which is grim.

## After this PR
==COMMIT_MSG==
Introduce an `allJavaVersionsUsed()` method to `javaVersions` extension
==COMMIT_MSG==

`gradle-jdks` can now use this method instead and avoid the tight coupling. When we add `javaCompiler`, it will get the new JDK automatically with no code changes.

`gradle-jdks` PR that uses this new method: https://github.com/palantir/gradle-jdks/pull/622

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

