### PR TITLE
Decouple from baseline-error-prone

### DIFF
--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -29,11 +29,6 @@ dependencies {
     implementation 'com.palantir.gradle.utils:environment-variables'
     implementation 'com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions'
 
-    // TEMPHACK(okelvin): remove this to decouple baseline-error-prone
-    api 'com.palantir.baseline-error-prone:gradle-baseline-error-prone'
-    testImplementation 'com.palantir.baseline-error-prone:gradle-baseline-error-prone'
-    gradlePluginForTesting 'com.palantir.baseline-error-prone:gradle-baseline-error-prone'
-
     runtimeOnly 'com.palantir.javaformat:gradle-palantir-java-format'
 
     testImplementation gradleTestKit()
@@ -83,8 +78,6 @@ test {
     environment 'CIRCLE_TEST_REPORTS', "${buildDir}/circle-reports"
 
     environment 'ORG_GRADLE_PROJECT_baselineTestCompilerPluginsVersion', project.version
-    // TEMPHACK(okelvin): remove this to decouple baseline-error-prone
-    environment 'ORG_GRADLE_PROJECT_baselineErrorProneVersion', "0.2.0"
 
     systemProperty 'ignoreDeprecations', 'true'
 }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/Baseline.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/Baseline.java
@@ -16,7 +16,6 @@
 
 package com.palantir.baseline.plugins;
 
-import com.palantir.gradle.baselineerrorprone.BaselineErrorProne;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -50,8 +49,6 @@ public final class Baseline implements Plugin<Project> {
             // these are groovy-based classes so java has trouble with cross compiler
             proj.getPluginManager().apply("com.palantir.baseline-eclipse");
             proj.getPluginManager().apply("com.palantir.baseline-idea");
-            // TEMPHACK(okelvin): remove this to decouple baseline-error-prone
-            proj.getPluginManager().apply(BaselineErrorProne.class);
             proj.getPluginManager().apply(BaselineFormat.class);
             proj.getPluginManager().apply(BaselineEncoding.class);
             proj.getPluginManager().apply(BaselineReproducibility.class);

--- a/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTest.groovy
+++ b/gradle-baseline-java/src/test/groovy/com/palantir/baseline/BaselineTest.groovy
@@ -45,8 +45,6 @@ class BaselineTest extends Specification {
     void hasAllPlugins(Project p) {
         assert p.pluginManager.hasPlugin('com.palantir.baseline-checkstyle')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-eclipse')
-        // TEMPHACK(okelvin): remove this to decouple baseline-error-prone
-        assert p.pluginManager.hasPlugin('com.palantir.baseline-error-prone')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-idea')
         assert p.pluginManager.hasPlugin('com.palantir.baseline-class-uniqueness')
     }

--- a/versions.lock
+++ b/versions.lock
@@ -42,7 +42,7 @@ com.google.errorprone:error_prone_annotations:2.41.0 (6 constraints: d2590cfa)
 
 com.google.guava:failureaccess:1.0.3 (2 constraints: f3154f13)
 
-com.google.guava:guava:33.5.0-jre (15 constraints: 2945ea3c)
+com.google.guava:guava:33.5.0-jre (13 constraints: a90b841e)
 
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 
@@ -56,13 +56,11 @@ com.googlecode.java-diff-utils:diffutils:1.3.0 (1 constraints: 0605f935)
 
 com.googlecode.javaewah:JavaEWAH:1.2.3 (1 constraints: 460e7e50)
 
-com.palantir.baseline-error-prone:gradle-baseline-error-prone:0.5.0 (1 constraints: 0705fa35)
-
 com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions:1.9.0 (4 constraints: cb43f715)
 
 com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.7.0 (4 constraints: 8c457539)
 
-com.palantir.gradle.utils:environment-variables:0.21.0 (2 constraints: 5d228fae)
+com.palantir.gradle.utils:environment-variables:0.21.0 (1 constraints: 35052a3b)
 
 com.palantir.gradle.utils:exec:0.21.0 (1 constraints: 2e0f5e76)
 
@@ -78,8 +76,6 @@ com.palantir.javaformat:palantir-java-format-jdk-bootstrap:2.73.0 (1 constraints
 
 com.palantir.javaformat:palantir-java-format-spi:2.73.0 (2 constraints: 2a2ed21c)
 
-com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.26.0 (1 constraints: 7419b3d0)
-
 com.squareup.okhttp3:okhttp:4.12.0 (1 constraints: f6093eb3)
 
 com.squareup.okio:okio:3.6.0 (1 constraints: 530c38fd)
@@ -93,10 +89,6 @@ dev.equo.ide:solstice:1.8.1 (1 constraints: 771167da)
 javax.annotation:javax.annotation-api:1.2 (1 constraints: e01020af)
 
 javax.inject:javax.inject:1 (7 constraints: e66230f0)
-
-net.ltgt.gradle:gradle-errorprone-plugin:4.3.0 (2 constraints: 3d366a24)
-
-one.util:streamex:0.8.4 (3 constraints: ce3df6ab)
 
 org.apache.commons:commons-lang3:3.20.0 (6 constraints: 85555c67)
 
@@ -172,7 +164,7 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 (2 constraints: 8118c1c5)
 
 org.jspecify:jspecify:1.0.0 (9 constraints: bf90aa32)
 
-org.ow2.asm:asm:9.9.1 (4 constraints: 6345f650)
+org.ow2.asm:asm:9.9.1 (3 constraints: ba28af74)
 
 org.slf4j:slf4j-api:2.0.17 (6 constraints: 465e1561)
 
@@ -243,6 +235,8 @@ junit:junit-dep:4.11 (1 constraints: ba1063b3)
 net.bytebuddy:byte-buddy:1.17.7 (1 constraints: 560b56df)
 
 net.lingala.zip4j:zip4j:1.3.2 (1 constraints: 0805fb35)
+
+one.util:streamex:0.8.4 (2 constraints: cd2005f2)
 
 org.apache.commons:commons-compress:1.27.1 (1 constraints: 940f5492)
 

--- a/versions.props
+++ b/versions.props
@@ -7,7 +7,6 @@ com.palantir.safe-logging:* = 3.9.0
 org.apache.maven.shared:maven-dependency-analyzer = 1.16.0
 org.apache.maven:maven-core = 3.9.1
 org.inferred:freebuilder = 1.14.6
-com.palantir.baseline-error-prone:* = 0.5.0
 com.palantir.gradle.consistentversions:* = 3.7.0
 org.slf4j:* = 2.0.17
 org.immutables:* = 2.12.0


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Final stage of separating https://github.com/palantir/baseline-error-prone from baseline. 

## After this PR

This should be a major release

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Decouple from baseline-error-prone
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

