### PR TITLE
baseline-java-versions: Ensure `checkJavaVersions` handles `javaCompiler` not being set

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -19,6 +19,7 @@ package com.palantir.baseline.plugins.javaversions;
 import com.google.common.collect.Sets;
 import com.palantir.baseline.extensions.BaselineModuleJvmArgsExtension;
 import java.util.Collections;
+import java.util.Optional;
 import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
@@ -345,6 +346,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
         }
 
         @Input
+        @org.gradle.api.tasks.Optional
         public abstract Property<JavaLanguageVersion> getJavaCompilerVersion();
 
         @Input
@@ -358,7 +360,8 @@ public final class BaselineJavaVersion implements Plugin<Project> {
 
         @TaskAction
         public final void checkJavaVersions() {
-            JavaLanguageVersion javaCompiler = getJavaCompilerVersion().get();
+            Optional<JavaLanguageVersion> possibleJavaCompiler =
+                    Optional.ofNullable(getJavaCompilerVersion().getOrNull());
             ChosenJavaVersion target = getTargetVersion().get();
             ChosenJavaVersion runtime = getRuntimeVersion().get();
 
@@ -367,7 +370,7 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                             "BaselineJavaVersion configured {} with javaCompiler version {}, target version {} and"
                                     + " runtime version {}",
                             getProjectDisplayName().get(),
-                            javaCompiler,
+                            possibleJavaCompiler,
                             target,
                             runtime);
 
@@ -380,14 +383,16 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                             runtime, target, getProjectDisplayName().get()));
                 }
 
-                if (!target.javaLanguageVersion().equals(javaCompiler)) {
-                    throw new GradleException(String.format(
-                            "The version of the Java Compiler (%s) must be exactly the same as the compilation target"
-                                    + " (%s) in %s, because --enable-preview is enabled. Otherwise the preview feature"
-                                    + " will not necessarily be available in the compiler."
-                                    + " See https://openjdk.org/jeps/12.",
-                            javaCompiler, target, getProjectDisplayName().get()));
-                }
+                possibleJavaCompiler.ifPresent(javaCompiler -> {
+                    if (!target.javaLanguageVersion().equals(javaCompiler)) {
+                        throw new GradleException(String.format(
+                                "The version of the Java Compiler (%s) must be exactly the same as the compilation"
+                                    + " target (%s) in %s, because --enable-preview is enabled. Otherwise the preview"
+                                    + " feature will not necessarily be available in the compiler. See"
+                                    + " https://openjdk.org/jeps/12.",
+                                javaCompiler, target, getProjectDisplayName().get()));
+                    }
+                });
             }
 
             if (target.javaLanguageVersion().asInt()
@@ -398,12 +403,14 @@ public final class BaselineJavaVersion implements Plugin<Project> {
                         target, runtime, getProjectDisplayName().get()));
             }
 
-            if (target.javaLanguageVersion().asInt() > javaCompiler.asInt()) {
-                throw new GradleException(String.format(
-                        "The requested compilation target Java version (%s) must not "
-                                + "exceed the javaCompiler Java version (%s) in %s",
-                        target, javaCompiler, getProjectDisplayName().get()));
-            }
+            possibleJavaCompiler.ifPresent(javaCompiler -> {
+                if (target.javaLanguageVersion().asInt() > javaCompiler.asInt()) {
+                    throw new GradleException(String.format(
+                            "The requested compilation target Java version (%s) must not "
+                                    + "exceed the javaCompiler Java version (%s) in %s",
+                            target, javaCompiler, getProjectDisplayName().get()));
+                }
+            });
         }
     }
 

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -878,6 +878,18 @@ class BaselineJavaVersionIntegrationTest {
 
             gradle.withArgs("checkJavaVersions").buildsSuccessfully();
         }
+
+        @Test
+        void verification_should_succeed_when_compilation_not_set(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                javaVersion {
+                    target = 17
+                    runtime = 17
+                }
+                """);
+
+            gradle.withArgs("checkJavaVersions").buildsSuccessfully();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/gradle-baseline/pull/3342 we introduced a `javaCompiler` parameter to let people control the Java compiler version use for the compiler process. At the last minute in the PR, we decided to make `javaCompiler` optional  so it would not be a breaking change. Despite testing with RCs up until that point, we did not test on a real repo's CI after the change to make it optional. The `checkJavaVersions` task cannot handle the optional property (we had no test for this) and fails with this error:

```
A problem was found with the configuration of task ':docker:checkJavaVersions' (type 'BaselineJavaVersion.CheckJavaVersionsTask').
  - In plugin 'com.palantir.baseline.plugins.BaselineCheckstyle' type 'com.palantir.baseline.plugins.javaversions.BaselineJavaVersion.CheckJavaVersionsTask' property 'javaCompilerVersion' doesn't have a configured value.
    
    Reason: This property isn't marked as optional and no value has been configured.
    
    Possible solutions:
      1. Assign a value to 'javaCompilerVersion'.
      2. Mark property 'javaCompilerVersion' as optional.
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
baseline-java-versions: Ensure `checkJavaVersions` handles `javaCompiler` not being set, avoiding this error:
> 'com.palantir.baseline.plugins.javaversions.BaselineJavaVersion.CheckJavaVersionsTask' property 'javaCompilerVersion' doesn't have a configured value.
==COMMIT_MSG==

Added a test to make sure this doesn't happen.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

