### PR TITLE
[`BaselineModuleJvmArgs`] Avoid capturing `SourceSet` to fix a configuration cache problem

### DIFF
--- a/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
+++ b/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/BaselineModuleJvmArgs.java
@@ -214,6 +214,10 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
             return;
         }
 
+        // Grab a reference to the annotation processor path early to avoid capturing a reference to the full SourceSet
+        // (which is not Gradle configuration cache compatible) in the doFirst action below.
+        FileCollection annotationProcessorPath = sourceSet.getAnnotationProcessorPath();
+
         project.getTasks().named(sourceSet.getJavadocTaskName(), Javadoc.class, javadoc -> {
             // Javadoc task is horrible. There's no lazy properties/CommandLineArgumentProviders, so we have to
             // resort to this fresh hell of changing its configuration in a task action before it runs. Once
@@ -231,7 +235,7 @@ public abstract class BaselineModuleJvmArgs implements Plugin<Project> {
                     }
 
                     Set<String> exportValuesRaw = ModuleJvmArgsArgumentProvider.fromJustExtensionForCompilation(javadoc)
-                            .configureWithClasspath(sourceSet::getAnnotationProcessorPath)
+                            .configureWithClasspath(() -> annotationProcessorPath)
                             // Javadoc runs as *compilation* which means that everything that is normally an
                             // opens at runtime needs to be exports. Since we need to use the horrible
                             // addMultilineStringsOption, we just get all the arg fragments eg


### PR DESCRIPTION
## PR Stack

- https://github.com/palantir/gradle-baseline/pull/3665
- https://github.com/palantir/gradle-baseline/pull/3667
- https://github.com/palantir/gradle-baseline/pull/3666

## Context

In a project on my team, I'm seeing a configuration cache issue that traces back the `doFirst` action added by `BaselineModuleJvmArgs`.

```
❯ ./gradlew assemble --configuration-cache

FAILURE: Build failed with an exception.

* What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Task `:<project>:javadoc` of type `org.gradle.api.tasks.javadoc.Javadoc`: cannot serialize object of type 'org.gradle.api.internal.tasks.DefaultSourceSet', a subtype of 'org.gradle.api.tasks.SourceSet', as these are not supported with the configuration cache.
  See https://docs.gradle.org/8.14.4/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
```

## Changes

Saving a reference to the `sourceSet.getAnnotationProcessorPath()` gets past this error. There's a few other errors in this file that will need to be fixed separately.