### PR TITLE
Remove RegexpMultiline & RegexpSingleline checkstyle

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -26,15 +26,6 @@
         <property name="format" value="&gt;&gt;&gt;&gt;&gt;&gt;&gt;"/>
         <property name="message" value="Found (&gt;&gt;&gt;&gt;&gt;&gt;&gt;), so it looks like you had a merge conflict that compiles. Please fix it."/>
     </module>
-    <module name="RegexpSingleline">
-        <property name="format" value="\s+$"/>
-        <property name="message" value="Whitespace at end-of-line"/>
-    </module>
-    <module name="RegexpMultiline"> <!-- Java Style Guide: Vertical Whitespace -->
-        <property name="fileExtensions" value="java"/>
-        <property name="format" value="^\n\n$"/>
-        <property name="message" value="Two consecutive blank lines are not permitted."/>
-    </module>
     <module name="SuppressionFilter"> <!-- baseline-gradle: README.md -->
         <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
     </module>


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
RegexpMultiline & RegexpSingleline checks are not needed as palantir-java-format collapses multiple blank lines and drop empty spaces at the end of the file. These checks will only catch cases like [here](https://github.com/palantir/gradle-consistent-versions/blob/aceddf46a569d48ea476c36cf729745aadc0b641/src/test/java/com/palantir/gradle/versions/ConflictSafeLockFileTest.java#L49) or [here](https://github.com/palantir/gradle-consistent-versions/pull/1510/changes#diff-1c21a76ce3ff3c7a4805f72b8f9c8c46ff4a3d71a449516559e1d17db0f7a917R573)


## After this PR
Drop `RegexpMultiline` & `RegexpSingleline` checkstyle checks
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove`RegexpMultiline` & `RegexpSingleline` checkstyle checks
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

