### PR TITLE
Allow local variable names that start with underscore

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -439,7 +439,7 @@
         <module name="LocalFinalVariableName"/> <!-- Java Style Guide: Local variable names -->
         <module name="LocalVariableName"> <!-- Java Style Guide: Local variable names -->
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+            <property name="format" value="^_?[a-z][a-zA-Z0-9]+$"/>
             <property name="allowOneCharVarInForLoop" value="true"/>
             <message key="name.invalidPattern" value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
## Before this PR
For code with an unused local variable name like this:
```
// fire and forget
Future<?> ignored = submitFuture();
```

There's an error prone rule [StrictUnusedVariable](https://github.com/palantir/baseline-error-prone/blob/2778b52c0f77e0304e3bb44be275d0ebee0f101c/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/StrictUnusedVariable.java#L265-L266) that fires with a message like

```
 error: [StrictUnusedVariable] The local variable 'ignored' is never read. Intentional occurrences are acknowledged by renaming the unused variable with a leading underscore. '_ignored', for example.
              Future<?> ignored = submitFuture();
                        ^
      (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
```

But then if you take the suggestion and name the variable according to its suggestion like this:

```
// fire and forget
Future<?> _ignored = submitFuture();
```

Then now checkstyle fails with an error like:

```
MyFile.java:296: error: Local variable name '_ignored' must match pattern '^[a-z][a-zA-Z0-9]+$'.
```

It is problematic that the baseline error prone suggests a format that then the baseline checkstyle configuration rejects.

## After this PR
==COMMIT_MSG==
Allow local variable names that start with underscore
==COMMIT_MSG==

With this PR, now the recommendation from StrictUnusedVariable can actually be taken.

The regex is similar to the existing regex ~15 lines below for `ParameterName`

## Alternative: no variable assignment

Instead of make this allowed in checkstyle, an alternative could be to stop recommending it in error-prone. Now users should resolve the original error by removing the variable assignment entirely, like this:

```
// fire and forget
submitFuture();
```

However, this interacts poorly with the [FutureReturnValueIgnored](https://errorprone.info/bugpattern/FutureReturnValueIgnored) bug pattern, which would now fail with this message:

```
 warning: [FutureReturnValueIgnored] Return value of methods returning Future must be checked. Ignoring returned Futures suppresses exceptions thrown from the code that completes the Future.
              submitFuture();
                                                             ^
      (see https://errorprone.info/bugpattern/FutureReturnValueIgnored)
    Did you mean 'var unused = submitFuture();' or to remove this line?
```

and is recommending to create an unused variable assignment again!

For users truly trying to fire and forget a future, they would have to suppress the error-prone at the surrounding method. Unfortunately this is a very wide suppression and can suppress over hundreds of lines when the problem is only in one.  Like this:

```
@SuppressWarnings("FutureReturnValueIgnored")
void myFunction() {
  //
  // ..snip hundreds of lines
  //

  // fire and forget
  submitFuture();

  //
  // ..snip hundreds of lines
  //
}
```

Because of this bad interaction with `FutureReturnValueIgnored`, I think it's better to move towards an explicit assignment to an unused variable that starts with an underscore.


In the end, making this the desirable and allowed phrasing:

```
// fire and forget
Future<?> _ignored = submitFuture();
```

and allowing the `_` prefix for variable names in checkstyle (what this PR does)