### PR TITLE
Use `javaCompiler` version for javadoc tool when set

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -207,15 +207,13 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             });
         });
 
-        Provider<ChosenJavaVersion> javadocJavaVersion =
-                javaCompiler.map(ChosenJavaVersion::of).orElse(target);
         project.getTasks().withType(Javadoc.class).configureEach(javadocTask -> {
             setJavaDocTool(
                     javadocTask,
                     rootExtension,
                     baselineConfiguredJavaToolchains,
                     javaToolchainService,
-                    javadocJavaVersion);
+                    javaCompiler.map(ChosenJavaVersion::of).orElse(target));
 
             // javadocTask doesn't allow us to add a CommandLineArgumentProvider, so we do it just in time
             javadocTask.doFirst(new Action<Task>() {

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -207,8 +207,15 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             });
         });
 
+        Provider<ChosenJavaVersion> javadocJavaVersion =
+                javaCompiler.map(ChosenJavaVersion::of).orElse(target);
         project.getTasks().withType(Javadoc.class).configureEach(javadocTask -> {
-            setJavaDocTool(javadocTask, rootExtension, baselineConfiguredJavaToolchains, javaToolchainService, target);
+            setJavaDocTool(
+                    javadocTask,
+                    rootExtension,
+                    baselineConfiguredJavaToolchains,
+                    javaToolchainService,
+                    javadocJavaVersion);
 
             // javadocTask doesn't allow us to add a CommandLineArgumentProvider, so we do it just in time
             javadocTask.doFirst(new Action<Task>() {

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -111,7 +111,7 @@ class BaselineJavaVersionIntegrationTest {
         import java.util.List;
 
         public class Main {
-            /** Returns a sequenced view. */
+            /** SequencedCollection is a Java 21 API. */
             public SequencedCollection<String> getItems() {
                 return List.of("a", "b", "c");
             }

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -106,6 +106,18 @@ class BaselineJavaVersionIntegrationTest {
         }
         """;
 
+    private static final String JAVA_21_API_IN_PUBLIC_SIGNATURE = """
+        import java.util.SequencedCollection;
+        import java.util.List;
+
+        public class Main {
+            /** Returns a sequenced view. */
+            public SequencedCollection<String> getItems() {
+                return List.of("a", "b", "c");
+            }
+        }
+        """;
+
     // language=XML
     private static final String CHECKSTYLE_XML = """
         <?xml version="1.0"?>
@@ -607,6 +619,26 @@ class BaselineJavaVersionIntegrationTest {
                 """);
 
             rootProject.mainSourceSet().java().writeClass(JAVA_17_COMPATIBLE_CODE);
+
+            gradle.withArgs("javadoc").buildsSuccessfully();
+        }
+
+        @Test
+        void javadoc_succeeds_with_jdk21_api_in_signature_when_java_compiler_is_21_and_target_is_17(
+                GradleInvoker gradle, RootProject rootProject) {
+
+            rootProject.buildGradle().append("""
+                javaVersion {
+                    javaCompiler = 21
+                    target = 17
+                }
+
+                tasks.withType(JavaCompile).configureEach {
+                    options.release.unset()
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass(JAVA_21_API_IN_PUBLIC_SIGNATURE);
 
             gradle.withArgs("javadoc").buildsSuccessfully();
         }


### PR DESCRIPTION
## Before this PR

The javadoc tool always uses the `target` JDK version, even when `javaCompiler` is set to a higher version. This causes javadoc failures when code references APIs from the compiler JDK that don't exist in the target JDK.

For example, in a project with `javaCompiler = 21` and `target = 17` that unsets `options.release` to allow using JDK 21 APIs (like `SequencedCollection` or `InetAddressResolver`) while producing Java 17 bytecode, the JDK 17 javadoc tool cannot resolve those types and fails. This forces workarounds like `@SuppressWarnings("Since15")`.

## After this PR

==CHANGELOG_MSG==
Javadoc now uses the `javaCompiler` JDK version (when set) instead of the `target` version, allowing javadoc to resolve types from the compiler JDK.
==CHANGELOG_MSG==

When `javaCompiler` is explicitly set, the javadoc tool uses that JDK version. When `javaCompiler` is not set, behavior is unchanged (falls back to `target`).

This mirrors the existing pattern used for Checkstyle (line 231), and is safe because javadoc generates documentation, not bytecode — there is no compatibility concern from using a higher JDK version for the tool.

## Possible downsides?

## Test plan

- Added integration test that sets `javaCompiler = 21, target = 17`, unsets `options.release`, and writes code using `SequencedCollection` (a Java 21 type) in a public method signature
- Verified the test fails before the production change (javadoc can't resolve `SequencedCollection` with JDK 17 tool)
- Verified the test passes after the change
- All existing Javadoc tests continue to pass
