### PR TITLE
Run checkstyle with the `javaCompiler` version

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -225,13 +225,17 @@ public final class BaselineJavaVersion implements Plugin<Project> {
         });
         // checkstyle.getJavaLauncher() was added in Gradle 7.5
         if (GradleVersion.current().compareTo(GradleVersion.version("7.5")) >= 0) {
+            // Checkstyle requires at least Java 17 to run, so we use the javaCompiler version, which is usually
+            // set high compared to the target version.
+            Provider<ChosenJavaVersion> checkstyleJavaVersion =
+                    javaCompiler.map(ChosenJavaVersion::of).orElse(target);
             project.getTasks().withType(Checkstyle.class).configureEach(checkstyle -> checkstyle
                     .getJavaLauncher()
                     .set(getJavaLauncher(
                             rootExtension,
                             baselineConfiguredJavaToolchains,
                             javaToolchainService,
-                            javaCompiler.map(ChosenJavaVersion::of).orElse(target))));
+                            checkstyleJavaVersion)));
         }
 
         project.getTasks().withType(GroovyCompile.class).configureEach(groovyCompileTask -> {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -228,7 +228,10 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             project.getTasks().withType(Checkstyle.class).configureEach(checkstyle -> checkstyle
                     .getJavaLauncher()
                     .set(getJavaLauncher(
-                            rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target)));
+                            rootExtension,
+                            baselineConfiguredJavaToolchains,
+                            javaToolchainService,
+                            javaCompiler.map(ChosenJavaVersion::of).orElse(target))));
         }
 
         project.getTasks().withType(GroovyCompile.class).configureEach(groovyCompileTask -> {

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -106,6 +106,23 @@ class BaselineJavaVersionIntegrationTest {
         }
         """;
 
+    // language=XML
+    private static final String CHECKSTYLE_XML = """
+        <?xml version="1.0"?>
+        <!DOCTYPE module PUBLIC
+                "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+                "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+        <module name="Checker">
+            <property name="charset" value="UTF-8"/>
+            <property name="severity" value="error"/>
+
+            <module name="TreeWalker">
+                <module name="ConstantName"/>
+            </module>
+        </module>
+        """;
+
     @BeforeEach
     void beforeEach(RootProject rootProject) {
         InheritGradleJdks.beforeEach(rootProject);
@@ -292,6 +309,22 @@ class BaselineJavaVersionIntegrationTest {
                         .toFile();
                 assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
             }
+
+            @Test
+            void checkstyle_runs_with_javaCompiler(GradleInvoker gradle, RootProject rootProject) {
+                rootProject.file("config/checkstyle/checkstyle.xml").append(CHECKSTYLE_XML);
+                rootProject.buildGradle().plugins().add("checkstyle");
+
+                rootProject.buildGradle().append("""
+                    javaVersion {
+                        javaCompiler = 21
+                        target = 11
+                    }
+                    """);
+
+                rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
+                gradle.withArgs("checkstyleMain").buildsSuccessfully();
+            }
         }
 
         /// These tests are mainly to maintain the old behaviour when javaCompiler is not set
@@ -431,6 +464,25 @@ class BaselineJavaVersionIntegrationTest {
                         .resolve("classes/java/main/Main.class")
                         .toFile();
                 assertBytecodeVersion(compiledClass, JAVA_17_BYTECODE, NOT_ENABLE_PREVIEW_BYTECODE);
+            }
+
+            @Test
+            void checkstyle_runs_with_target_version(GradleInvoker gradle, RootProject rootProject) {
+                rootProject.file("config/checkstyle/checkstyle.xml").append(CHECKSTYLE_XML);
+                rootProject.buildGradle().plugins().add("checkstyle");
+
+                rootProject.buildGradle().append("""
+                    javaVersion {
+                        runtime = 17
+                        target = 11
+                    }
+                    """);
+
+                rootProject.mainSourceSet().java().writeClass(JAVA_11_COMPATIBLE_CODE);
+                InvocationResult result = gradle.withArgs("checkstyleMain").buildsWithFailure();
+                result.assertThat()
+                        .output()
+                        .contains("this version of the Java Runtime only recognizes class file versions up to 55.0");
             }
         }
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Checkstyle would run with the `target` version, rather than the `javaCompiler` version. Meaning a project with target 11 and compiler 21 would fail with


```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':gradle-jdks-setup-common:checkstyleMain'.
> A failure occurred while executing org.gradle.api.plugins.quality.internal.CheckstyleAction
   > com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 5s
```


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Run checkstyle with the `javaCompiler` version
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

