### PR TITLE
Disable RequireExplicitNullMarking

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineNullAway.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineNullAway.java
@@ -70,6 +70,9 @@ public final class BaselineNullAway implements Plugin<Project> {
             @Override
             public void execute(ErrorProneOptions options) {
                 options.option("NullAway:AnnotatedPackages", String.join(",", DEFAULT_ANNOTATED_PACKAGES));
+                // 2025-12-04: Disabled to avoid excessive logs
+                // See https://github.com/uber/NullAway/issues/1363
+                options.disable("RequireExplicitNullMarking");
                 // Relax some checks for test code
                 if (options.getCompilingTestOnlyCode().get()) {
                     // NullAway has some poor interactions with mockito and

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -401,41 +401,4 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         where:
         checkConfigurationMethod << CheckConfigurationMethod.values()
     }
-
-    def 'check RequireExplicitNullMarking is disabled by default to avoid excessive logs'() {
-        when:
-        buildFile << '''
-            plugins {
-                id 'java'
-                id 'com.palantir.baseline-error-prone'
-                id 'com.palantir.baseline-null-away'
-            }
-            repositories {
-                mavenLocal()
-                mavenCentral()
-            }
-            dependencies {
-                compileOnly 'org.jspecify:jspecify:1.0.0'
-            }
-        '''.stripIndent()
-
-        // This file would trigger RequireExplicitNullMarking if it wasn't disabled
-        // because it lacks @NullMarked or @NullUnmarked annotations
-        file('src/main/java/com/palantir/test/Test.java') << '''
-        package com.palantir.test;
-        public class Test {
-            void test() {
-                String s = "hello";
-                System.out.println(s);
-            }
-        }
-        '''.stripIndent()
-
-        then:
-        // The build should succeed because the check is disabled
-        BuildResult result = with('compileJava').build()
-        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
-        // The check should be explicitly disabled, so we shouldn't see warnings
-        !result.output.contains("[RequireExplicitNullMarking]")
-    }
 }

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineErrorProneIntegrationTest.groovy
@@ -401,4 +401,41 @@ class BaselineErrorProneIntegrationTest extends AbstractPluginTest {
         where:
         checkConfigurationMethod << CheckConfigurationMethod.values()
     }
+
+    def 'check RequireExplicitNullMarking is disabled by default to avoid excessive logs'() {
+        when:
+        buildFile << '''
+            plugins {
+                id 'java'
+                id 'com.palantir.baseline-error-prone'
+                id 'com.palantir.baseline-null-away'
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+            }
+            dependencies {
+                compileOnly 'org.jspecify:jspecify:1.0.0'
+            }
+        '''.stripIndent()
+
+        // This file would trigger RequireExplicitNullMarking if it wasn't disabled
+        // because it lacks @NullMarked or @NullUnmarked annotations
+        file('src/main/java/com/palantir/test/Test.java') << '''
+        package com.palantir.test;
+        public class Test {
+            void test() {
+                String s = "hello";
+                System.out.println(s);
+            }
+        }
+        '''.stripIndent()
+
+        then:
+        // The build should succeed because the check is disabled
+        BuildResult result = with('compileJava').build()
+        result.task(":compileJava").outcome == TaskOutcome.SUCCESS
+        // The check should be explicitly disabled, so we shouldn't see warnings
+        !result.output.contains("[RequireExplicitNullMarking]")
+    }
 }

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineNullAwayIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineNullAwayIntegrationTest.java
@@ -124,4 +124,34 @@ class BaselineNullAwayIntegrationTest {
 
         gradle.withArgs("compileJava").buildsSuccessfully();
     }
+
+    @Test
+    void requireExplicitNullMarking_is_disabled_by_default_to_avoid_excessive_logs(
+            GradleInvoker gradle, RootProject rootProject) {
+        standardBuildFile(rootProject);
+
+        rootProject.buildGradle().append("""
+            dependencies {
+                compileOnly 'org.jspecify:jspecify:1.0.0'
+            }
+            """);
+
+        // This file would trigger RequireExplicitNullMarking if it wasn't disabled
+        // because it lacks @NullMarked or @NullUnmarked annotations
+        // See https://github.com/uber/NullAway/issues/1363
+        rootProject.mainSourceSet().java().writeClass("""
+            package com.palantir.test;
+            public class Test {
+                void test() {
+                    String s = "hello";
+                    System.out.println(s);
+                }
+            }
+            """);
+
+        InvocationResult result = gradle.withArgs("compileJava").buildsSuccessfully();
+
+        // The check should be explicitly disabled, so we shouldn't see warnings
+        assertThat(result).output().doesNotContain("[RequireExplicitNullMarking]");
+    }
 }

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineNullAwayIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineNullAwayIntegrationTest.java
@@ -130,12 +130,6 @@ class BaselineNullAwayIntegrationTest {
             GradleInvoker gradle, RootProject rootProject) {
         standardBuildFile(rootProject);
 
-        rootProject.buildGradle().append("""
-            dependencies {
-                compileOnly 'org.jspecify:jspecify:1.0.0'
-            }
-            """);
-
         // This file would trigger RequireExplicitNullMarking if it wasn't disabled
         // because it lacks @NullMarked or @NullUnmarked annotations
         // See https://github.com/uber/NullAway/issues/1363


### PR DESCRIPTION
## Before this PR
per internal thread on our support channel, this check was added to nullaway by mistake and is flooding logs - https://github.com/uber/NullAway/issues/1363

## After this PR
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

