### PR TITLE
Remove `LineLength` checkstyle

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -38,15 +38,6 @@
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
-    <module name="LineLength"> <!-- Java Style Guide: No line-wrapping -->
-        <property name="max" value="120"/>
-        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|\{@link"/>
-    </module>
-    <module name="SuppressWithPlainTextCommentFilter"> <!-- Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
-        <property name="checkFormat" value="LineLength"/>
-        <property name="offCommentFormat" value='^.*"""\s*$'/>
-        <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
-    </module>
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/> <!-- baseline-gradle: README.md -->
         <module name="SuppressionCommentFilter">


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Flagging lines like:  https://pl.ntr/2AN (123 characters exceeding 120 characters)

## After this PR
We are formatting using `palantir-java-format` which will format correctly (up to 120 characters when it can split the test (eg. by space)). The `LineLength` checks shouldn't be needed anymore.

==COMMIT_MSG==
Remove LineLength checkstyle
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

