### PR TITLE
baseline-java-versions: Fix `allJavaVersionsUsed()` not supporting optional `javaCompiler`

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionExtension.java
@@ -16,6 +16,7 @@
 
 package com.palantir.baseline.plugins.javaversions;
 
+import java.util.Collections;
 import java.util.Set;
 import javax.inject.Inject;
 import org.gradle.api.model.ObjectFactory;
@@ -108,7 +109,7 @@ public abstract class BaselineJavaVersionExtension {
         SetProperty<JavaLanguageVersion> allJavaVersionsUsed =
                 getObjectFactory().setProperty(JavaLanguageVersion.class);
 
-        allJavaVersionsUsed.add(javaCompiler);
+        allJavaVersionsUsed.addAll(javaCompiler.map(Collections::singleton).orElse(Set.of()));
         allJavaVersionsUsed.add(target.map(ChosenJavaVersion::javaLanguageVersion));
         allJavaVersionsUsed.add(runtime.map(ChosenJavaVersion::javaLanguageVersion));
 

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionsExtension.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersionsExtension.java
@@ -17,6 +17,7 @@
 package com.palantir.baseline.plugins.javaversions;
 
 import com.palantir.gradle.utils.lazilyconfiguredmapping.LazilyConfiguredMapping;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -161,7 +162,7 @@ public abstract class BaselineJavaVersionsExtension implements BaselineJavaVersi
         SetProperty<JavaLanguageVersion> allJavaVersionsUsed =
                 getObjectFactory().setProperty(JavaLanguageVersion.class);
 
-        allJavaVersionsUsed.add(javaCompiler);
+        allJavaVersionsUsed.addAll(javaCompiler.map(Collections::singleton).orElse(Set.of()));
         allJavaVersionsUsed.add(libraryTarget);
         allJavaVersionsUsed.add(distributionTarget.map(ChosenJavaVersion::javaLanguageVersion));
         allJavaVersionsUsed.add(runtime.map(ChosenJavaVersion::javaLanguageVersion));

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -1031,6 +1031,21 @@ class BaselineJavaVersionIntegrationTest {
             result.assertThat().task(":generateTarget").upToDate();
             result.assertThat().task(":generateRuntime").upToDate();
         }
+
+        @Test
+        void has_a_value_when_javaCompiler_is_not_set(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                javaVersion {
+                    target = 17
+                    runtime = 21
+                }
+                """);
+
+            InvocationResult result =
+                    gradle.withArgs("printAllJavaVersionsUsed").buildsSuccessfully();
+
+            result.assertThat().output().contains("allJavaVersionsUsed: [17, 21]");
+        }
     }
 
     private static final int BYTECODE_IDENTIFIER = 0xCAFEBABE;

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionsIntegrationTest.java
@@ -374,6 +374,44 @@ class BaselineJavaVersionsIntegrationTest {
             result.assertThat().task(":subProject:generateTarget").upToDate();
             result.assertThat().task(":subProject:generateRuntime").upToDate();
         }
+
+        @Test
+        void has_a_value_when_root_javaCompiler_is_not_set(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+                    distributionTarget = 17
+                    runtime = 21
+                }
+                """);
+
+            InvocationResult result =
+                    gradle.withArgs("printAllJavaVersionsUsed").buildsSuccessfully();
+
+            result.assertThat().output().contains("allJavaVersionsUsed: [11, 17, 21]");
+        }
+
+        @Test
+        void has_a_value_when_subproject_javaCompiler_is_not_set(
+                GradleInvoker gradle, RootProject rootProject, SubProject subProject) {
+
+            rootProject.buildGradle().append("""
+                javaVersions {
+                    libraryTarget = 11
+                }
+                """);
+
+            subProject.buildGradle().append("""
+                javaVersion {
+                    target = 17
+                }
+                """);
+
+            InvocationResult result =
+                    gradle.withArgs("printAllJavaVersionsUsed").buildsSuccessfully();
+
+            result.assertThat().output().contains("allJavaVersionsUsed: [11, 17]");
+        }
     }
 
     private static final int BYTECODE_IDENTIFIER = 0xCAFEBABE;


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/gradle-baseline/pull/3342 we introduced a `javaCompiler` parameter to let people control the Java compiler version use for the compiler process. At the last minute in the PR, we decided to make `javaCompiler` optional  so it would not be a breaking change. Despite testing with RCs up until that point, we did not test on a real repo's CI after the change to make it optional.

The `allJavaVersionsUsed()` method has odd behaviour when the `javaCompiler` property is not set (we had no test for this) and fails with this error when combined with gradle-jdks:

```
Execution failed for task ':checkGradleJdkConfigs'.
> Error while evaluating property 'javaVersionToJdkDistros' of task ':checkGradleJdkConfigs'.
   > Failed to query the value of task ':checkGradleJdkConfigs' property 'javaVersionToJdkDistros'.
      > Cannot query the value of this property because it has no value available.
```

The root cause of the issue is we have this this code:

```
SetProperty<JavaLanguageVersion> allJavaVersionsUsed;
Provider<JavaLanguageVersion> javaCompiler;

allJavaVersionsUsed.add(javaCompiler);
```

[It turns out](https://docs.gradle.org/8.14.3/javadoc/org/gradle/api/provider/HasMultipleValues.html#add(org.gradle.api.provider.Provider)) that if you do `setProperty.add(provider)`, if `provider` is empty, the _whole_ `setProperty` will be empty. I would have thought it would just not add the value.

So in this case, since `javaCompiler` is empty, it will force the whole `allJavaVersionsUsed` provider to be empty. When gradle-jdks maps and feeds this into a task (`:checkGradleJdkConfigs`), we get the error from Gradle that it's input property is empty.

## After this PR
==COMMIT_MSG==
baseline-java-versions: Fix `allJavaVersionsUsed()` not supporting optional `javaCompiler`. Avoid error with gradle-jdks:
```
Execution failed for task ':checkGradleJdkConfigs'.
> Error while evaluating property 'javaVersionToJdkDistros' of task ':checkGradleJdkConfigs'.
   > Failed to query the value of task ':checkGradleJdkConfigs' property 'javaVersionToJdkDistros'.
      > Cannot query the value of this property because it has no value available.
```
==COMMIT_MSG==

We do this by using `setProperty.addAll` instead of `add` to add an empty set if the `javaCompiler` property is empty.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

