### PR TITLE
Don't load exteral DTDs in baselineUpdateConfig

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineConfig.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineConfig.java
@@ -22,6 +22,7 @@ import java.io.FileWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -110,6 +111,8 @@ class BaselineConfig extends AbstractBaselinePlugin {
 
                 try {
                     DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+                    builderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                    builderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
                     DocumentBuilder builder = builderFactory.newDocumentBuilder();
 
                     InputSource inputSource = new InputSource(new FileReader(checkstyleXml.toFile()));


### PR DESCRIPTION
This both helps prevent [XML External Entity (XXE) vulnerabilities](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html) as well as ensure that `baselineUpdateConfig` can run in environment where network access is restricted. This has prevented some of our automations from updating `checkstyle.xml` as part of `gradle-baseline` upgrades.

Ideally we would just enable `http://apache.org/xml/features/disallow-doctype-decl`, which more comprehensively disables DTD features. But this fails because `checkstyle.xml` has a `DOCTYPE` declaration.

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':baselineUpdateConfig'.
        ...
Caused by: java.lang.RuntimeException: Unable to patch /Volumes/git/sap-auth-poller/.baseline/checkstyle/checkstyle.xml
        ...
Caused by: org.xml.sax.SAXParseException; lineNumber: 2; columnNumber: 10; DOCTYPE is disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true.
        at java.xml/com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:262)
        at java.xml/com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:342)
        at com.palantir.baseline.plugins.BaselineConfig$BaselineUpdateConfigAction.execute(BaselineConfig.java:120)
```

I've confirmed that, after this change, `baselineUpdateConfig` succeeds even when there is no network access.