### PR TITLE
Migrate from `GFileUtils` to Apache Commons IO `FileUtils`

### DIFF
--- a/gradle-baseline-java/build.gradle
+++ b/gradle-baseline-java/build.gradle
@@ -11,6 +11,7 @@ import org.gradle.api.internal.project.ProjectInternal
 dependencies {
     implementation gradleApi()
     implementation 'com.palantir.gradle.idea-configuration:gradle-idea-configuration'
+    implementation 'commons-io:commons-io'
     implementation 'org.apache.commons:commons-lang3'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle'
     implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -25,6 +25,9 @@ import com.palantir.gradle.failurereports.exceptions.ExceptionWithSuggestion;
 import difflib.DiffUtils;
 import difflib.Patch;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -34,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Named;
@@ -47,7 +51,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
-import org.gradle.util.GFileUtils;
 
 @CacheableTask
 public abstract class CheckClassUniquenessLockTask extends DefaultTask {
@@ -175,10 +178,14 @@ public abstract class CheckClassUniquenessLockTask extends DefaultTask {
                 .collect(Collectors.joining(", ", "[", "]"));
     }
 
-    @SuppressWarnings({"for-rollout:IllegalMethodCalledDuringTaskExecution", "for-rollout:deprecation"})
+    @SuppressWarnings("for-rollout:IllegalMethodCalledDuringTaskExecution")
     private void ensureLockfileContains(String expected) {
         if (shouldFix.get()) {
-            GFileUtils.writeFile(expected, lockFile);
+            try {
+                FileUtils.writeStringToFile(lockFile, expected, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
             getLogger()
                     .lifecycle("Updated {}", getProject().getRootDir().toPath().relativize(lockFile.toPath()));
             return;
@@ -192,8 +199,12 @@ public abstract class CheckClassUniquenessLockTask extends DefaultTask {
                     "./gradlew checkClassUniqueness --fix");
         }
 
-        @SuppressWarnings("for-rollout:deprecation")
-        String onDisk = GFileUtils.readFile(lockFile);
+        String onDisk;
+        try {
+            onDisk = FileUtils.readFileToString(lockFile, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         if (!onDisk.equals(expected)) {
             List<String> onDiskLines = Splitter.on('\n').splitToList(onDisk);
             Patch<String> diff = DiffUtils.diff(onDiskLines, Splitter.on('\n').splitToList(expected));
@@ -221,11 +232,11 @@ public abstract class CheckClassUniquenessLockTask extends DefaultTask {
         }
     }
 
-    @SuppressWarnings({"for-rollout:IllegalMethodCalledDuringTaskExecution", "for-rollout:deprecation"})
+    @SuppressWarnings("for-rollout:IllegalMethodCalledDuringTaskExecution")
     private void ensureLockfileDoesNotExist() {
         if (lockFile.exists()) {
             if (shouldFix.get()) {
-                GFileUtils.deleteQuietly(lockFile);
+                FileUtils.deleteQuietly(lockFile);
                 getLogger()
                         .lifecycle(
                                 "Deleted {}", getProject().getRootDir().toPath().relativize(lockFile.toPath()));

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/tasks/CheckClassUniquenessLockTask.java
@@ -27,7 +27,7 @@ import difflib.Patch;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -182,7 +182,7 @@ public abstract class CheckClassUniquenessLockTask extends DefaultTask {
     private void ensureLockfileContains(String expected) {
         if (shouldFix.get()) {
             try {
-                FileUtils.writeStringToFile(lockFile, expected, StandardCharsets.UTF_8);
+                Files.writeString(lockFile.toPath(), expected);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
@@ -201,7 +201,7 @@ public abstract class CheckClassUniquenessLockTask extends DefaultTask {
 
         String onDisk;
         try {
-            onDisk = FileUtils.readFileToString(lockFile, StandardCharsets.UTF_8);
+            onDisk = Files.readString(lockFile.toPath());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/util/GitUtils.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/util/GitUtils.java
@@ -17,18 +17,17 @@
 package com.palantir.baseline.util;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.io.FileUtils;
 
 public final class GitUtils {
     private static final Pattern GIT_ORIGIN = Pattern.compile("url = git@([^:]+):([^.]+).git");
 
     public static Optional<String> maybeGitHubUri() {
         try {
-            String gitConfigContents = FileUtils.readFileToString(new File(".git/config"), StandardCharsets.UTF_8);
+            String gitConfigContents = Files.readString(new File(".git/config").toPath());
             Matcher matcher = GIT_ORIGIN.matcher(gitConfigContents);
             if (matcher.find()) {
                 return Optional.of(String.format("https://%s/%s", matcher.group(1), matcher.group(2)));

--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/util/GitUtils.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/util/GitUtils.java
@@ -17,18 +17,18 @@
 package com.palantir.baseline.util;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.gradle.util.GFileUtils;
+import org.apache.commons.io.FileUtils;
 
 public final class GitUtils {
     private static final Pattern GIT_ORIGIN = Pattern.compile("url = git@([^:]+):([^.]+).git");
 
     public static Optional<String> maybeGitHubUri() {
         try {
-            @SuppressWarnings("for-rollout:deprecation")
-            String gitConfigContents = GFileUtils.readFile(new File(".git/config"));
+            String gitConfigContents = FileUtils.readFileToString(new File(".git/config"), StandardCharsets.UTF_8);
             Matcher matcher = GIT_ORIGIN.matcher(gitConfigContents);
             if (matcher.find()) {
                 return Optional.of(String.format("https://%s/%s", matcher.group(1), matcher.group(2)));

--- a/versions.lock
+++ b/versions.lock
@@ -88,6 +88,8 @@ com.squareup.okio:okio-jvm:3.6.0 (1 constraints: 500ad3b9)
 
 commons-codec:commons-codec:1.19.0 (2 constraints: 1c1e1787)
 
+commons-io:commons-io:2.21.0 (5 constraints: f2503923)
+
 dev.equo.ide:solstice:1.8.1 (1 constraints: 771167da)
 
 javax.annotation:javax.annotation-api:1.2 (1 constraints: e01020af)
@@ -235,8 +237,6 @@ com.palantir.sls-packaging:gradle-sls-packaging:7.87.0 (1 constraints: 48057e3b)
 com.palantir.sls-packaging:gradle-sls-packaging-api:7.87.0 (1 constraints: f2133b70)
 
 com.palantir.sls.versions:sls-versions:1.9.0 (1 constraints: 571bdd45)
-
-commons-io:commons-io:2.21.0 (5 constraints: f2503923)
 
 info.picocli:picocli:4.7.7 (1 constraints: 2816dcdd)
 


### PR DESCRIPTION
## Before this PR
Uses `org.gradle.util.GFileUtils` which was part of Gradle's public API but has been deprecated and is being removed in newer Gradle versions.

## After this PR
Uses `org.apache.commons.io.FileUtils` from Apache Commons IO, which is a stable, well-maintained library for file operations.

## Possible downsides?

## Is this a breaking change?
No — this is a pure implementation detail change with no public API impact.