### PR TITLE
Don't apply `baseline-error-prone` if it already exists

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/Baseline.java
@@ -51,7 +51,9 @@ public final class Baseline implements Plugin<Project> {
             proj.getPluginManager().apply("com.palantir.baseline-eclipse");
             proj.getPluginManager().apply("com.palantir.baseline-idea");
             // TEMPHACK(okelvin): remove this to decouple baseline-error-prone
-            proj.getPluginManager().apply(BaselineErrorProne.class);
+            if (!proj.getPluginManager().hasPlugin("com.palantir.baseline-error-prone")) {
+                proj.getPluginManager().apply(BaselineErrorProne.class);
+            }
             proj.getPluginManager().apply(BaselineFormat.class);
             proj.getPluginManager().apply(BaselineEncoding.class);
             proj.getPluginManager().apply(BaselineReproducibility.class);


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We are migrating to a separate baseline-error-prone repository. Firstly we entered an intermediary stage https://github.com/palantir/gradle-baseline/pull/3387 to not block contributions to gradle-baseline and baseline-error-prone. 

To reduce the risk of error-prone not being applied, lets enter the second stage of the rollout, where both `com.palantir.baseline` and `com.palantir.baseline-error-prone-root` applies `com.palantir.baseline-error-prone` to all projects if it isn't already applied: https://github.com/palantir/baseline-error-prone/pull/21

We don't want to apply the plugin twice because e.g. we cannot create the same extension twice. 

Then, when the dust settles, `com.palantir.baseline` can completely decouple from `baseline-error-prone`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Don't apply `baseline-error-prone` if it already exists
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

No behavior changes expected. 
