### PR TITLE
Fix paths like `/generatedfoo/` being excluded from formatting

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineFormat.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineFormat.java
@@ -47,7 +47,7 @@ class BaselineFormat extends AbstractBaselinePlugin {
     // TODO(dfox): remove this feature flag when we've refined the eclipse.xml sufficiently
     private static final String ECLIPSE_FORMATTING = "com.palantir.baseline-format.eclipse";
     private static final String PJF_PROPERTY = "com.palantir.baseline-format.palantir-java-format";
-    private static final String GENERATED_MARKER = File.separator + "generated";
+    private static final String GENERATED_MARKER = File.separator + "generated" + File.separator;
     private static final String PJF_PLUGIN = "com.palantir.java-format";
 
     @Override

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineFormatIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineFormatIntegrationTest.java
@@ -231,25 +231,13 @@ public class BaselineFormatIntegrationTest {
 
     @Test
     void format_does_not_skip_packages_that_merely_start_with_generated(GradleInvoker gradle, RootProject rootProject) {
-        // Regression test: the GENERATED_MARKER exclusion used to be a plain `/generated` substring match, which
-        // accidentally excluded any package whose name started with "generated" — e.g. `generatedxforms`,
-        // `generators`, `generation`. Such directories are not generated sources and must be formatted.
         standardBuildFile(rootProject).plugins().add("com.palantir.java-format");
         rootProject.gradlePropertiesFile().setProperty("com.palantir.baseline-format.palantir-java-format", "true");
 
-        String malformedJavaFile = """
+        rootProject.file("src/main/java/test/generatedxforms/Test.java").overwrite("""
             package test.generatedxforms;
             public class Test { Void test() {} }
-            """;
-        String formattedJavaFile = """
-            package test.generatedxforms;
-
-            public class Test {
-                Void test() {}
-            }
-            """;
-
-        rootProject.file("src/main/java/test/generatedxforms/Test.java").overwrite(malformedJavaFile);
+            """);
 
         InvocationResult result = gradle.withArgs(":format").buildsSuccessfully();
 
@@ -257,7 +245,13 @@ public class BaselineFormatIntegrationTest {
         rootProject
                 .file("src/main/java/test/generatedxforms/Test.java")
                 .assertThat()
-                .hasContent(formattedJavaFile);
+                .hasContent("""
+                    package test.generatedxforms;
+
+                    public class Test {
+                        Void test() {}
+                    }
+                    """);
     }
 
     @Test

--- a/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineFormatIntegrationTest.java
+++ b/gradle-baseline-java/src/test/java/com/palantir/baseline/BaselineFormatIntegrationTest.java
@@ -230,6 +230,37 @@ public class BaselineFormatIntegrationTest {
     }
 
     @Test
+    void format_does_not_skip_packages_that_merely_start_with_generated(GradleInvoker gradle, RootProject rootProject) {
+        // Regression test: the GENERATED_MARKER exclusion used to be a plain `/generated` substring match, which
+        // accidentally excluded any package whose name started with "generated" — e.g. `generatedxforms`,
+        // `generators`, `generation`. Such directories are not generated sources and must be formatted.
+        standardBuildFile(rootProject).plugins().add("com.palantir.java-format");
+        rootProject.gradlePropertiesFile().setProperty("com.palantir.baseline-format.palantir-java-format", "true");
+
+        String malformedJavaFile = """
+            package test.generatedxforms;
+            public class Test { Void test() {} }
+            """;
+        String formattedJavaFile = """
+            package test.generatedxforms;
+
+            public class Test {
+                Void test() {}
+            }
+            """;
+
+        rootProject.file("src/main/java/test/generatedxforms/Test.java").overwrite(malformedJavaFile);
+
+        InvocationResult result = gradle.withArgs(":format").buildsSuccessfully();
+
+        assertThat(result).task(":spotlessApply").succeeded();
+        rootProject
+                .file("src/main/java/test/generatedxforms/Test.java")
+                .assertThat()
+                .hasContent(formattedJavaFile);
+    }
+
+    @Test
     void formatDiff_updates_only_lines_changed_in_git_diff(GradleInvoker gradle, RootProject rootProject)
             throws InterruptedException, IOException {
         standardBuildFile(rootProject);


### PR DESCRIPTION
## Before this PR

gradle-baseline treated `/generatedfoo/` as a generated file, and excludes it from formatting

This was causing some files to be excluded from the formatter but still hit by suppressible-error-prone, leading to files being misformatted. 

## After this PR

Only treat paths with `/generated/` as generated files. 


