### PR TITLE
Support apiNote, implNote and implSpec tags in javadoc

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java
@@ -44,7 +44,7 @@ import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.api.tasks.scala.ScalaDoc;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.external.javadoc.CoreJavadocOptions;
+import org.gradle.external.javadoc.StandardJavadocDocletOptions;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
@@ -219,12 +219,15 @@ public final class BaselineJavaVersion implements Plugin<Project> {
             javadocTask.doFirst(new Action<Task>() {
                 @Override
                 public void execute(Task task) {
-                    CoreJavadocOptions options = (CoreJavadocOptions) ((Javadoc) task).getOptions();
+                    StandardJavadocDocletOptions options = (StandardJavadocDocletOptions) ((Javadoc) task).getOptions();
                     if (target.get().enablePreview()) {
                         // yes, javadoc truly takes a single-dash where everyone else takes a double dash
                         options.addBooleanOption("-enable-preview", true);
                         options.setSource(target.get().javaLanguageVersion().toString());
                     }
+                    // These are common tags that are not supported by default by Javadoc, but commonly used
+                    // in e.g. openjdk, as well as in conjure-java.
+                    options.tags("apiNote", "implSpec", "implNote");
                 }
             });
         });

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -118,6 +118,15 @@ class BaselineJavaVersionIntegrationTest {
         }
         """;
 
+    private static final String USE_API_NOTE_TAG = """
+        public class Main {
+            /** @apiNote This is an API note. */
+            public String get() {
+                return "a";
+            }
+        }
+        """;
+
     // language=XML
     private static final String CHECKSTYLE_XML = """
         <?xml version="1.0"?>
@@ -639,6 +648,21 @@ class BaselineJavaVersionIntegrationTest {
                 """);
 
             rootProject.mainSourceSet().java().writeClass(JAVA_21_API_IN_PUBLIC_SIGNATURE);
+
+            gradle.withArgs("javadoc").buildsSuccessfully();
+        }
+
+        @Test
+        void javadoc_succeeds_with_api_note_tag(GradleInvoker gradle, RootProject rootProject) {
+
+            rootProject.buildGradle().append("""
+                javaVersion {
+                    javaCompiler = 21
+                    target = 17
+                }
+                """);
+
+            rootProject.mainSourceSet().java().writeClass(USE_API_NOTE_TAG);
 
             gradle.withArgs("javadoc").buildsSuccessfully();
         }

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineJavaVersionIntegrationTest.java
@@ -118,9 +118,13 @@ class BaselineJavaVersionIntegrationTest {
         }
         """;
 
-    private static final String USE_API_NOTE_TAG = """
+    private static final String USE_UNOFFICIAL_JDK_TAG = """
         public class Main {
-            /** @apiNote This is an API note. */
+            /**
+             * @apiNote This is an API note.
+             * @implNote This is an implementation note.
+             * @implSpec This is an implementation spec annotation.
+             */
             public String get() {
                 return "a";
             }
@@ -653,16 +657,16 @@ class BaselineJavaVersionIntegrationTest {
         }
 
         @Test
-        void javadoc_succeeds_with_api_note_tag(GradleInvoker gradle, RootProject rootProject) {
+        void javadoc_succeeds_with_unofficial_jdk_tags(GradleInvoker gradle, RootProject rootProject) {
 
             rootProject.buildGradle().append("""
                 javaVersion {
-                    javaCompiler = 21
+                    javaCompiler = 25
                     target = 17
                 }
                 """);
 
-            rootProject.mainSourceSet().java().writeClass(USE_API_NOTE_TAG);
+            rootProject.mainSourceSet().java().writeClass(USE_UNOFFICIAL_JDK_TAG);
 
             gradle.withArgs("javadoc").buildsSuccessfully();
         }


### PR DESCRIPTION
## Before this PR
These tags have been [added as of Java 8](https://bugs.openjdk.org/browse/JDK-8068562), but never made it into [official, standard tags](https://docs.oracle.com/en/java/javase/21/docs/specs/javadoc/doc-comment-spec.html).

However, as per https://stackoverflow.com/a/55150289, these have been adopted by a number of standard tools (e.g. IntelliJ), and is also [used in a lot of places in openjdk](https://github.com/search?q=repo%3Aopenjdk%2Fjdk%20%40apiNote&type=code).

Given the cost to adopt support for these is pretty small here, we might as well do it.

## After this PR
==COMMIT_MSG==
Support apiNote, implNote and implSpec tags in javadoc
==COMMIT_MSG==

Note: I've run the test without my change and it indeed fails. I've also tested `options.tags('apiNote')` on an internal repo and it worked fine and generated proper Javadoc, with a dedicated ApiNote. I have also tested this specific gradle-baseline change locally and it works fine as well.

<img width="159" height="70" alt="image" src="https://github.com/user-attachments/assets/6197f7ff-cf2c-4f75-b14c-be841480dec7" />


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

